### PR TITLE
fix(map): fixes the automatic geolocation and default zoom

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -11,6 +11,7 @@ import GeocodingControl from '../../../common/Maps/common/GeocodingControl';
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
+import { defaultZoom, focusZoom } from '../../../../conf/config';
 
 const getMultiPolygonCentroid = function (coordinates) {
   const result = coordinates.reduce(
@@ -30,7 +31,7 @@ const PolygonMap = ({ onChange, data }) => {
   const { formatMessage } = useIntl();
   const isMounted = useRef(true);
   const displayValue = useRef(false);
-  const { location: geoLocation, isReady } = useGeolocation();
+  const { location: geoLocation, isReady, hasError } = useGeolocation();
   const [map, setMap] = useState();
 
   // Configure Leaflet Draw text
@@ -79,12 +80,16 @@ const PolygonMap = ({ onChange, data }) => {
       ? getMultiPolygonCentroid(data.coordinates[0][0])
       : geoLocation
   );
-  const ZOOM_LEVEL = 10;
+  const ZOOM_LEVEL = !data && hasError ? defaultZoom : focusZoom;
 
   useEffect(() => {
-    if (!data && isReady && map) {
-      map.setView(geoLocation, ZOOM_LEVEL);
-      setCenter(geoLocation);
+    if (map) {
+      if (data && data.coordinates && data.coordinates[0] && data.coordinates[0][0]) {
+        map.fitBounds(data.coordinates[0][0].map(e => [e[1], e[0]]));
+      } else if (isReady) {
+        map.setView(geoLocation, ZOOM_LEVEL);
+        setCenter(geoLocation);
+      }
     }
   }, [isReady, geoLocation, data, map, ZOOM_LEVEL]);
 

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -12,6 +12,7 @@ import LocateControl from '../../../common/Maps/common/LocateControl';
 import ConverterControl from '../../../common/Maps/common/Converter';
 import GeocodingControl from '../../../common/Maps/common/GeocodingControl';
 import { fetchProjections } from '../../../../actions/Projections';
+import { defaultZoom, focusZoom } from '../../../../conf/config';
 
 const StyledMapContainer = styled(MapContainer)`
   margin: 0 4px;
@@ -31,7 +32,7 @@ const StyledMapContainer = styled(MapContainer)`
 `;
 
 // Needed because useMap is only accessible from inside <MapContainer>
-const MapBind = ({ center, onMoveEnd }) => {
+const MapBind = ({ center, zoom, onMoveEnd }) => {
   const lastValidCenter = useRef({});
   const lastSetViewTs = useRef(0);
   const map = useMap();
@@ -55,13 +56,14 @@ const MapBind = ({ center, onMoveEnd }) => {
   useEffect(() => {
     lastValidCenter.current = center;
     lastSetViewTs.current = Date.now();
-    map.setView(center, map.getZoom(), { animate: false });
-  }, [center, map]);
+    map.setView(center, zoom, { animate: false });
+  }, [center, zoom, map]);
 
   return null;
 };
 MapBind.propTypes = {
   center: PropTypes.shape({}),
+  zoom: PropTypes.number,
   onMoveEnd: PropTypes.func
 };
 
@@ -75,18 +77,15 @@ const toFloat = value => {
 const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   const DEBOUNCE_TIME_MS = 300;
   const lastSetFormTs = useRef(0);
-  const { location: geoLocation } = useGeolocation();
+  const { location: geoLocation, hasError: geoHasError } = useGeolocation();
   const [currentPosition, setCurrentPosition] = useState(geoLocation);
+  const [shouldUpdate, setShouldUpdate] = useState(false);
   const dispatch = useDispatch();
   const { projections } = useSelector(state => state.projections);
 
   useEffect(() => {
     dispatch(fetchProjections());
   }, [dispatch]);
-
-  useEffect(() => {
-    setCurrentPosition(geoLocation);
-  }, [geoLocation]);
 
   const latitude = useDebounce(
     useWatch({ control, name: formLatitudeKey }),
@@ -110,13 +109,17 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   useEffect(() => {
     // Prevent dispatching a setCurrentPosition event triggered by a setForm below
     const timeSinceSetFormMs = Date.now() - lastSetFormTs.current;
-    const shouldUpdate =
+    const isValid =
       !Number.isNaN(validLatitude) && !Number.isNaN(validLongitude);
 
-    if (shouldUpdate && timeSinceSetFormMs > DEBOUNCE_TIME_MS + 100) {
+    if (isValid && timeSinceSetFormMs > DEBOUNCE_TIME_MS + 100) {
       setCurrentPosition({ lat: validLatitude, lng: validLongitude });
+      setShouldUpdate(true);
+    } else {
+      setCurrentPosition(geoLocation);
+      setShouldUpdate(false);
     }
-  }, [validLatitude, validLongitude]);
+  }, [validLatitude, validLongitude, geoLocation]);
 
   // Binding form <- map
   const onMoveEnd = newLocation => {
@@ -125,11 +128,13 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
     setFormLongitude(newLocation.lng.toFixed(6));
   };
 
+  const ZOOM_LEVEL = shouldUpdate ? focusZoom : (geoHasError ? defaultZoom : focusZoom);
+
   return (
     <StyledMapContainer
       style={{ height: '40vh', width: 'calc(100% - 8px)' }}
-      center={[0, 0]}
-      zoom={14}
+      center={currentPosition}
+      zoom={ZOOM_LEVEL}
       dragging={!isMobile} // For usability only use two fingers drag/zoom on mobile
       scrollWheelZoom="center" // To avoid losing the coordinate when only zooming
       doubleClickZoom="center"
@@ -144,7 +149,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
       <LayersControl />
       <ConverterControl projectionsList={projections} hideOutput />
 
-      <MapBind center={currentPosition} onMoveEnd={onMoveEnd} />
+      <MapBind center={currentPosition} zoom={ZOOM_LEVEL} onMoveEnd={onMoveEnd} />
 
       <span className="centralMarker">
         <img

--- a/packages/web-app/src/conf/config.js
+++ b/packages/web-app/src/conf/config.js
@@ -76,10 +76,9 @@ export const breadcrumpKeys = {
   users: 'Users'
 };
 
-export const defaultCoord = { lat: 47.5, lng: 19 }; // Budapest
-export const defaultZoom = 6;
+export const defaultCoord = { lat: 0, lng: 0 };
+export const defaultZoom = 2;
 export const focusZoom = 13;
-export const ipGeolocationUrl = 'https://ipwho.is/';
 export const sideMenuWidth = '215px';
 export const logoGC = '/images/logo.svg';
 

--- a/packages/web-app/src/hooks/useGeolocation.js
+++ b/packages/web-app/src/hooks/useGeolocation.js
@@ -1,40 +1,33 @@
 import { useEffect, useState } from 'react';
-import { defaultCoord, ipGeolocationUrl } from '../conf/config';
+import { defaultCoord } from '../conf/config';
 
 const useGeolocation = () => {
   const [location, setLocation] = useState(defaultCoord);
   const [isReady, setIsReady] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
-    const tryIpGeolocation = () => {
-      fetch(ipGeolocationUrl)
-        .then(res => res.json())
-        .then(data => {
-          if (data.latitude && data.longitude) {
-            setLocation({ lat: data.latitude, lng: data.longitude });
-          }
-        })
-        .catch(() => {})
-        .finally(() => setIsReady(true));
-    };
-
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          setLocation({ 
-            lat: position.coords.latitude, 
-            lng: position.coords.longitude 
+          setLocation({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
           });
           setIsReady(true);
         },
-        tryIpGeolocation
+        () => {
+          setHasError(true);
+          setIsReady(true);
+        }
       );
     } else {
-      tryIpGeolocation();
+      setHasError(true);
+      setIsReady(true);
     }
   }, []);
 
-  return { location, isReady };
+  return { location, isReady, hasError };
 };
 
 export default useGeolocation;

--- a/packages/web-app/src/pages/Map.jsx
+++ b/packages/web-app/src/pages/Map.jsx
@@ -16,6 +16,7 @@ import {
 import { fetchProjections } from '../actions/Projections';
 import useGeolocation from '../hooks/useGeolocation';
 import 'leaflet/dist/leaflet.css';
+import { defaultZoom, focusZoom } from '../conf/config';
 
 const MapClusters = React.lazy(
   () => import('../components/common/Maps/MapClusters')
@@ -39,7 +40,7 @@ const Map = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const params = useParams();
-  const { location: geoLocation, isReady: isGeoReady } = useGeolocation();
+  const { location: geoLocation, isReady: isGeoReady, hasError: geoHasError } = useGeolocation();
   const {
     location,
     zoom,
@@ -103,7 +104,7 @@ const Map = () => {
       dispatch(changeZoom(target.zoom));
     } else {
       dispatch(changeLocation(geoLocation));
-      dispatch(changeZoom(10));
+      dispatch(changeZoom(geoHasError ? defaultZoom : focusZoom));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isGeoReady]);


### PR DESCRIPTION
# Fix automatic geolocation and default zoom

## 🤔 What

- Removed IP-based geolocation fallback (ipwho.is)
- Added error handling for geolocation failures
- Updated default coordinates from Budapest (47.5, 19) to world center (0, 0)
- Changed default zoom from 6 to 2 for better global view when geolocation fails
- Fixed map initialization to properly handle geolocation errors
- Improved PolygonMap to fit bounds when data exists

## 🤷♂️ Why

The previous implementation relied on an external IP geolocation service (ipwho.is) as a fallback, which impacts user privacy. When geolocation was denied or unavailable, the map would default to Budapest with a regional zoom level, which wasn't appropriate for a global application. This change provides a better user experience by:
- Respecting user privacy by removing IP-based geolocation
- Providing a proper global view when location cannot be determined
- Handling geolocation errors explicitly

## 🔍 How

- Modified `useGeolocation` hook to return `hasError` state
- Removed `ipGeolocationUrl` and IP-based geolocation logic
- Updated `defaultCoord` to `{ lat: 0, lng: 0 }` and `defaultZoom` to `2`
- Added conditional zoom logic: use `focusZoom` (13) when geolocation succeeds, `defaultZoom` (2) when it fails
- Updated MapMarkerSelector to properly handle initial map state and zoom levels
- Enhanced PolygonMap to fit bounds when polygon data exists

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Test with geolocation enabled:
   - Allow location access
   - Map should center on your location with zoom level 13
2. Test with geolocation denied:
   - Deny location access
   - Map should show world view centered at (0, 0) with zoom level 2
3. Test PolygonMap with existing polygon data:
   - Map should fit bounds to show the entire polygon
4. Test MapMarkerSelector with coordinates in form:
   - Map should center on the coordinates with appropriate zoom

