### PR TITLE
fix(caver): error when selecting a user in dashboard #972

### DIFF
--- a/packages/web-app/src/components/appli/ManageUserGroups/UserGroups.jsx
+++ b/packages/web-app/src/components/appli/ManageUserGroups/UserGroups.jsx
@@ -24,6 +24,8 @@ const UserGroups = ({
   setSelectedUser
 }) => {
   const { formatMessage } = useIntl();
+  // eslint-disable-next-line no-param-reassign
+  if (!initialUser.groups) initialUser.groups = [];
 
   const userGroupsHaveChanged =
     // Check if groups are different between selectedUser and initialUser

--- a/packages/web-app/src/components/common/Person/PersonProperties.jsx
+++ b/packages/web-app/src/components/common/Person/PersonProperties.jsx
@@ -35,6 +35,8 @@ const PersonProperties = ({ person }) => {
 
   let groupString = '';
   let groupsComplete = true;
+  // eslint-disable-next-line no-param-reassign
+  if (!person.groups) person.groups = [];
   const { groups } = person;
   const mappedGroups = groups.map(group => {
     if (!group.name) {

--- a/packages/web-app/src/pages/Admin/ManageUsers.jsx
+++ b/packages/web-app/src/pages/Admin/ManageUsers.jsx
@@ -42,7 +42,7 @@ const ManageUsers = () => {
   } = useSelector(state => state.updatePersonGroups);
 
   const onSaveGroups = () => {
-    dispatch(postPersonGroups(selectedUser.id, selectedUser.groups));
+    dispatch(postPersonGroups(selectedUser.id, selectedUser.groups ?? []));
   };
 
   const onSelection = selection => {


### PR DESCRIPTION
 Fixes the error when selecting a user in dashboard.

When the caver is not part of any groups, the `groups` key in the search result is sometimes not present, causing issues

Should fix #972