### PR TITLE
[DOC PAGE] Display child documents

### DIFF
--- a/packages/web-app/src/actions/DocumentChildren.js
+++ b/packages/web-app/src/actions/DocumentChildren.js
@@ -1,0 +1,32 @@
+import fetch from 'isomorphic-fetch';
+import { getDocumentChildren } from '../conf/Config';
+import makeErrorMessage from '../helpers/makeErrorMessage';
+
+export const FETCH_DOCUMENT_CHILDREN = 'FETCH_DOCUMENT_CHILDREN';
+export const FETCH_DOCUMENT_CHILDREN_SUCCESS =
+  'FETCH_DOCUMENT_CHILDREN_SUCCESS';
+export const FETCH_DOCUMENT_CHILDREN_FAILURE =
+  'FETCH_DOCUMENT_CHILDREN_FAILURE';
+
+export const fetchDocumentChildren = documentId => dispatch => {
+  dispatch({ type: FETCH_DOCUMENT_CHILDREN });
+  return fetch(getDocumentChildren(documentId))
+    .then(response => {
+      if (response.status >= 400) {
+        throw new Error(response.status);
+      }
+      return response.json();
+    })
+    .then(data =>
+      dispatch({ type: FETCH_DOCUMENT_CHILDREN_SUCCESS, data: data.documents })
+    )
+    .catch(error =>
+      dispatch({
+        type: FETCH_DOCUMENT_CHILDREN_FAILURE,
+        error: makeErrorMessage(
+          error.message,
+          `Fetching children of document with id ${documentId}`
+        )
+      })
+    );
+};

