### PR TITLE
fix(login): logout user on unauthorized response

### DIFF
--- a/packages/web-app/src/actions/Notifications/CountUnreadNotifications.js
+++ b/packages/web-app/src/actions/Notifications/CountUnreadNotifications.js
@@ -2,6 +2,7 @@ import fetch from 'isomorphic-fetch';
 import { countUnreadNotificationsUrl } from '../../conf/apiRoutes';
 import makeErrorMessage from '../../helpers/makeErrorMessage';
 import { checkAndGetStatus } from '../utils';
+import { logout } from '../Login';
 
 export const COUNT_UNREAD_NOTIFICATIONS = 'COUNT_UNREAD_NOTIFICATIONS';
 export const COUNT_UNREAD_NOTIFICATIONS_SUCCESS =
@@ -38,13 +39,21 @@ export function countUnreadNotifications() {
       .then(data => {
         dispatch(countUnreadNotificationsActionSuccess(data.count));
       })
-      .catch(error =>
+      .catch(error => {
+        // When logged, countUnreadNotifications() is the first authenticated request made to the API
+        // So it is the first request that test if the JWT is really valid
+        // In case of invalid token we logout the user
+        if (error.message === '401') {
+          dispatch(logout());
+          return;
+        }
+
         dispatch(
           countUnreadNotificationsActionFailure(
             makeErrorMessage(error.message, `Counting unread notifications`),
             error.message
           )
-        )
-      );
+        );
+      });
   };
 }


### PR DESCRIPTION
## Logout user on 401 unauthorized response

The key for generating session JWT have recently been changed.
Users with old JWT should be disconnected in order to avoid errors in the pages
