### PR TITLE
Fixes errors on pages when there is a table with custom render.

### DIFF
--- a/packages/web-app/src/components/common/Table/index.jsx
+++ b/packages/web-app/src/components/common/Table/index.jsx
@@ -4,14 +4,11 @@ import styled from 'styled-components';
 import {
   __,
   append,
-  defaultTo,
-  find,
   includes,
   isNil,
   pipe,
   prepend,
   prop,
-  propEq,
   reject,
   unless,
   without,
@@ -115,24 +112,12 @@ const Table = ({
     )
   );
   const getCustomCellRenders = useCallback(
-    id =>
-      pipe(
-        defaultTo([]),
-        find(propEq('id', id)),
-        prop('customRender'),
-        defaultTo(undefined)
-      )(customCellRenders),
+    id => customCellRenders.find(r => r.id === id)?.customRender,
     [customCellRenders]
   );
 
   const getCustomHeaderCellRenders = useCallback(
-    id =>
-      pipe(
-        defaultTo([]),
-        find(propEq('id', id)),
-        prop('customRender'),
-        defaultTo(undefined)
-      )(customHeaderCellRenders),
+    id => customHeaderCellRenders.find(r => r.id === id)?.customRender,
     [customHeaderCellRenders]
   );
 


### PR DESCRIPTION
## Fixes errors on pages when there is a table with custom render.

Like here: https://grottocenter.org/ui/documents/validation

Replacing the `find` line with: `find(propEq(id, 'id'))` would also have fixed the issue ([doc](https://ramdajs.com/docs/#find)), but I believe removing Ramda is clearer here.
