### PR TITLE
[API CALLS] Fix to match new api (22.0.17) data format

### DIFF
--- a/packages/web-app/src/actions/FileFormats.js
+++ b/packages/web-app/src/actions/FileFormats.js
@@ -33,7 +33,7 @@ export const fetchFormats = () => dispatch => {
   return fetch(getFileFormatsUrl)
     .then(checkStatus)
     .then(response => {
-      dispatch(fetchFormatsSuccess(response));
+      dispatch(fetchFormatsSuccess(response.fileFormats));
     })
     .catch(error => {
       dispatch(fetchFormatsError(error.message));

--- a/packages/web-app/src/actions/Licenses.js
+++ b/packages/web-app/src/actions/Licenses.js
@@ -33,7 +33,7 @@ export const fetchLicense = () => dispatch => {
   return fetch(getLicensesUrl)
     .then(checkStatus)
     .then(response => {
-      dispatch(fetchLicenseSuccess(response));
+      dispatch(fetchLicenseSuccess(response.licenses));
     })
     .catch(error => {
       dispatch(fetchLicenseError(error.message));

--- a/packages/web-app/src/actions/PartnersForCarousel.js
+++ b/packages/web-app/src/actions/PartnersForCarousel.js
@@ -11,9 +11,9 @@ export const fetchPartnersForCarousel = () => ({
   partners: undefined
 });
 
-export const fetchPartnersForCarouselSuccess = entry => ({
+export const fetchPartnersForCarouselSuccess = partners => ({
   type: FETCH_PARTNERS_FC_SUCCESS,
-  entry
+  partners
 });
 
 export const fetchPartnersForCarouselFailure = error => ({
@@ -32,7 +32,11 @@ export function loadPartnersForCarousel() {
         }
         return response.text();
       })
-      .then(text => dispatch(fetchPartnersForCarouselSuccess(JSON.parse(text))))
+      .then(text =>
+        dispatch(
+          fetchPartnersForCarouselSuccess(JSON.parse(text).organizations)
+        )
+      )
       .catch(error =>
         dispatch(
           fetchPartnersForCarouselFailure(

--- a/packages/web-app/src/reducers/PartnersCarouselReducer.js
+++ b/packages/web-app/src/reducers/PartnersCarouselReducer.js
@@ -15,7 +15,7 @@ const partnersCarousel = (state = initialState, action) => {
     case FETCH_PARTNERS_FC:
       return { ...state, isFetching: true };
     case FETCH_PARTNERS_FC_SUCCESS:
-      return { ...state, isFetching: false, partners: action.entry };
+      return { ...state, isFetching: false, partners: action.partners };
     case FETCH_PARTNERS_FC_FAILURE:
       return { ...state, isFetching: false, error: action.error };
     default:


### PR DESCRIPTION
La nouvelle API refactorisée (v22.0.17) est arrivée et présente quelques modifications  dans le formattage de certaines données. J'ai peut-être oublié de tester certaines fonctionnalités, à tester intensivement. 

### :warning: A tester dans quelques heures, quand l'API 22.0.17 est en ligne (je préviendrai)
## **EDIT** c'est bon !