### PR TITLE
feat(#648): make doc identifier clickable if it's an url

### DIFF
--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -110,7 +110,11 @@ const DocumentPage = ({
             content={[
               {
                 label: formatMessage({ id: 'Identifier' }),
-                value: details.identifier
+                value: details.identifier,
+                url:
+                  details.identifierType === 'url'
+                    ? details.identifier
+                    : undefined
               },
               {
                 label: formatMessage({ id: 'BBS reference' }),
@@ -293,6 +297,7 @@ DocumentPage.propTypes = {
   details: PropTypes.shape({
     authorComment: PropTypes.string,
     identifier: PropTypes.string,
+    identifierType: PropTypes.string,
     bbsReference: PropTypes.string,
     documentType: PropTypes.string,
     oldPublication: PropTypes.string,

--- a/packages/web-app/src/pages/DocumentDetails/transformers.js
+++ b/packages/web-app/src/pages/DocumentDetails/transformers.js
@@ -57,27 +57,19 @@ export const makeOrganizations = data => ({
   })
 });
 
-export const makeDetails = data => {
-  const formatedIdentfier = pathOr(null, ['identifierType', 'id'], data)
-    ? `${propOr(
-        '',
-        'identifier',
-        data
-      )} (${data.identifierType.id.toUpperCase()})`
-    : propOr('', 'identifier', data);
-  return {
-    authorComment: propOr('', 'authorComment', data),
-    identifier: formatedIdentfier,
-    bbsReference: propOr('', 'refBbs', data),
-    documentType: pathOr('', ['type', 'name'], data),
-    publicationDate: propOr('', 'datePublication', data),
-    oldPublication: propOr('', 'publication', data),
-    oldPublicationFascicule: propOr('', 'publicationFasciculeBBSOld', data),
-    pages: propOr('', 'pages', data),
-    subjects: pipe(propOr([], 'subjects'), reject(isEmpty))(data),
-    regions: pipe(propOr([], 'regions'), reject(isEmpty))(data)
-  };
-};
+export const makeDetails = data => ({
+  authorComment: propOr('', 'authorComment', data),
+  identifier: data.identifier,
+  identifierType: data.identifierType?.id,
+  bbsReference: propOr('', 'refBbs', data),
+  documentType: pathOr('', ['type', 'name'], data),
+  publicationDate: propOr('', 'datePublication', data),
+  oldPublication: propOr('', 'publication', data),
+  oldPublicationFascicule: propOr('', 'publicationFasciculeBBSOld', data),
+  pages: propOr('', 'pages', data),
+  subjects: pipe(propOr([], 'subjects'), reject(isEmpty))(data),
+  regions: pipe(propOr([], 'regions'), reject(isEmpty))(data)
+});
 
 export const makeEntities = data => ({
   ...getEntity(data, 'cave'),


### PR DESCRIPTION
Fix #648

Il y a eu un souci avec les branches et commits à propos de cette PR initialement créée par @YohanHATOT. 

À noter que toutes les urls qui commencent par "www" ne fonctionneront pas : ce ne sont pas des urls valides car elles ne commencent pas par "http" ou "https". Il faut donc les remplacer pour mettre "http://www..." à la place. Il y en a 408 au total.