### PR TITLE
Fix: entrance coordinates with ','

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../actions/CaveAndEntrance';
 
 import { FormContainer, FormActionRow } from '../utils/FormContainers';
+import { normelizeCoordinate } from '../utils/InputCoordinate';
 import LicenseBox from '../utils/LicenseBox';
 import FormProgressInfo from '../utils/FormProgressInfo';
 import EditTypeSelection from './EditTypeSelection';
@@ -109,6 +110,13 @@ export const EntranceForm = ({ caveValues = null, entranceValues = null }) => {
   }, [reset]);
 
   const onSubmit = async data => {
+    /* eslint-disable no-param-reassign */
+    if (data?.entrance?.longitude)
+      data.entrance.longitude = normelizeCoordinate(data.entrance.longitude);
+    if (data?.entrance?.latitude)
+      data.entrance.latitude = normelizeCoordinate(data.entrance.latitude);
+    /* eslint-enable no-param-reassign */
+
     const caveData = {
       ...makeCaveData(data),
       id: caveValues?.id

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
@@ -28,11 +28,8 @@ export const makeCaveData = data => ({
     language: data.language,
     title: desc.title
   })),
-  massif: data.cave.massif,
   depth: Number(data.cave.depth),
   isDiving: data.cave.isDiving,
   length: Number(data.cave.length),
-  longitude: data.cave.longitude,
-  latitude: data.cave.latitude,
   temperature: Number(data.cave.temperature)
 });

--- a/packages/web-app/src/components/appli/EntitiesForm/Organization/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Organization/index.jsx
@@ -6,6 +6,7 @@ import { updateName } from '../../../../actions/Name';
 import { postOrganization } from '../../../../actions/Organization/CreateOrganization';
 import { updateOrganization } from '../../../../actions/Organization/UpdateOrganization';
 import FormProgressInfo from '../utils/FormProgressInfo';
+import { normelizeCoordinate } from '../utils/InputCoordinate';
 import OrganizationFields from './OrganizationFields';
 import LicenseBox from '../utils/LicenseBox';
 import {
@@ -68,6 +69,17 @@ export const OrganizationForm = ({ organizationValues = null }) => {
   }, [organizationValues, reset]);
 
   const onSubmit = async data => {
+    /* eslint-disable no-param-reassign */
+    if (data?.organization?.longitude)
+      data.organization.longitude = normelizeCoordinate(
+        data.organization.longitude
+      );
+    if (data?.organization?.latitude)
+      data.organization.latitude = normelizeCoordinate(
+        data.organization.latitude
+      );
+    /* eslint-enable no-param-reassign */
+
     if (isNewOrganization) {
       const organizationToPost = makePostOrganizationData(data);
       dispatch(postOrganization(organizationToPost));

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/InputCoordinate.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/InputCoordinate.jsx
@@ -4,6 +4,14 @@ import { Controller } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 import { TextField } from '@material-ui/core';
 
+// The InputCoordinate input accept coordinate with ',' or '.'
+// But the api only accept notation with '.'
+// So before submitting to the api, coordinates must be normalised
+export function normelizeCoordinate(coordStr) {
+  if (typeof coordStr != 'string') return coordStr;
+  return coordStr.replace(',', '.');
+}
+
 const InputCoordinate = ({
   formKey,
   labelName,


### PR DESCRIPTION
- Allows to create an entrance or organisation with coordinates containing ',' #902
- Delete unused fields in cave data transformer