### PR TITLE
[DOC PAGE] Add a link to doc parent

### DIFF
--- a/packages/web-app/src/pages/DocumentDetails/Section.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/Section.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isEmpty, isNil, is } from 'ramda';
-import { Skeleton, TreeItem, TreeView } from '@material-ui/lab';
+import { Skeleton, TreeItem, TreeView as MuiTreeView } from '@material-ui/lab';
 import { ExpandMore, ChevronRight, Launch } from '@material-ui/icons';
 
 import { isMobileOnly } from 'react-device-detect';
@@ -29,11 +29,6 @@ const Wrapper = styled.div`
 const CardContent = styled(MuiCardContent)`
   display: flex;
   flex-direction: column;
-`;
-
-const Text = styled(Typography)`
-  margin-left: auto;
-  text-align: right;
 `;
 
 const WrapperListItem = styled.div`
@@ -70,6 +65,11 @@ const IconAndLabelWrapper = styled.span`
 const ValueContainer = styled.div`
   flex: 1;
   margin-right: ${isMobileOnly ? '5%' : '20%'};
+  text-align: right;
+`;
+
+const TreeView = styled(MuiTreeView)`
+  text-align: left;
 `;
 
 const isArray = is(Array);
@@ -99,8 +99,9 @@ const ChildTreeItem = ({ item }) => {
 const Item = ({
   Icon,
   label,
-  value,
   type,
+  url,
+  value,
   CustomComponent,
   CustomComponentProps,
   isLabelAndIconOnTop = false,
@@ -145,7 +146,12 @@ const Item = ({
               })}
             </List>
           )}
-          {isString(value) && <Text>{value}</Text>}
+          {isString(value) &&
+            (url ? (
+              <GCLink href={url}>{value}</GCLink>
+            ) : (
+              <Typography>{value}</Typography>
+            ))}
         </>
       )}
     </ValueContainer>
@@ -175,6 +181,7 @@ const Section = ({ title, content, loading }) => {
                   Icon={item.Icon}
                   label={item.label}
                   type={item.type}
+                  url={item.url}
                   value={item.value}
                   CustomComponent={item.CustomComponent}
                   CustomComponentProps={item.CustomComponentProps}
@@ -213,6 +220,7 @@ Item.propTypes = {
     PropTypes.arrayOf(PropTypes.shape({}))
   ]),
   type: PropTypes.oneOf(['list', 'tree']),
+  url: PropTypes.string,
   CustomComponent: PropTypes.node,
   CustomComponentProps: PropTypes.arrayOf(PropTypes.object),
   isLabelAndIconOnTop: PropTypes.bool,

--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -20,7 +20,8 @@ import {
   makeDocumentChildren,
   makeEntities,
   makeOrganizations,
-  makeOverview
+  makeOverview,
+  makeDocumentParent
 } from './transformers';
 import { usePermissions } from '../../hooks';
 
@@ -37,6 +38,7 @@ const DocumentPage = ({
   details,
   entities,
   documentChildren,
+  documentParent,
   isValidated,
   onEdit,
   areDocumentChildrenLoading
@@ -100,7 +102,8 @@ const DocumentPage = ({
           },
           {
             label: formatMessage({ id: 'Parent document' }),
-            value: details.parentDocument
+            value: documentParent.title,
+            url: documentParent.url
           },
           {
             label: formatMessage({ id: 'Pages' }),
@@ -215,6 +218,7 @@ const HydratedDocumentPage = ({ id }) => {
       details={makeDetails(details || {})}
       entities={makeEntities(details || {})}
       documentChildren={makeDocumentChildren(children || {}, locale)}
+      documentParent={makeDocumentParent(details || {})}
       areDocumentChildrenLoading={areDocumentChildrenLoading}
       loading={
         isNil(documentId) || isLoading || !isNil(error) || !isNil(childrenError)
@@ -282,6 +286,10 @@ DocumentPage.propTypes = {
       childrenData: PropTypes.arrayOf(PropTypes.shape({})) // recursive data
     })
   ),
+  documentParent: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  }),
   isValidated: PropTypes.bool.isRequired,
   onEdit: PropTypes.func.isRequired
 };

--- a/packages/web-app/src/pages/DocumentDetails/transformers.js
+++ b/packages/web-app/src/pages/DocumentDetails/transformers.js
@@ -48,11 +48,6 @@ export const makeDetails = data => {
     publicationDate: propOr('', 'datePublication', data),
     oldPublication: propOr('', 'publication', data),
     oldPublicationFascicule: propOr('', 'publicationFasciculeBBSOld', data),
-    parentDocument: pipe(
-      pathOr([], ['parent', 'titles']),
-      head,
-      propOr('', 'text')
-    )(data),
     pages: propOr('', 'pages', data),
     subjects: pipe(propOr([], 'subjects'), reject(isEmpty))(data),
     regions: pipe(propOr([], 'regions'), reject(isEmpty))(data)
@@ -89,6 +84,16 @@ export const makeEntities = data => {
       pathOr('', ['text'])
     )(data)
   };
+};
+
+export const makeDocumentParent = data => {
+  const result = { title: '', url: '' };
+  const parent = propOr(null, 'parent', data);
+  if (parent) {
+    result.title = pipe(propOr([], 'titles'), head, propOr('', 'text'))(parent);
+    result.url = `/ui/documents/${parent.id}`;
+  }
+  return result;
 };
 
 export const makeDocumentChildren = (data, locale) => {


### PR DESCRIPTION
On peut désormais naviguer de documents en documents, en remontant soit vers le parent soit en descendant vers les enfants :slightly_smiling_face: 

J'ai dû ajuster un peu le code pour permettre l'ajout d'un attribut "url" aux valeurs textuelles à droite.

![image](https://user-images.githubusercontent.com/20704943/143478816-2fac3952-5be9-4330-9fa5-e307b361b8b3.png)