### PR TITLE
fix(docTable): add a cell render for languages array

### DIFF
--- a/packages/web-app/src/components/common/DocumentsTable/customCellRenders.js
+++ b/packages/web-app/src/components/common/DocumentsTable/customCellRenders.js
@@ -45,6 +45,14 @@ const useMakeCustomCellRenders = () => {
         formatMessage({ id: isValidated ? 'Yes' : 'No' })
     },
     {
+      id: 'languages',
+      customRender: pipe(
+        map(propOr('', 'refName')),
+        reject(isEmpty),
+        join('; ')
+      )
+    },
+    {
       id: 'license',
       customRender: propOr('', 'name')
     },


### PR DESCRIPTION
Fix #386
Without it, the document tables were making the app crash.