### PR TITLE
#478 Add average rating above general rating

### DIFF
--- a/packages/web-app/src/components/appli/Entry/Properties.jsx
+++ b/packages/web-app/src/components/appli/Entry/Properties.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import { Box } from '@material-ui/core';
+import EmptyStarIcon from '@material-ui/icons/StarBorder';
 import {
   CalendarToday,
   Category,
@@ -178,6 +179,11 @@ const Properties = () => {
           />
         )}
       </Box>
+
+      <Property
+        label={formatMessage({ id: 'Average rating' })}
+        icon={<EmptyStarIcon fontSize="large" color="primary" />}
+      />
       <SmallRatingsWrapper>
         <Ratings
           accessRate={accessRate}

--- a/packages/web-app/src/lang/en.json
+++ b/packages/web-app/src/lang/en.json
@@ -177,6 +177,7 @@
   "authors": "authors",
   "Authors": "Authors",
   "Available versions:": "Available versions:",
+  "Average rating": "Average rating",
   "azBELARUS": "Belarus",
   "Azerbaijan": "Azerbaijan",
   "B": "Belgique",


### PR DESCRIPTION
Je me suis permis d'ajouter une icône avec la mention "average rating" pour l'illustrer un peu. Mais il me semble qu'il y aurait peut être d'autres illustrations plus adaptées. 