### PR TITLE
feat(entrances): adds pagination to all `/entrances/with-quality/` screens

### DIFF
--- a/packages/web-app/src/actions/Country/GetEntrancesDataQuality.js
+++ b/packages/web-app/src/actions/Country/GetEntrancesDataQuality.js
@@ -9,14 +9,14 @@ export const FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_LOADING =
 export const FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_ERROR =
   'FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_ERROR';
 
-export const fetchCountryEntrances = countryId => (dispatch, getState) => {
+export const fetchCountryEntrances = (countryId, { limit, offset } = {}) => (dispatch, getState) => {
   dispatch({ type: FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_LOADING });
   const requestOptions = {
     headers: {
       ...getState().login.authorizationHeader
     }
   };
-  return fetch(getCountryEntrancesUrl(countryId), requestOptions)
+  return fetch(getCountryEntrancesUrl(countryId, { limit, offset }), requestOptions)
     .then(response => {
       if (response.status >= 400) {
         throw new Error(response.status);

--- a/packages/web-app/src/actions/Massif/GetEntrancesDataQuality.js
+++ b/packages/web-app/src/actions/Massif/GetEntrancesDataQuality.js
@@ -9,14 +9,14 @@ export const FETCH_MASSIF_ENTRANCES_DATA_QUALITY_LOADING =
 export const FETCH_MASSIF_ENTRANCES_DATA_QUALITY_ERROR =
   'FETCH_MASSIF_ENTRANCES_DATA_QUALITY_ERROR';
 
-export const fetchMassifEntrances = massifId => (dispatch, getState) => {
+export const fetchMassifEntrances = (massifId, { limit, offset } = {}) => (dispatch, getState) => {
   dispatch({ type: FETCH_MASSIF_ENTRANCES_DATA_QUALITY_LOADING });
   const requestOptions = {
     headers: {
       ...getState().login.authorizationHeader
     }
   };
-  return fetch(getMassifEntrancesUrl(massifId), requestOptions)
+  return fetch(getMassifEntrancesUrl(massifId, { limit, offset }), requestOptions)
     .then(response => {
         if (response.status >= 400) {
             throw new Error(response.status);

--- a/packages/web-app/src/actions/Region/GetEntrancesDataQuality.js
+++ b/packages/web-app/src/actions/Region/GetEntrancesDataQuality.js
@@ -10,14 +10,14 @@ export const FETCH_REGION_ENTRANCES_DATA_QUALITY_ERROR =
   'FETCH_REGION_ENTRANCES_DATA_QUALITY_ERROR';
 
 export const fetchRegionEntrances =
-  (countryId, regionId) => (dispatch, getState) => {
+  (countryId, regionId, { limit, offset } = {}) => (dispatch, getState) => {
     dispatch({ type: FETCH_REGION_ENTRANCES_DATA_QUALITY_LOADING });
     const requestOptions = {
       headers: {
         ...getState().login.authorizationHeader
       }
     };
-    return fetch(getRegionEntrancesUrl(countryId, regionId), requestOptions)
+    return fetch(getRegionEntrancesUrl(countryId, regionId, { limit, offset }), requestOptions)
       .then(response => {
         if (response.status >= 400) {
           throw new Error(response.status);

--- a/packages/web-app/src/components/appli/AdvancedSearch/SearchResults/SearchResultsTable.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/SearchResults/SearchResultsTable.jsx
@@ -456,6 +456,17 @@ class SearchResultsTable extends React.Component {
                     formatMessage={intl.formatMessage}
                   />
                 )}
+                sx={{
+                  '.MuiTablePagination-selectLabel': {
+                    margin: 0
+                  },
+                  '.MuiTablePagination-displayedRows': {
+                    margin: 0
+                  },
+                  '.MuiTablePagination-select': {
+                    fontSize: '1.3986rem'
+                  }
+                }}
               />
               <Button
                 disabled={!canDownloadDataAsCSV}

--- a/packages/web-app/src/components/common/Table/index.jsx
+++ b/packages/web-app/src/components/common/Table/index.jsx
@@ -242,6 +242,18 @@ const Table = ({
             page={currentPage}
             onPageChange={handleChangePage}
             onRowsPerPageChange={handleChangeRowsPerPage}
+            sx={{
+              overflow: 'visible',
+              '.MuiTablePagination-selectLabel': {
+                margin: 0
+              },
+              '.MuiTablePagination-displayedRows': {
+                margin: 0
+              },
+              '.MuiTablePagination-select': {
+                fontSize: '1.3986rem'
+              }
+            }}
           />
         )}
       </TableFooter>

--- a/packages/web-app/src/conf/apiRoutes.js
+++ b/packages/web-app/src/conf/apiRoutes.js
@@ -41,14 +41,24 @@ export const getCountryUrl = countryId =>
   `${API_BASE_PATH}/countries/${countryId}`;
 export const getStatisticsCountryUrl = countryId =>
   `${API_BASE_PATH}/countries/${countryId}/statistics`;
-export const getCountryEntrancesUrl = countryId =>
-  `${API_BASE_PATH}/entrances/with-quality/countries/${countryId}`;
+export const getCountryEntrancesUrl = (countryId, { limit, offset } = {}) => {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.append('limit', limit);
+  if (offset !== undefined) params.append('offset', offset);
+  const query = params.toString();
+  return `${API_BASE_PATH}/entrances/with-quality/countries/${countryId}${query ? `?${query}` : ''}`;
+};
 export const getRegionUrl = (countryId, regionId) =>
   `${API_BASE_PATH}/countries/${countryId}/regions/${regionId}`;
 export const getStatisticsRegionUrl = (countryId, regionId) =>
   `${API_BASE_PATH}/countries/${countryId}/regions/${regionId}/statistics`;
-export const getRegionEntrancesUrl = (countryId, regionId) =>
-  `${API_BASE_PATH}/entrances/with-quality/countries/${countryId}/regions/${regionId}`;
+export const getRegionEntrancesUrl = (countryId, regionId, { limit, offset } = {}) => {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.append('limit', limit);
+  if (offset !== undefined) params.append('offset', offset);
+  const query = params.toString();
+  return `${API_BASE_PATH}/entrances/with-quality/countries/${countryId}/regions/${regionId}${query ? `?${query}` : ''}`;
+};
 
 // ===== Descriptions urls
 export const postDescriptionUrl = `${API_BASE_PATH}/descriptions`;
@@ -190,8 +200,13 @@ export const postCreateMassifUrl = `${API_BASE_PATH}/massifs/`;
 export const putMassifUrl = massifId => `${API_BASE_PATH}/massifs/${massifId}`;
 export const getStatisticsMassifUrl = massifId =>
   `${API_BASE_PATH}/massifs/${massifId}/statistics`;
-export const getMassifEntrancesUrl = massifId =>
-  `${API_BASE_PATH}/entrances/with-quality/massifs/${massifId}`;
+export const getMassifEntrancesUrl = (massifId, { limit, offset } = {}) => {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.append('limit', limit);
+  if (offset !== undefined) params.append('offset', offset);
+  const query = params.toString();
+  return `${API_BASE_PATH}/entrances/with-quality/massifs/${massifId}${query ? `?${query}` : ''}`;
+};
 export const deleteMassifUrl = (massifId, { entityId, isPermanent = false }) =>
   `${API_BASE_PATH}/massifs/${massifId}?${[
     isPermanent ? 'isPermanent=1' : '',

--- a/packages/web-app/src/pages/EntrancesList/EntranceList.jsx
+++ b/packages/web-app/src/pages/EntrancesList/EntranceList.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { List, Typography, Box, useTheme, Pagination } from '@mui/material';
+import { List, Typography, Box, useTheme } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
@@ -33,12 +33,9 @@ const getFormatDate = (date, formatMessage, locale) => {
 const EntrancesList = props => {
   const { entrances, handleClickScroll } = props;
   const { formatMessage } = useIntl();
-  const nbEntrancesPerPage = 36;
   const theme = useTheme();
   const locale = useSelector(state => state.intl);
 
-  const [entrancestoDisplay, setEntrancestoDisplay] = useState([]);
-  const [page, setPage] = useState(1);
   const [dateOfUpdate, setDateOfUpdate] = useState(null);
 
   // manage format of date of update
@@ -50,16 +47,6 @@ const EntrancesList = props => {
       setDateOfUpdate(null);
     }
   }, [entrances, formatMessage, locale]);
-
-  // manage entrance list with pagination
-  useEffect(() => {
-    setEntrancestoDisplay(
-      entrances.slice(
-        (page - 1) * nbEntrancesPerPage,
-        page * nbEntrancesPerPage
-      )
-    );
-  }, [page, entrances]);
 
   return (
     <>
@@ -96,31 +83,15 @@ const EntrancesList = props => {
           )}
         </Box>
       </Box>
-      {entrancestoDisplay && entrancestoDisplay.length > 0 ? (
-        <>
-          <StyledList>
-            {entrancestoDisplay.map(entrance => (
-              <EntranceListItem
-                key={entrance.id_entrance}
-                entrance={entrance}
-              />
-            ))}
-          </StyledList>
-          {entrances.length > nbEntrancesPerPage && (
-            <Box
-              style={{
-                display: 'flex',
-                justifyContent: 'center',
-                marginTop: '10px'
-              }}>
-              <Pagination
-                count={Math.ceil(entrances.length / nbEntrancesPerPage)}
-                page={page}
-                onChange={(o, p) => setPage(p)}
-              />
-            </Box>
-          )}
-        </>
+      {entrances && entrances.length > 0 ? (
+        <StyledList>
+          {entrances.map(entrance => (
+            <EntranceListItem
+              key={entrance.id_entrance}
+              entrance={entrance}
+            />
+          ))}
+        </StyledList>
       ) : (
         <Alert
           title={formatMessage({

--- a/packages/web-app/src/pages/EntrancesList/index.jsx
+++ b/packages/web-app/src/pages/EntrancesList/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { List } from '@mui/material';
+import { List, Pagination, Box } from '@mui/material';
 import Skeleton from '@mui/material/Skeleton';
 import { styled } from '@mui/material/styles';
 import Alert from '../../components/common/Alert';
@@ -32,11 +32,15 @@ const EntrancesListPage = () => {
   const { countryId, massifId, regionId } = useParams();
   const dispatch = useDispatch();
 
+  const [page, setPage] = useState(1);
+  const limit = 36;
   // to store entrances even if it's massif entrances or country entrances (managed with a useEffect)
   const [entrances, setEntrances] = useState(null);
   // to store error even if it's massif entrances error or country entrances error (managed with a useEffect)
   const [error, setError] = useState(null);
   const [entityType, setEntityType] = useState();
+  const [totalPages, setTotalPages] = useState(0);
+  const [hasData, setHasData] = useState(false);
 
   const { massifEntrances, massifEntrancesLoading, massifEntrancesError } =
     useSelector(state => state.massifEntrances);
@@ -52,45 +56,73 @@ const EntrancesListPage = () => {
   const { massif } = useSelector(state => state.massif);
 
   useEffect(() => {
+    const offset = (page - 1) * limit;
     if (regionId && countryId) {
-      dispatch(fetchRegionEntrances(countryId, regionId));
+      dispatch(fetchRegionEntrances(countryId, regionId, { limit, offset }));
       dispatch(fetchRegion(countryId, regionId));
     } else if (countryId) {
-      dispatch(fetchCountryEntrances(countryId));
+      dispatch(fetchCountryEntrances(countryId, { limit, offset }));
       dispatch(fetchCountry(countryId));
     } else {
-      dispatch(fetchMassifEntrances(massifId));
+      dispatch(fetchMassifEntrances(massifId, { limit, offset }));
       dispatch(loadMassif(massifId));
     }
-  }, [countryId, massifId, regionId, dispatch]);
+  }, [countryId, massifId, regionId, page, limit, dispatch]);
+
+  const massifState = useSelector(state => state.massifEntrances);
+  const countryState = useSelector(state => state.countryEntrances);
+  const regionState = useSelector(state => state.regionEntrances);
+
+  // Reset page when entity changes
+  useEffect(() => {
+    setPage(1);
+  }, [countryId, massifId, regionId]);
 
   // manage entrances
   useEffect(() => {
-    setEntrances(
-      Array.isArray(countryEntrances)
-        ? sortByDataQuality(countryEntrances)
-        : countryEntrances
-    );
-    setEntityType('country');
-  }, [countryEntrances]);
+    if (countryEntrances) {
+      setEntrances(
+        Array.isArray(countryEntrances)
+          ? sortByDataQuality(countryEntrances)
+          : countryEntrances
+      );
+      setEntityType('country');
+      if (countryState.totalPages) {
+        setTotalPages(countryState.totalPages);
+        setHasData(true);
+      }
+    }
+  }, [countryEntrances, countryState.totalPages]);
 
   useEffect(() => {
-    setEntrances(
-      Array.isArray(massifEntrances)
-        ? sortByDataQuality(massifEntrances)
-        : massifEntrances
-    );
-    setEntityType('massif');
-  }, [massifEntrances]);
+    if (massifEntrances) {
+      setEntrances(
+        Array.isArray(massifEntrances)
+          ? sortByDataQuality(massifEntrances)
+          : massifEntrances
+      );
+      setEntityType('massif');
+      if (massifState.totalPages) {
+        setTotalPages(massifState.totalPages);
+        setHasData(true);
+      }
+    }
+  }, [massifEntrances, massifState.totalPages]);
 
   useEffect(() => {
-    setEntrances(
-      Array.isArray(regionEntrances)
-        ? sortByDataQuality(regionEntrances)
-        : regionEntrances
-    );
-    setEntityType('region');
-  }, [regionEntrances]);
+    if (regionEntrances) {
+      setEntrances(
+        Array.isArray(regionEntrances)
+          ? sortByDataQuality(regionEntrances)
+          : regionEntrances
+      );
+      setEntityType('region');
+      if (regionState.totalPages) {
+        setTotalPages(regionState.totalPages);
+        setHasData(true);
+      }
+    }
+  }, [regionEntrances, regionState.totalPages]);
 
   // manage error
   useEffect(() => {
@@ -139,6 +171,13 @@ const EntrancesListPage = () => {
     }
   };
 
+  const handlePageChange = (event, newPage) => {
+    setPage(newPage);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const shouldShowPagination = hasData && totalPages > 1;
+
   return (
     <Layout
       title={getTitle()}
@@ -168,7 +207,17 @@ const EntrancesListPage = () => {
                 entrances={entrances}
                 handleClickScroll={handleClickScroll}
               />
-
+              {shouldShowPagination && (
+                <Box mt={3} mb={3} display="flex" justifyContent="center">
+                  <Pagination
+                    count={totalPages}
+                    page={page}
+                    onChange={handlePageChange}
+                    disabled={massifEntrancesLoading || countryEntrancesLoading || regionEntrancesLoading}
+                    color="primary"
+                  />
+                </Box>
+              )}
               <DataQualityComputeDetails />
             </>
           )}

--- a/packages/web-app/src/reducers/CountryEntrancesDataQualityReducer.js
+++ b/packages/web-app/src/reducers/CountryEntrancesDataQualityReducer.js
@@ -7,7 +7,9 @@ import {
 const initialState = {
   countryEntrances: {},
   countryEntrancesLoading: false,
-  countryEntrancesError: null
+  countryEntrancesError: null,
+  totalCount: 0,
+  totalPages: 0
 };
 
 const reducer = (state = initialState, action) => {
@@ -21,7 +23,9 @@ const reducer = (state = initialState, action) => {
     case FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_SUCCESS:
       return {
         ...initialState,
-        countryEntrances: action.data.quality
+        countryEntrances: action.data.quality,
+        totalCount: action.data.totalCount || 0,
+        totalPages: action.data.totalPages || 0
       };
     case FETCH_COUNTRY_ENTRANCES_DATA_QUALITY_ERROR:
       return {

--- a/packages/web-app/src/reducers/MassifEntrancesDataQualityReducer.js
+++ b/packages/web-app/src/reducers/MassifEntrancesDataQualityReducer.js
@@ -7,7 +7,9 @@ import {
 const initialState = {
   massifEntrances: {},
   massifEntrancesLoading: false,
-  massifEntrancesError: null
+  massifEntrancesError: null,
+  totalCount: 0,
+  totalPages: 0
 };
 
 const reducer = (state = initialState, action) => {
@@ -21,7 +23,9 @@ const reducer = (state = initialState, action) => {
     case FETCH_MASSIF_ENTRANCES_DATA_QUALITY_SUCCESS:
       return {
         ...initialState,
-        massifEntrances: action.data.quality
+        massifEntrances: action.data.quality,
+        totalCount: action.data.totalCount || 0,
+        totalPages: action.data.totalPages || 0
       };
     case FETCH_MASSIF_ENTRANCES_DATA_QUALITY_ERROR:
       return {

--- a/packages/web-app/src/reducers/RegionEntrancesDataQualityReducer.js
+++ b/packages/web-app/src/reducers/RegionEntrancesDataQualityReducer.js
@@ -7,7 +7,9 @@ import {
 const initialState = {
   regionEntrances: {},
   regionEntrancesLoading: false,
-  regionEntrancesError: null
+  regionEntrancesError: null,
+  totalCount: 0,
+  totalPages: 0
 };
 
 const reducer = (state = initialState, action) => {
@@ -21,7 +23,9 @@ const reducer = (state = initialState, action) => {
     case FETCH_REGION_ENTRANCES_DATA_QUALITY_SUCCESS:
       return {
         ...initialState,
-        regionEntrances: action.data.quality
+        regionEntrances: action.data.quality,
+        totalCount: action.data.totalCount || 0,
+        totalPages: action.data.totalPages || 0
       };
     case FETCH_REGION_ENTRANCES_DATA_QUALITY_ERROR:
       return {


### PR DESCRIPTION
# Add server-side pagination to entrances with quality screens

## 🤔 What

This PR implements server-side pagination for entrances data quality lists across Country, Region, and Massif pages.

- Replaced client-side pagination with server-side pagination
- Added `limit` and `offset` query parameters to API calls
- Updated Redux reducers to store pagination metadata (`totalCount`, `totalPages`)
- Moved pagination controls from EntranceList component to EntrancesListPage
- Fixed MUI TablePagination styling issues (margin and font-size)

## 🤷♂️ Why

The previous implementation loaded all entrances at once and paginated them on the client side, which:
- Caused performance issues with large datasets
- Increased initial load time and memory usage
- Didn't scale well for countries/regions/massifs with hundreds or thousands of entrances

Server-side pagination improves performance by fetching only the required page of data from the API.

## 🔍 How

**API Layer:**
- Modified `getCountryEntrancesUrl`, `getRegionEntrancesUrl`, and `getMassifEntrancesUrl` in `apiRoutes.js` to accept optional `limit` and `offset` parameters
- Updated action creators (`fetchCountryEntrances`, `fetchRegionEntrances`, `fetchMassifEntrances`) to pass pagination parameters to API calls

**State Management:**
- Enhanced reducers to store `totalCount` and `totalPages` from API responses
- Reducers now extract pagination metadata alongside entrance data

**UI Components:**
- Removed local pagination logic from `EntranceList.jsx` (now displays all items passed to it)
- Moved pagination controls to `EntrancesListPage` component
- Added page state management with automatic reset when switching between entities
- Pagination triggers new API calls with updated offset
- Added scroll-to-top behavior on page change

**Styling:**
- Fixed TablePagination component styling in both `Table/index.jsx` and `SearchResultsTable.jsx` to remove unwanted margins and adjust font size

## 🔗 Related API PR

This PR requires corresponding API changes to support `limit` and `offset` query parameters on the following endpoints:
- `/entrances/with-quality/countries/:countryId`
- `/entrances/with-quality/countries/:countryId/regions/:regionId`
- `/entrances/with-quality/massifs/:massifId`

The API must return responses with `quality`, `totalCount`, and `totalPages` fields.

## 🧪 Testing

1. Navigate to a Country page with many entrances
2. Verify pagination controls appear at the bottom
3. Click through pages and verify:
   - Only 36 entrances load per page
   - Page changes trigger new API requests
   - Page scrolls to top on navigation
   - Pagination is disabled during loading
4. Repeat for Region and Massif pages
5. Test with entities having fewer than 36 entrances (pagination should not appear)
6. Verify table pagination styling in Advanced Search results
