### PR TITLE
[LANGUAGE SEARCH] Add LanguageAutoComplete component and use it in Document form

### DIFF
--- a/packages/web-app/src/components/appli/Document/DocumentForm/formSteps/Step1.jsx
+++ b/packages/web-app/src/components/appli/Document/DocumentForm/formSteps/Step1.jsx
@@ -5,15 +5,16 @@ import styled from 'styled-components';
 import { Fade } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { includes } from 'ramda';
-
+import { useIntl } from 'react-intl';
+import LanguageAutoComplete from '../../../Form/LanguageAutoComplete';
 import { loadDocumentTypes } from '../../../../../actions/DocumentType';
 import { DocumentFormContext } from '../Provider';
+
 import DescriptionEditor from '../formElements/DescriptionEditor';
 import DocumentTypeSelect from '../formElements/DocumentTypeSelect';
 import PublicationDatePicker from '../formElements/PublicationDatePicker';
 import TitleEditor from '../formElements/TitleEditor';
 
-import DocumentLanguageSelect from '../../../DocumentLanguageSelect';
 import useDocumentTypes from '../../../../../hooks/useDocumentTypes';
 
 const FlexWrapper = styled.div`
@@ -47,6 +48,7 @@ const Step1 = ({ stepId }) => {
     validatedSteps
   } = useContext(DocumentFormContext);
   const dispatch = useDispatch();
+  const { formatMessage } = useIntl();
   const { isLoading, documentTypes: allDocumentTypes, error } = useSelector(
     state => state.documentType
   );
@@ -93,11 +95,16 @@ const Step1 = ({ stepId }) => {
             <Fade in={!isUnknown(documentType) && !isImage(documentType)}>
               <FlexItemWrapper>
                 {!isUnknown(documentType) && !isImage(documentType) && (
-                  <DocumentLanguageSelect
-                    helperText="Language used in the document."
-                    labelText="Document main language"
+                  <LanguageAutoComplete
                     contextValueName="documentMainLanguage"
+                    helperContent={formatMessage({
+                      id: 'Language used in the document.'
+                    })}
+                    labelText="Document main language"
                     required={!isOther(documentType)}
+                    searchLabelText={formatMessage({
+                      id: 'Search for a language...'
+                    })}
                   />
                 )}
               </FlexItemWrapper>
@@ -113,11 +120,17 @@ const Step1 = ({ stepId }) => {
                       <TitleEditor required />
                     </BigFlexItemWrapper>
                     <FlexItemWrapper style={{ minWidth: '300px' }}>
-                      <DocumentLanguageSelect
-                        helperText="Language used for the title and the description you are writing."
-                        labelText="Title and description language"
+                      <LanguageAutoComplete
                         contextValueName="titleAndDescriptionLanguage"
+                        helperContent={formatMessage({
+                          id:
+                            'Language used for the title and the description you are writing.'
+                        })}
+                        labelText="Title and description language"
                         required
+                        searchLabelText={formatMessage({
+                          id: 'Search for a language...'
+                        })}
                       />
                     </FlexItemWrapper>
                   </TitleAndDescriptionLanguageWrapper>

--- a/packages/web-app/src/components/appli/Form/LanguageAutoComplete/index.jsx
+++ b/packages/web-app/src/components/appli/Form/LanguageAutoComplete/index.jsx
@@ -1,0 +1,97 @@
+import React, { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import { isNil } from 'ramda';
+import { InputAdornment } from '@material-ui/core';
+import LanguageIcon from '@material-ui/icons/Language';
+
+import {
+  fetchQuicksearchResult,
+  resetQuicksearch
+} from '../../../../actions/Quicksearch';
+
+import { entityOptionForSelector } from '../../../../helpers/Entity';
+
+import SearchBar from '../../Document/DocumentForm/formElements/SearchBar';
+import FormAutoComplete from '../FormAutoComplete';
+
+// ===================================
+
+const LanguageAutoComplete = ({
+  contextValueName,
+  helperContent,
+  helperContentIfValueIsForced,
+  labelText,
+  required = false,
+  searchLabelText
+}) => {
+  const dispatch = useDispatch();
+  const { error, isLoading, results: suggestions } = useSelector(
+    state => state.quicksearch
+  );
+
+  const { formatMessage } = useIntl();
+
+  const getLanguageToString = useCallback(
+    language => formatMessage({ id: language.refName }),
+    [formatMessage]
+  );
+
+  const fetchSearchResults = debouncedInput => {
+    const criterias = {
+      query: debouncedInput.trim(),
+      complete: false,
+      resourceType: 'languages'
+    };
+    dispatch(fetchQuicksearchResult(criterias));
+  };
+
+  const resetSearchResults = () => {
+    dispatch(resetQuicksearch());
+  };
+
+  return (
+    <FormAutoComplete
+      autoCompleteSearch={
+        <SearchBar
+          fetchSearchResults={fetchSearchResults}
+          getOptionLabel={getLanguageToString}
+          getValueName={getLanguageToString}
+          hasError={!isNil(error)}
+          isLoading={isLoading}
+          label={searchLabelText}
+          renderOption={entityOptionForSelector}
+          resetSearchResults={resetSearchResults}
+          searchLabelText={searchLabelText}
+          suggestions={suggestions}
+          contextValueName={contextValueName}
+          resourceSearchedType="languages"
+        />
+      }
+      contextValueName={contextValueName}
+      getValueName={getLanguageToString}
+      hasError={false} // How to check for errors ?
+      helperContent={helperContent}
+      helperContentIfValueIsForced={helperContentIfValueIsForced}
+      label={labelText}
+      required={required}
+      resultEndAdornment={
+        <InputAdornment position="end">
+          <LanguageIcon color="primary" />
+        </InputAdornment>
+      }
+    />
+  );
+};
+
+LanguageAutoComplete.propTypes = {
+  contextValueName: PropTypes.string.isRequired,
+  helperContent: PropTypes.node,
+  helperContentIfValueIsForced: PropTypes.node,
+  labelText: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  searchLabelText: PropTypes.string.isRequired
+};
+
+export default LanguageAutoComplete;

--- a/packages/web-app/src/components/appli/QuickSearch.jsx
+++ b/packages/web-app/src/components/appli/QuickSearch.jsx
@@ -125,6 +125,7 @@ QuickSearch.propTypes = {
       'documents',
       'entrances',
       'grottos',
+      'languages',
       'massifs',
       'caves',
       'networks'
@@ -134,6 +135,7 @@ QuickSearch.propTypes = {
     'documents',
     'entrances',
     'grottos',
+    'languages',
     'massifs',
     'caves',
     'networks'

--- a/packages/web-app/src/helpers/Entity.jsx
+++ b/packages/web-app/src/helpers/Entity.jsx
@@ -56,8 +56,8 @@ export const entityOptionForSelector = option => {
     });
   }
 
-  let iconPath = '/images/';
-  let textToDisplay = option.name; // Default for all entities except for caver (see below)
+  let iconName;
+  let textToDisplay = option.name; // Default for all entities
   switch (option.type) {
     case 'caver':
       if (!option.name && !option.surname) {
@@ -71,24 +71,28 @@ export const entityOptionForSelector = option => {
         textToDisplay = option.surname.toUpperCase();
       }
 
-      iconPath += 'caver.svg';
+      iconName = 'caver.svg';
       break;
     case 'document-collection':
     case 'document-issue':
     case 'document':
       textToDisplay = `${option.name} [${option.documentType.name}]`;
-      iconPath += 'bibliography.svg';
+      iconName = 'bibliography.svg';
       break;
     case 'cave':
     case 'entrance':
-      iconPath += 'entry.svg';
+      iconName = 'entry.svg';
       break;
     case 'grotto':
-      iconPath += 'club.svg';
+      iconName = 'club.svg';
       break;
+
     case 'massif':
-      iconPath += 'massif.svg';
+      iconName = 'massif.svg';
       break;
+
+    // TODO : language icon
+    // case 'language':
 
     default:
       break;
@@ -96,7 +100,9 @@ export const entityOptionForSelector = option => {
 
   return (
     <>
-      <EntityIcon src={iconPath} alt={`${option.type} icon`} />
+      {iconName && (
+        <EntityIcon src={`/images/${iconName}`} alt={`${option.type} icon`} />
+      )}
       <EntityLabel>{textToDisplay}</EntityLabel>
 
       {highlights.map(hl => {


### PR DESCRIPTION
Fix #331

Language name must be searched in english ("français" or "español" doesn't work) because in the DB, we only have the english name stored.

## TODO

I need a brown logo for a language. It will be displayed at the left of the search result (like the others search results) : 
![screen](https://user-images.githubusercontent.com/20704943/162745065-7566312c-1f49-439e-8965-2d2b48792edd.PNG)

