### PR TITLE
Entrances and massifs, when editing stops asking user geolocation directly

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -58,7 +58,6 @@
     "redux": "^4.2.1",
     "redux-debounced": "^0.5.0",
     "redux-thunk": "^2.4.2",
-    "rooks": "^7.14.1",
     "styled-components": "^6.0.4",
     "swagger-ui-react": "^4.19.1",
     "underscore.string": "^3.3.6",

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
-import { isNil } from 'ramda';
 import { useDispatch, useSelector } from 'react-redux';
-import { useGeolocation } from 'rooks';
 
 import { updateEntrance } from '../../../../actions/Entrance/UpdateEntrance';
 import { postEntrance } from '../../../../actions/Entrance/CreateEntrance';
@@ -46,9 +44,6 @@ const defaultEntranceValues = {
 
 export const EntranceForm = ({ caveValues = null, entranceValues = null }) => {
   const isNewEntrance = entranceValues === null || caveValues === null;
-  const geolocation = useGeolocation();
-  const latitude = geolocation?.lat;
-  const longitude = geolocation?.lng;
 
   const { locale, AVAILABLE_LANGUAGES } = useSelector(state => state.intl);
 
@@ -86,19 +81,6 @@ export const EntranceForm = ({ caveValues = null, entranceValues = null }) => {
   });
 
   // TODO set latitude & longitude from the selected Entry
-  useEffect(() => {
-    if (isNil(entranceValues?.latitude) || isNil(entranceValues?.longitude)) {
-      const values = getValues();
-      reset({
-        ...values,
-        entrance: {
-          ...values.entrance,
-          latitude,
-          longitude
-        }
-      });
-    }
-  }, [entranceValues, getValues, latitude, longitude, reset]);
 
   const handleUpdateEntityType = type => {
     setEntityType(type);

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { MapContainer, FeatureGroup, ScaleControl } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
-import { useGeolocation } from 'rooks';
 import L from 'leaflet';
 import LayersControl from '../../../common/Maps/common/LayersControl';
+import LocateControl from '../../../common/Maps/common/LocateControl';
+
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
@@ -25,17 +26,15 @@ const getMultiPolygonCentroid = function (coordinates) {
 const PolygonMap = ({ onChange, data }) => {
   const isMounted = useRef(true);
   const displayValue = useRef(false);
+  // eslint-disable-next-line no-unused-vars
   const [map, setMap] = useState();
   const [mapLayers, setMapLayers] = useState([]);
-  const geolocation = useGeolocation();
-  const latitude = geolocation?.lat;
-  const longitude = geolocation?.lng;
   const [center] = useState(
     data
       ? getMultiPolygonCentroid(data.coordinates[0][0])
       : {
-          lat: latitude || 43.6,
-          lng: longitude || 3.86
+          lat: 43.6,
+          lng: 3.86
         }
   );
   const ZOOM_LEVEL = 10;
@@ -74,16 +73,6 @@ const PolygonMap = ({ onChange, data }) => {
     // Quick fix infinite loop if onChange is added to the array
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapLayers]);
-
-  useEffect(() => {
-    isMounted.current = true;
-    if (geolocation && geolocation.lat && geolocation.lng && !data) {
-      map.setView([geolocation.lat, geolocation.lng]);
-    }
-    return () => {
-      isMounted.current = false;
-    };
-  }, [data, geolocation, map]);
 
   const onCreate = e => {
     const { layerType, layer } = e;
@@ -186,6 +175,7 @@ const PolygonMap = ({ onChange, data }) => {
         />
       </FeatureGroup>
 
+      <LocateControl />
       <ScaleControl position="bottomright" />
       <LayersControl />
     </MapContainer>

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -5,8 +5,9 @@ import PropTypes from 'prop-types';
 import { isMobile } from 'react-device-detect';
 import styled from 'styled-components';
 import { useDebounce } from '../../../../hooks';
-import { defaultCoord, defaultZoom } from '../../../../conf/config';
+import { defaultCoord } from '../../../../conf/config';
 import LayersControl from '../../../common/Maps/common/LayersControl';
+import LocateControl from '../../../common/Maps/common/LocateControl';
 
 const StyledMapContainer = styled(MapContainer)`
   margin: 0 4px;
@@ -113,12 +114,13 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
     <StyledMapContainer
       style={{ height: '40vh', width: 'calc(100% - 8px)' }}
       center={currentPosition}
-      zoom={defaultZoom}
+      zoom={14}
       dragging={!isMobile} // For usability only use two fingers drag/zoom on mobile
       scrollWheelZoom="center" // To avoid losing the coordinate when only zooming
       doubleClickZoom="center"
       touchZoom="center"
       preferCanvas>
+      <LocateControl />
       <ScaleControl position="bottomright" />
       <LayersControl />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,7 +3019,6 @@ __metadata:
     redux: ^4.2.1
     redux-debounced: ^0.5.0
     redux-thunk: ^2.4.2
-    rooks: ^7.14.1
     storybook: ^7.0.27
     storybook-react-router: 1.0.8
     styled-components: ^6.0.4
@@ -19005,21 +19004,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rooks@npm:^7.14.1":
-  version: 7.14.1
-  resolution: "rooks@npm:7.14.1"
-  dependencies:
-    fast-deep-equal: ^3.1.3
-    lodash.debounce: ^4.0.8
-    raf: ^3.4.1
-    use-sync-external-store: ^1.2.0
-  peerDependencies:
-    react: ^16.8.0  || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
-  checksum: b88dc3d7451b017503b11be995fba2ccc260ac18a386922e490ef3d328a796cfd677c4425454efd2de4e2c936eb879febe2f9f8a939be4f22aa2a66329567895
-  languageName: node
-  linkType: hard
-
 "run-applescript@npm:^5.0.0":
   version: 5.0.0
   resolution: "run-applescript@npm:5.0.0"
@@ -21318,7 +21302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0":
+"use-sync-external-store@npm:^1.0.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
For entrances and massifs, when editing stops asking user geolocation directly, adds a control on the map instead.

Also for entrances edit map sets the default zoom to 14 to match the map preview on the entrance page 