### PR TITLE
fix(#720): fix lat lng null check

### DIFF
--- a/packages/web-app/src/components/common/Maps/MapMultipleMarkers/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapMultipleMarkers/index.jsx
@@ -1,6 +1,16 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { is, pipe, length, equals, all, allPass, flatten, isNil } from 'ramda';
+import {
+  is,
+  isEmpty,
+  pipe,
+  length,
+  equals,
+  all,
+  allPass,
+  flatten,
+  isNil
+} from 'ramda';
 import { useMap } from 'react-leaflet';
 import CustomMapContainer from '../common/MapContainer';
 import useMarkers from '../common/Markers/useMarkers';
@@ -26,7 +36,11 @@ const MultipleMarkers = ({ positions, zoom }) => {
   }
   useEffect(() => {
     updateEntranceMarkers(positions.map(makePosition));
-    if (!isNil(positions) && !positions.every(p => !isNil(p))) {
+    if (
+      !isNil(positions) &&
+      !isEmpty(positions) &&
+      positions.every(p => !isNil(p[0]) && !isNil(p[1]))
+    ) {
       map.fitBounds(positions);
     }
 


### PR DESCRIPTION
Fix #720

## 🤔 What  
- Fix latitude / longitude check when displaying markers

## 🤷‍♂️ Why  
A previous PR (#719) was breaking the code for not sensitive entrances. This PR fixes everything, for both sensitive and not sensitive entrances.

## 🔍 How  
Check if both longitude and latitude are not null (instead of checking the pair)

Test with multiple caves & entrances. Some examples: 

- entrances/74789 (not sensitive)
- entrances/6074 (sensitive)
- caves/6074 (cave of a sensitive entrance → the entrance is not displayed if you are not a moderator / admin)
- caves/75363 (cave with unsensitive entrances → entrances are displayed)
