### PR TITLE
fix(homepage): fix partners carousel on homepage

### DIFF
--- a/packages/web-app/src/actions/PartnersForCarousel.js
+++ b/packages/web-app/src/actions/PartnersForCarousel.js
@@ -33,9 +33,7 @@ export function loadPartnersForCarousel() {
         return response.text();
       })
       .then(text =>
-        dispatch(
-          fetchPartnersForCarouselSuccess(JSON.parse(text).organizations)
-        )
+        dispatch(fetchPartnersForCarouselSuccess(JSON.parse(text).organization))
       )
       .catch(error =>
         dispatch(


### PR DESCRIPTION
# Fix the partners carousel on homepage

## 🤔 What  
After https://github.com/GrottoCenter/grottocenter-api/pull/1061
The call to the partners carousel api now returns the top level key `organization` instead of `organizations`

https://api.grottocenter.org/api/v1/partners/findForCarousel