### PR TITLE
fix(altitude): adds the altitude field in the entrance creation and m…

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceDetail.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceDetail.jsx
@@ -112,6 +112,22 @@ const EntranceDetail = ({ control, errors, getValues }) => {
           />
         )}
         <Controller
+          name="entrance.altitude"
+          control={control}
+          rules={{ valueAsNumber: true }}
+          render={({ field: { ref, value, onChange } }) => (
+            <TextField
+              fullWidth
+              label={formatMessage({ id: 'Altitude' })}
+              type="number"
+              error={!!errors.entrance?.altitude}
+              inputRef={ref}
+              value={value}
+              onChange={onChange}
+            />
+          )}
+        />
+        <Controller
           name="entrance.yearDiscovery"
           control={control}
           rules={{ valueAsNumber: true }}
@@ -150,6 +166,7 @@ EntranceDetail.propTypes = {
       longitude: PropTypes.shape({ message: PropTypes.string }),
       language: PropTypes.shape({ message: PropTypes.string }),
       name: PropTypes.shape({ message: PropTypes.string }),
+      altitude: PropTypes.shape({ message: PropTypes.number }),
       yearDiscovery: PropTypes.shape({ message: PropTypes.number })
     })
   }),

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -39,6 +39,7 @@ const defaultEntranceValues = {
   language: '',
   latitude: '',
   longitude: '',
+  altitude: '',
   yearDiscovery: ''
 };
 

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
@@ -13,6 +13,7 @@ export const makeEntranceData = (data, entityType) => ({
   isSensitive: data.entrance.isSensitive,
   longitude: data.entrance.longitude,
   latitude: data.entrance.latitude,
+  altitude: data.entrance.altitude ? Number(data.entrance.altitude) : null,
   yearDiscovery: data.entrance.yearDiscovery
     ? Number(data.entrance.yearDiscovery)
     : null

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -267,6 +267,7 @@ export const Entry = ({ isLoading, error, entrance }) => {
                     language: entrance.language,
                     latitude: entrance?.latitude,
                     longitude: entrance?.longitude,
+                    altitude: entrance.altitude,
                     yearDiscovery: entrance.discoveryYear
                   }}
                   caveValues={{


### PR DESCRIPTION
# Add altitude field support for entrance creation and modification

## 🤔 What

- Added altitude input field to the entrance creation and modification form
- Altitude value is now properly loaded when editing an existing entrance
- Altitude is sent to the API during entrance creation and updates

## 🤷♂️ Why

The altitude field was already supported by the backend API and displayed in the entrance properties view, but users had no way to set or modify this value through the entrance form. This created an incomplete user experience where altitude data could only be added through the duplicates handler.

## 🔍 How

- Added a numeric `TextField` controller for `entrance.altitude` in `EntranceDetail.jsx`
- Updated `defaultEntranceValues` to include `altitude: ''` in the entrance form
- Modified `makeEntranceData` transformer to include altitude in the API payload (converted to number or null)
- Added `altitude: entrance.altitude` to the `entranceValues` prop when editing an entrance in `Entry/index.jsx`

## 🔗 Related API PR

None - the API already supports the altitude field.

## 🧪 Testing

1. Create a new entrance and verify the altitude field is present and can be filled
2. Edit an existing entrance with an altitude value and verify the field is pre-populated
3. Edit an existing entrance without an altitude value and verify the field is empty
4. Submit the form and verify the altitude is saved correctly

## 📸 Previews

<img width="1368" height="729" alt="Screenshot 2025-11-12 at 2 43 06 p m" src="https://github.com/user-attachments/assets/eb352aa0-2cb3-4c28-b4ca-85950692ff66" />
<img width="1161" height="576" alt="Screenshot 2025-11-12 at 2 42 33 p m" src="https://github.com/user-attachments/assets/d37ac9f1-2087-48a6-a312-2fbf2d804ce2" />


