### PR TITLE
Fixes map layers and adds opacity control

### DIFF
--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1232,6 +1232,7 @@
   "on": "on",
   "One of my caving  buddies  told me I should NOT  post anything at  all on Grottocenter That sometimes makes it  hard to contribute !": "One of my caving  buddies  told me I should NOT  post anything at  all on Grottocenter… That sometimes makes it  hard to contribute...",
   "One of my caving buddies told me I should NOT post anything at all on GrottoCenter. That sometimes makes it hard to contribute!": "One of my caving buddies told me I should NOT post anything at all on GrottoCenter. That sometimes makes it hard to contribute!",
+  "Opacity": "Opacity",
   "open drawer": "open drawer",
   "Open on Google Maps": "Open on Google Maps",
   "Open on OpenStreetMap": "Open on OpenStreetMap",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1233,6 +1233,7 @@
   "on": "en",
   "One of my caving  buddies  told me I should NOT  post anything at  all on Grottocenter That sometimes makes it  hard to contribute !": "Uno de mis amigos espeleólogo me dijo que NO debería publicar nada en Grottocenter... A veces eso hace que sea difícil contribuir...",
   "One of my caving buddies told me I should NOT post anything at all on GrottoCenter. That sometimes makes it hard to contribute!": "¡Uno de mis compañeros espeleólogos me dijo que NO debería publicar nada en absoluto en GrottoCenter. ¡A veces eso hace difícil contribuir!",
+  "Opacity": "Opacidad",
   "open drawer": "abrir cajón",
   "Open on Google Maps": "Abrir en Google Maps",
   "Open on OpenStreetMap": "Abrir en OpenStreetMap",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1233,6 +1233,7 @@
   "on": "sur",
   "One of my caving  buddies  told me I should NOT  post anything at  all on Grottocenter That sometimes makes it  hard to contribute !": "Un de mes collègues spéléo me dit que je ne devrais rien mettre sur Grottocenter… Vous comprenez que c’est parfois difficile de contribuer ?",
   "One of my caving buddies told me I should NOT post anything at all on GrottoCenter. That sometimes makes it hard to contribute!": "Un de mes amis spéléologues m'a dit que je ne devrais RIEN publier du tout sur GrottoCenter. Cela rend parfois difficile de contribuer !",
+  "Opacity": "Opacité",
   "open drawer": "ouvrir le tiroir",
   "Open on Google Maps": "Ouvrir sur Google Maps",
   "Open on OpenStreetMap": "Ouvrir sur OpenStreetMap",

--- a/packages/web-app/src/components/common/Maps/common/CustomControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/CustomControl.jsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useMap } from 'react-leaflet';
 import PropTypes from 'prop-types';
