### PR TITLE
fix(Documents): fix documents query: always display all documents

### DIFF
--- a/packages/web-app/src/actions/Documents.js
+++ b/packages/web-app/src/actions/Documents.js
@@ -44,7 +44,6 @@ const doGet = (url, criteria) => {
     keys,
     map(c => `${c}=${encodeURIComponent(criteria[c])}`),
     join('&'),
-    urlCriteria => `${queryDocuments}?${urlCriteria}`,
     urlCriteria => `${url}?${urlCriteria}`
   );
 


### PR DESCRIPTION
Closes #11

Call `documents` didn't take into account the criteria
It was due to a wrong rebase