--- a/packages/web-app/src/conf/Config.jsx
+++ b/packages/web-app/src/conf/Config.jsx
@@ -187,6 +187,8 @@ export const subjectsUrl = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/d
 export const subjectsSearchUrl = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents/subjects/search/logical/or`;
 export const getDocumentTypesUrl = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents/types`;
 export const getDocuments = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents`;
+export const getDocumentChildren = documentId =>
+  `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents/${documentId}/children`;
 export const processDocumentIds = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents/validate`;
 export const getDocumentDetailsUrl = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/documents/`;
 export const getEntryUrl = `${process.env.REACT_APP_API_URL}/api/${apiVersion}/entrances/`;

--- a/packages/web-app/src/conf/grottoTheme.jsx
+++ b/packages/web-app/src/conf/grottoTheme.jsx
@@ -112,9 +112,6 @@ export const overridings = {
     },
     MuiButton: {
       variant: 'contained'
-    },
-    MuiSkeleton: {
-      animation: 'wave'
     }
     // For default color on a specific variant on Typography
     // Wait until V5 to (maybe) use this for some titles
@@ -126,6 +123,14 @@ export const overridings = {
     // },
   },
   overrides: {
+    MuiSkeleton: {
+      root: {
+        backgroundColor: brown['100']
+      },
+      pulse: {
+        animationDuration: '1s'
+      }
+    },
     MuiFormHelperText: {
       root: {
         color: brown['500'],

--- a/packages/web-app/src/pages/DocumentDetails/transformers.js
+++ b/packages/web-app/src/pages/DocumentDetails/transformers.js
@@ -59,32 +59,53 @@ export const makeDetails = data => {
   };
 };
 
-export const makeEntities = data => ({
-  massif: pathOr(
-    pipe(pathOr([], ['massif', 'names']), head, pathOr('', ['name']))(data),
-    ['massif', 'name'],
-    data
-  ),
-  cave: pathOr(
-    pipe(pathOr([], ['cave', 'names']), head, pathOr('', ['name']))(data),
-    ['cave', 'name'],
-    data
-  ),
-  entrance: pathOr(
-    pipe(pathOr([], ['entrance', 'names']), head, pathOr('', ['name']))(data),
-    ['entrance', 'name'],
-    data
-  ),
-  files: {
-    fileNames: pipe(pathOr([], ['files']), map(propOr('', 'fileName')))(data),
-    fileLinks: pipe(
-      pathOr([], ['files']),
-      map(file => ({ href: propOr('', 'completePath', file) }))
+export const makeEntities = data => {
+  return {
+    massif: pathOr(
+      pipe(pathOr([], ['massif', 'names']), head, pathOr('', ['name']))(data),
+      ['massif', 'name'],
+      data
+    ),
+    cave: pathOr(
+      pipe(pathOr([], ['cave', 'names']), head, pathOr('', ['name']))(data),
+      ['cave', 'name'],
+      data
+    ),
+    entrance: pathOr(
+      pipe(pathOr([], ['entrance', 'names']), head, pathOr('', ['name']))(data),
+      ['entrance', 'name'],
+      data
+    ),
+    files: {
+      fileNames: pipe(pathOr([], ['files']), map(propOr('', 'fileName')))(data),
+      fileLinks: pipe(
+        pathOr([], ['files']),
+        map(file => ({ href: propOr('', 'completePath', file) }))
+      )(data)
+    },
+    authorizationDocument: pipe(
+      pathOr([], ['authorizationDocument', 'titles']),
+      head,
+      pathOr('', ['text'])
     )(data)
-  },
-  authorizationDocument: pipe(
-    pathOr([], ['authorizationDocument', 'titles']),
-    head,
-    pathOr('', ['text'])
-  )(data)
-});
+  };
+};
+
+export const makeDocumentChildren = (data, locale) => {
+  const makeChild = doc => ({
+    id: doc.id,
+    url: `/ui/documents/${doc.id}`,
+    title: pipe(
+      propOr([], 'titles'),
+      head,
+      propOr('No title provided', 'text')
+    )(doc),
+    childrenData: doc.children ? doc.children.map(c => makeChild(c)) : null
+  });
+
+  const children = data.map(childDoc => makeChild(childDoc));
+
+  return children.sort((c1, c2) =>
+    c1.title.localeCompare(c2.title, locale, { numeric: true })
+  );
+};

--- a/packages/web-app/src/reducers/DocumentChildrenReducer.js
+++ b/packages/web-app/src/reducers/DocumentChildrenReducer.js
@@ -1,0 +1,37 @@
+import {
+  FETCH_DOCUMENT_CHILDREN,
+  FETCH_DOCUMENT_CHILDREN_FAILURE,
+  FETCH_DOCUMENT_CHILDREN_SUCCESS
+} from '../actions/DocumentChildren';
+
+const initialState = {
+  error: null,
+  isLoading: false,
+  children: []
+};
+
+const documentChildren = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_DOCUMENT_CHILDREN:
+      return {
+        ...initialState,
+        isLoading: true
+      };
+    case FETCH_DOCUMENT_CHILDREN_FAILURE:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.error
+      };
+    case FETCH_DOCUMENT_CHILDREN_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        children: action.data
+      };
+    default:
+      return state;
+  }
+};
+
+export default documentChildren;

--- a/packages/web-app/src/reducers/GCReducer.jsx
+++ b/packages/web-app/src/reducers/GCReducer.jsx
@@ -6,6 +6,7 @@ import caverGroups from './CaverGroupsReducer';
 import createCaver from './CreateCaver';
 import createOrganization from './CreateOrganization';
 import document from './DocumentReducer';
+import documentChildren from './DocumentChildrenReducer';
 import documentDetails from './DetailsDocumentReducer';
 import documents from './DocumentsReducer';
 import documentType from './DocumentTypeReducer';
@@ -42,6 +43,7 @@ const GCReducer = combineReducers({
   createCaver,
   createOrganization,
   document,
+  documentChildren,
   documentDetails,
   documents,
   documentType,


### PR DESCRIPTION
Fix #52 

~:warning: This needs https://github.com/GrottoCenter/Grottocenter3/pull/645 to be merged before in order to work: we now load the children separately from the document.~ --> **EDIT:** c'est bon !

I used the "tree" type and implemented it recursively. The "external link" symbol is used because the click on the item trigger the tree opening / closing. I needed something else for the link.

## Top of the section 
![image](https://user-images.githubusercontent.com/20704943/139871300-7fdaaeea-29ea-4a63-a798-bbe5195f5019.png)

## Indented data
![image](https://user-images.githubusercontent.com/20704943/139870923-4023fc97-f267-40f1-9c71-f9fa92fe5978.png)

## Loading for the biggest Collection (1000 issues)
![doc](https://user-images.githubusercontent.com/20704943/140041797-b949b844-2746-4fc5-8f2c-c2b198fabdee.gif)

You can test with the document with id 22695 => /ui/documents/22695