### PR TITLE
Remove sslib link

### DIFF
--- a/packages/web-app/src/components/appli/Document/DocumentForm/index.jsx
+++ b/packages/web-app/src/components/appli/Document/DocumentForm/index.jsx
@@ -17,7 +17,7 @@ import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 import { DocumentFormContext } from './Provider';
 import { DocumentFormTypes } from './types';
 
-import { bbsLink, wikiBBSLinks } from '../../../../conf/externalLinks';
+import { wikiBBSLinks } from '../../../../conf/externalLinks';
 import Translate from '../../../common/Translate';
 import InternationalizedLink from '../../../common/InternationalizedLink';
 import Stepper from '../../../common/Form/Stepper';

--- a/packages/web-app/src/components/appli/Document/DocumentForm/index.jsx
+++ b/packages/web-app/src/components/appli/Document/DocumentForm/index.jsx
@@ -153,10 +153,6 @@ const DocumentForm = ({ isLoading, onSubmit, onUpdate }) => {
               Grottocenter-wiki page.
             </Translate>
           </InternationalizedLink>
-          <br />
-          <InternationalizedLink links={bbsLink}>
-            <Translate>Or directly on the BBS website.</Translate>
-          </InternationalizedLink>
         </BbsInfoText>
       </BbsHeader>
 

--- a/packages/web-app/src/lang/en.json
+++ b/packages/web-app/src/lang/en.json
@@ -939,7 +939,6 @@
   "Open on OpenStreetMap": "Open on OpenStreetMap",
   "Open!": "Open!",
   "Option": "Option",
-  "Or directly on the BBS website.": "Or directly on the BBS website.",
   "Or use this link to reset your password:": "Or use this link to reset your password:",
   "organization": "organization",
   "Organization": "Organization",


### PR DESCRIPTION
# Remove sslib link

## 🤔 What  
Remove sslib link

## 🤷‍♂️ Why  
Documentation on the BBS will be entirely on the Grottocenter Wiki. pages on SSSLib must be closed 

## 🔍 How  
Translation file and index of the document editing and creation form

## 🧪 Testing
Click on the menu to create and/or edit a document, there is only the link to the wiki