### PR TITLE
fix(#662): hide true/false for sensitive cave, use only sentences

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/Entrance.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/Entrance.jsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  FormLabel,
   FormControlLabel,
   FormControl,
   FormHelperText,
@@ -42,7 +41,6 @@ const Entrance = ({
   to allow the user to mark and unmark it freely before submitting the form
   */
   const values = getValues();
-  const { isSensitive } = values.entrance;
   const initialIsSensitive = useRef(values.entrance.isSensitive).current;
 
   const caveIdValue = useDebounce(useWatch({ control, name: 'cave.id' }), 300);
@@ -168,11 +166,6 @@ const Entrance = ({
             margin="dense"
             component="fieldset"
             error={!!errors?.entrance?.isSensitive}>
-            <FormLabel component="legend">
-              {formatMessage({
-                id: `The cave access is ${isSensitive ? '' : 'not'} restricted.`
-              })}
-            </FormLabel>
             <FormControlLabel
               control={
                 <Switch
@@ -183,11 +176,9 @@ const Entrance = ({
                   onChange={e => field.onChange(e.target.checked)}
                 />
               }
-              label={
-                field.value
-                  ? formatMessage({ id: 'True' })
-                  : formatMessage({ id: 'False' })
-              }
+              label={formatMessage({
+                id: `The cave access is${field.value ? '' : ' not'} restricted.`
+              })}
             />
 
             {isSensitiveDisabled ? (


### PR DESCRIPTION
Fix #662
![firefox_2mRk58Y5ub](https://user-images.githubusercontent.com/20704943/180276757-9272a695-7c0c-4d3c-9f72-d912dbea6887.gif)

