### PR TITLE
Changed title for the country list (issue #939)

### DIFF
--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -402,6 +402,7 @@
   "CoteIvoire": "Ivory Coast",
   "countries": "countries",
   "Countries": "Countries",
+  "Countries : Sovereign countries and autonomous territories (ISO 3166-1)": "Countries : Sovereign countries and autonomous territories (ISO 3166-1)",
   "country": "country",
   "Country": "Country",
   "Country code": "Country code",

--- a/packages/web-app/src/components/appli/Country/CountryList.jsx
+++ b/packages/web-app/src/components/appli/Country/CountryList.jsx
@@ -18,7 +18,9 @@ const CountryList = ({ countries }) => {
 
   return (
     <ScrollableContent
-      title={formatMessage({ id: 'Countries' })}
+      title={formatMessage({
+        id: 'Countries : Sovereign countries and autonomous territories (ISO 3166-1)'
+      })}
       content={
         <TableContainer component={Paper} style={{ width: '500px' }}>
           <Table size="small">


### PR DESCRIPTION
_Describe what is being changed/added/reworked._

Answering the issue #939, I have changed the title of the list of countries (https://grottocenter.org/ui/countries) from "Pays" to "Pays : Pays souverains et territoires autonomes (ISO 3166-1)" in french. I have also done the change on every language.


_Describe how we're implementing the change.  
Feel free to dive into technicalities!_

I created a new variable for language files named 'Countries : Sovereign countries and autonomous territories (ISO 3166-1)' and I translated it on every json language files.


_Add screenshots to get the taste of the changes._

![Capture d'écran 2024-02-12 024236](https://github.com/GrottoCenter/grottocenter-front/assets/115457166/b9d66d31-13bd-4502-829e-255da0de558f)

![Capture d'écran 2024-02-12 024515](https://github.com/GrottoCenter/grottocenter-front/assets/115457166/e430abbe-ab9c-452d-bc99-2b6a955a230b)

