### PR TITLE
Maps improvements

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { MapContainer, FeatureGroup } from 'react-leaflet';
+import { MapContainer, FeatureGroup, ScaleControl } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import { useGeolocation } from 'rooks';
 import L from 'leaflet';
@@ -184,6 +184,7 @@ const PolygonMap = ({ onChange, data }) => {
         />
       </FeatureGroup>
 
+      <ScaleControl position="bottomright" />
       <LayersControl />
     </MapContainer>
   );

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useWatch, useController } from 'react-hook-form';
-import { MapContainer, useMap, useMapEvent } from 'react-leaflet';
+import { MapContainer, useMap, useMapEvent, ScaleControl } from 'react-leaflet';
 import PropTypes from 'prop-types';
 import { isMobile } from 'react-device-detect';
 import styled from 'styled-components';
@@ -118,6 +118,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
       doubleClickZoom="center"
       touchZoom="center"
       preferCanvas>
+      <ScaleControl position="bottomright" />
       <LayersControl />
 
       <MapBind center={currentPosition} onMoveEnd={onMoveEnd} />

--- a/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
+++ b/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { MapContainer, useMap, useMapEvents } from 'react-leaflet';
+import {
+  MapContainer,
+  useMap,
+  useMapEvents,
+  ScaleControl
+} from 'react-leaflet';
 import PropTypes from 'prop-types';
 import LayersControl from './LayersControl';
 import FullscreenControl from './FullscreenControl';
@@ -96,6 +101,7 @@ const CustomMapContainer = ({
         <FullscreenControl forceSeparateButton="true" />
       )}
       {forceCentering && <Centerer center={center} />}
+      <ScaleControl position="bottomright" />
       <LayersControl />
       {children}
     </MapContainer>


### PR DESCRIPTION
# Maps improvements

- Adds scale to maps ( #875)

Map Page:
- Restores location from url
- Uses `history.replace()` instead of `push()` to not pollute the history
