### PR TITLE
Entities create  : remove cave from list

### DIFF
--- a/packages/web-app/src/lang/en.json
+++ b/packages/web-app/src/lang/en.json
@@ -336,7 +336,6 @@
   "create": "create",
   "Create": "Create",
   "Create a new entity in Grottocenter": "Create a new entity in Grottocenter",
-  "Create a new entity such as entrance, massif or organization in Grottocenter using this form.": "Create a new entity such as entrance, massif or organization in Grottocenter using this form.",
   "Create a new Entrance": "Create a new Entrance",
   "Create new entity": "Create new entity",
   "Created by": "Created by",

--- a/packages/web-app/src/lang/en.json
+++ b/packages/web-app/src/lang/en.json
@@ -336,7 +336,7 @@
   "create": "create",
   "Create": "Create",
   "Create a new entity in Grottocenter": "Create a new entity in Grottocenter",
-  "Create a new entity such as cave, entrance or organization in Grottocenter using this form.": "Create a new entity such as cave, entrance or organization in Grottocenter using this form.",
+  "Create a new entity such as entrance, massif or organization in Grottocenter using this form.": "Create a new entity such as entrance, massif or organization in Grottocenter using this form.",
   "Create a new Entrance": "Create a new Entrance",
   "Create new entity": "Create new entity",
   "Created by": "Created by",

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -89,7 +89,8 @@ const CreationForm = () => {
     <>
       <Header>
         <Translate>
-          Create a new entity such as entrance or organization in Grottocenter using this form.
+          Create a new entity such as entrance or organization in Grottocenter
+          using this form.
         </Translate>
       </Header>
       <hr />

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -89,8 +89,7 @@ const CreationForm = () => {
     <>
       <Header>
         <Translate>
-          Create a new entity such as entrance or organization in Grottocenter
-          using this form.
+          Create a new entity in Grottocenter using this form.
         </Translate>
       </Header>
       <hr />

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -24,7 +24,6 @@ const StyledFormControl = styled(FormControl)`
 
 const ENTITIES = {
   entrance: 'Entrance',
-  cavity: 'Cavity',
   massif: 'Massif',
   organization: 'Organization'
 };
@@ -52,9 +51,6 @@ const EntityTypeSelect = ({ entity, onEntityChange }) => {
         <MenuItem value={ENTITIES.entrance}>
           <Translate>Entrance</Translate>
         </MenuItem>
-        <MenuItem value={ENTITIES.cavity}>
-          <Translate>Cave</Translate>
-        </MenuItem>
         <MenuItem value={ENTITIES.massif}>
           <Translate>Massif</Translate>
         </MenuItem>
@@ -75,7 +71,6 @@ const EntityForm = ({ selectedEntity }) => {
       return <EntranceForm />;
     case ENTITIES.massif:
       return <MassifForm />;
-    case ENTITIES.cavity:
     case ENTITIES.organization:
       return <OrganizationForm />;
 
@@ -94,7 +89,7 @@ const CreationForm = () => {
     <>
       <Header>
         <Translate>
-          Create a new entity such as cave, entrance or organization in
+          Create a new entity such as entrance or organization in
           Grottocenter using this form.
         </Translate>
       </Header>

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -89,8 +89,7 @@ const CreationForm = () => {
     <>
       <Header>
         <Translate>
-          Create a new entity such as entrance or organization in
-          Grottocenter using this form.
+          Create a new entity such as entrance or organization in Grottocenter using this form.
         </Translate>
       </Header>
       <hr />

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -89,7 +89,7 @@ const CreationForm = () => {
     <>
       <Header>
         <Translate>
-          Create a new entity in Grottocenter using this form.
+          Create a new entity in Grottocenter
         </Translate>
       </Header>
       <hr />

--- a/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
+++ b/packages/web-app/src/pages/EntityCreation/CreationForm.jsx
@@ -88,9 +88,7 @@ const CreationForm = () => {
   return (
     <>
       <Header>
-        <Translate>
-          Create a new entity in Grottocenter
-        </Translate>
+        <Translate>Create a new entity in Grottocenter</Translate>
       </Header>
       <hr />
       <Wrapper>


### PR DESCRIPTION
Fix #499

Retrait des cavités de la liste des entités pouvant être créées. La sélection de cavité génère une erreur et il ne sera jamais possible de créer une cavité, qui est créé automatiquement lorsqu'on créé une entrée