+import * as L from 'leaflet';
 
 // Classes used by Leaflet to position controls.
 const POSITION_CLASSES = {
@@ -13,20 +16,56 @@ const CustomControl = ({
   position = 'topright',
   containerProps,
   children,
-  style
-}) => (
-  <div className={POSITION_CLASSES[position]} style={style}>
-    <div className="leaflet-control leaflet-bar" {...containerProps}>
-      {children}
+  style,
+  useLeafletControl = false
+}) => {
+  const controlRef = useRef(null);
+  const map = useMap();
+  const [container, setContainer] = useState(null);
+
+  useEffect(() => {
+    if (controlRef.current) {
+      L.DomEvent.disableClickPropagation(controlRef.current);
+      L.DomEvent.disableScrollPropagation(controlRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!useLeafletControl || !map) return;
+    const control = L.control({ position });
+    control.onAdd = () => {
+      const div = L.DomUtil.create('div', 'leaflet-bar leaflet-control');
+      L.DomEvent.disableClickPropagation(div);
+      L.DomEvent.disableScrollPropagation(div);
+      setContainer(div);
+      return div;
+    };
+    control.addTo(map);
+    return () => {
+      control.remove();
+    };
+  }, [map, position, useLeafletControl]);
+
+  if (useLeafletControl) {
+    if (!container) return null;
+    return createPortal(children, container);
+  }
+
+  return (
+    <div className={POSITION_CLASSES[position]} style={style}>
+      <div ref={controlRef} className="leaflet-control leaflet-bar" {...containerProps}>
+        {children}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export const customControlProps = {
   position: PropTypes.oneOf(Object.keys(POSITION_CLASSES)),
   containerProps: PropTypes.any,
   children: PropTypes.node,
-  style: PropTypes.object
+  style: PropTypes.object,
+  useLeafletControl: PropTypes.bool
 };
 
 CustomControl.propTypes = {

--- a/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
@@ -1,23 +1,29 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { head, pluck } from 'ramda';
 import {
   LayerGroup,
   LayersControl as LeafletLayersControl,
   TileLayer,
-  WMSTileLayer
+  WMSTileLayer,
+  useMap
 } from 'react-leaflet';
 import PropTypes from 'prop-types';
+import * as L from 'leaflet';
+import { styled } from '@mui/material/styles';
+import { useIntl } from 'react-intl';
 
 import layers from './mapLayers';
-import * as L from 'leaflet';
+import CustomControl from './CustomControl';
 
 const possibleLayers = pluck('name', layers);
 const localStorageBaseLayer = possibleLayers.find(
   name => name === window.localStorage.getItem('selectedBaseLayer')
 );
 const selectedBaseLayer = localStorageBaseLayer || head(possibleLayers);
+const localStorageOpacity = parseFloat(window.localStorage.getItem('layerOpacity'));
+const selectedOpacity = !isNaN(localStorageOpacity) ? localStorageOpacity : 1;
 
-const createWMTSTileLayer = layer => (
+const createWMTSTileLayer = (layer, opacity = 1) => (
   <TileLayer
     attribution={layer.attribution}
     url={layer.url}
@@ -25,27 +31,29 @@ const createWMTSTileLayer = layer => (
     maxZoom={layer.maxZoom ?? 22}
     maxNativeZoom={layer.maxNativeZoom ?? 22}
     bounds={layer.bounds ?? new L.LatLngBounds(new L.LatLng(-90, -180), new L.LatLng(90, 180))}
+    opacity={opacity}
   />
 );
 
-const createWMSTileLayer = layer => (
+const createWMSTileLayer = (layer, opacity = 1) => (
   <WMSTileLayer
     attribution={layer.attribution}
     layers={layer.layers}
     url={layer.url}
+    opacity={opacity}
   />
 );
 
 const OSM_LAYER = layers[0];
 const OSM_TILE_LAYER = createWMTSTileLayer(OSM_LAYER);
 
-const BaseMapLayer = ({ layer }) => (
+const BaseMapLayer = ({ layer, opacity }) => (
   <LayerGroup>
     {OSM_TILE_LAYER}
     {layer !== OSM_LAYER && (
       <>
-        {layer.type === 'WMTS' && createWMTSTileLayer(layer)}
-        {layer.type === 'WMS' && createWMSTileLayer(layer)}
+        {layer.type === 'WMTS' && createWMTSTileLayer(layer, opacity)}
+        {layer.type === 'WMS' && createWMSTileLayer(layer, opacity)}
       </>
     )}
   </LayerGroup>
@@ -61,24 +69,112 @@ BaseMapLayer.propTypes = {
     maxNativeZoom: PropTypes.number,
     bounds: PropTypes.object,
     layers: PropTypes.string
-  }).isRequired
+  }).isRequired,
+  opacity: PropTypes.number
+};
+
+const ControlContainer = styled('div')(({ isExpanded }) => ({
+  background: 'white',
+  padding: '5px',
+  width: isExpanded ? '200px' : 'min-content',
+  transition: 'max-height 0.2s ease-in-out, width 0.2s ease-in-out',
+  overflow: 'hidden',
+  maxHeight: isExpanded ? '100px' : '28px'
+}));
+
+const ControlLabel = styled('label')(({ isExpanded }) => ({
+  fontSize: '12px',
+  display: 'block',
+  marginBottom: isExpanded ? '5px' : '0',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  width: isExpanded ? 'auto' : 'fit-content'
+}));
+
+const OpacitySlider = styled('input')(({ theme, isExpanded }) => ({
+  width: '100%',
+  accentColor: theme.palette.primary.main,
+  margin: '2px',
+  transition: 'opacity 0.2s ease-in-out',
+  opacity: isExpanded ? 1 : 0,
+  pointerEvents: isExpanded ? 'auto' : 'none'
+}));
+
+const OpacityControl = ({ position, opacity, setOpacity }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { formatMessage } = useIntl();
+
+  return (
+    <CustomControl position={position} useLeafletControl>
+      <ControlContainer 
+        isExpanded={isExpanded}
+        onMouseEnter={() => setIsExpanded(true)}
+        onMouseLeave={() => setIsExpanded(false)}>
+        <ControlLabel isExpanded={isExpanded}>
+          {formatMessage({ id: 'Opacity' })}
+        </ControlLabel>
+        <OpacitySlider
+          type="range"
+          min="0"
+          max="100"
+          value={opacity * 100}
+          onChange={(e) => setOpacity(e.target.value / 100)}
+          isExpanded={isExpanded}
+        />
+      </ControlContainer>
+    </CustomControl>
+  );
+};
+
+OpacityControl.propTypes = {
+  position: PropTypes.string.isRequired,
+  opacity: PropTypes.number.isRequired,
+  setOpacity: PropTypes.func.isRequired
 };
 
 const LayersControl = ({
   position = 'topleft',
   initialLayerChecked = selectedBaseLayer
-}) => (
-  <LeafletLayersControl position={position}>
-    {layers.map(layer => (
-      <LeafletLayersControl.BaseLayer
-        key={layer.name}
-        checked={layer.name === initialLayerChecked}
-        name={layer.name}>
-        <BaseMapLayer layer={layer} />
-      </LeafletLayersControl.BaseLayer>
-    ))}
-  </LeafletLayersControl>
-);
+}) => {
+  const [opacity, setOpacity] = useState(selectedOpacity);
+  const [currentLayer, setCurrentLayer] = useState(initialLayerChecked);
+  const map = useMap();
+
+  useEffect(() => {
+    window.localStorage.setItem('layerOpacity', opacity);
+  }, [opacity]);
+
+  useEffect(() => {
+    const handleLayerChange = (e) => {
+      setCurrentLayer(e.name);
+      window.localStorage.setItem('selectedBaseLayer', e.name);
+    };
+
+    map.on('baselayerchange', handleLayerChange);
+
+    return () => {
+      map.off('baselayerchange', handleLayerChange);
+    };
+  }, [map]);
+
+  return (
+    <>
+      <LeafletLayersControl position={position}>
+        {layers.map(layer => (
+          <LeafletLayersControl.BaseLayer
+            key={layer.name}
+            checked={layer.name === initialLayerChecked}
+            name={layer.name}>
+            <BaseMapLayer layer={layer} opacity={opacity} />
+          </LeafletLayersControl.BaseLayer>
+        ))}
+      </LeafletLayersControl>
+      {currentLayer !== OSM_LAYER.name && (
+        <OpacityControl key={currentLayer} position={position} opacity={opacity} setOpacity={setOpacity} />
+      )}
+    </>
+  );
+};
 
 LayersControl.propTypes = {
   position: PropTypes.oneOf([

--- a/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
@@ -1,20 +1,68 @@
 import React from 'react';
 import { head, pluck } from 'ramda';
 import {
+  LayerGroup,
   LayersControl as LeafletLayersControl,
   TileLayer,
-  WMSTileLayer,
-  LayerGroup
+  WMSTileLayer
 } from 'react-leaflet';
 import PropTypes from 'prop-types';
 
 import layers from './mapLayers';
+import * as L from 'leaflet';
 
 const possibleLayers = pluck('name', layers);
 const localStorageBaseLayer = possibleLayers.find(
   name => name === window.localStorage.getItem('selectedBaseLayer')
 );
 const selectedBaseLayer = localStorageBaseLayer || head(possibleLayers);
+
+const createWMTSTileLayer = layer => (
+  <TileLayer
+    attribution={layer.attribution}
+    url={layer.url}
+    minZoom={layer.minZoom}
+    maxZoom={layer.maxZoom ?? 22}
+    maxNativeZoom={layer.maxNativeZoom ?? 22}
+    bounds={layer.bounds ?? new L.LatLngBounds(new L.LatLng(-90, -180), new L.LatLng(90, 180))}
+  />
+);
+
+const createWMSTileLayer = layer => (
+  <WMSTileLayer
+    attribution={layer.attribution}
+    layers={layer.layers}
+    url={layer.url}
+  />
+);
+
+const OSM_LAYER = layers[0];
+const OSM_TILE_LAYER = createWMTSTileLayer(OSM_LAYER);
+
+const BaseMapLayer = ({ layer }) => (
+  <LayerGroup>
+    {OSM_TILE_LAYER}
+    {layer !== OSM_LAYER && (
+      <>
+        {layer.type === 'WMTS' && createWMTSTileLayer(layer)}
+        {layer.type === 'WMS' && createWMSTileLayer(layer)}
+      </>
+    )}
+  </LayerGroup>
+);
+
+BaseMapLayer.propTypes = {
+  layer: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    attribution: PropTypes.string,
+    url: PropTypes.string,
+    minZoom: PropTypes.number,
+    maxZoom: PropTypes.number,
+    maxNativeZoom: PropTypes.number,
+    bounds: PropTypes.object,
+    layers: PropTypes.string
+  }).isRequired
+};
 
 const LayersControl = ({
   position = 'topleft',
@@ -26,41 +74,7 @@ const LayersControl = ({
         key={layer.name}
         checked={layer.name === initialLayerChecked}
         name={layer.name}>
-        {layer.type === 'WMTS' && (
-          layer.minZoom ? (
-            <LayerGroup>
-              <TileLayer
-                attribution='© OpenStreetMap contributors'
-                url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
-                maxZoom={22}
-                maxNativeZoom={18}
-              />
-              <TileLayer
-                attribution={layer.attribution}
-                url={layer.url}
-                minZoom={layer.minZoom}
-                maxZoom={layer.maxZoom ? layer.maxZoom : 22}
-                maxNativeZoom={layer.maxNativeZoom ? layer.maxNativeZoom : 22}
-              />
-            </LayerGroup>
-          ) : (
-            <TileLayer
-              attribution={layer.attribution}
-              url={layer.url}
-              minZoom={layer.minZoom}
-              maxZoom={layer.maxZoom ? layer.maxZoom : 22}
-              maxNativeZoom={layer.maxNativeZoom ? layer.maxNativeZoom : 22}
-              bounds={layer.bounds}
-            />
-          )
-        )}
-        {layer.type === 'WMS' && (
-          <WMSTileLayer
-            attribution={layer.attribution}
-            layers={layer.layers}
-            url={layer.url}
-          />
-        )}
+        <BaseMapLayer layer={layer} />
       </LeafletLayersControl.BaseLayer>
     ))}
   </LeafletLayersControl>

--- a/packages/web-app/src/components/common/Maps/common/mapLayers.js
+++ b/packages/web-app/src/components/common/Maps/common/mapLayers.js
@@ -6,8 +6,7 @@ This files is used to config all the map layers offered.
 Concerning the bounds of a layer,
 they represent the area on the map for which the layer is available.
 
-If the layer is available for the entire map, we should set its bounds to
-" new L.LatLngBounds(new L.LatLng(-90, -200), new L.LatLng(90, 200)) "
+If the layer is available for the entire map, we should omit the bounds property.
  */
 
 const layers = [
@@ -18,8 +17,7 @@ const layers = [
       '« © <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap </a> contributors » under ODbL licence',
     url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     maxZoom: 22,
-    maxNativeZoom: 18,
-    bounds: new L.LatLngBounds(new L.LatLng(-90, -200), new L.LatLng(90, 200))
+    maxNativeZoom: 18
   },
   {
     name: 'Esri Satellite',
@@ -28,8 +26,7 @@ const layers = [
       'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
     url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     maxZoom: 22,
-    maxNativeZoom: 19,
-    bounds: new L.LatLngBounds(new L.LatLng(50, -10), new L.LatLng(60, 2))
+    maxNativeZoom: 19
   },
   {
     name: 'OpenTopoMap',
@@ -38,8 +35,7 @@ const layers = [
       'Map data: &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a target="_blank" href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a target="_blank" href="https://opentopomap.org">OpenTopoMap</a> (<a target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
     url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
     maxZoom: 22,
-    maxNativeZoom: 17,
-    bounds: new L.LatLngBounds(new L.LatLng(50, -10), new L.LatLng(60, 2))
+    maxNativeZoom: 17
   },
   {
     name: 'France - IGN SCAN 25®',


### PR DESCRIPTION
# Fix map layers control and add opacity slider

## 🤔 What

- Added opacity control slider for map layers
- Enhanced CustomControl component with Leaflet control integration
- Refactored LayersControl to support layer opacity adjustment
- Fixed map layer bounds configuration
- Added event propagation prevention for custom controls

## 🤷♂️ Why

Users need the ability to adjust the opacity of overlay map layers to better visualize cave locations against different base maps. The previous implementation lacked this functionality and had issues with map layer bounds that needed correction.

## 🔍 How

**CustomControl.jsx:**
- Added `useLeafletControl` prop to support native Leaflet control positioning
- Implemented event propagation prevention (click and scroll) using Leaflet's DomEvent API
- Added React Portal support for rendering into Leaflet-managed DOM elements
- Used hooks (useEffect, useRef, useState) to manage control lifecycle

**LayersControl.jsx:**
- Created BaseMapLayer component that overlays selected layer on top of OSM base layer
- Implemented OpacityControl component with expandable UI (hover to expand)
- Added localStorage persistence for opacity and layer selection
- Refactored layer rendering logic to support opacity parameter
- Added map event listeners for baselayerchange to track current layer

**mapLayers.js:**
- Removed unnecessary bounds configuration for global layers
- Cleaned up layer definitions

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Open any map view in the application
2. Switch between different base layers using the layers control
3. Verify that an opacity slider appears for non-OSM layers
4. Hover over the opacity control to expand it
5. Adjust the opacity slider and verify the overlay layer transparency changes
6. Refresh the page and verify opacity and layer selection are persisted
7. Test that map interactions (click, scroll) work correctly on custom controls

## 📸 Previews

![opacity](https://github.com/user-attachments/assets/d5680d56-0a46-4c48-91e0-ffdd652f5434)
