### PR TITLE
chore(layers): adds a few layers. Reorganizes the layers control with purpose separation

### DIFF
--- a/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { head, pluck } from 'ramda';
 import {
   LayerGroup,
@@ -13,6 +13,7 @@ import { styled } from '@mui/material/styles';
 import { useIntl } from 'react-intl';
 
 import layers from './mapLayers';
+import { LAYER_ROLE } from './layerEnums';
 import CustomControl from './CustomControl';
 
 const possibleLayers = pluck('name', layers);
@@ -20,11 +21,36 @@ const localStorageBaseLayer = possibleLayers.find(
   name => name === window.localStorage.getItem('selectedBaseLayer')
 );
 const selectedBaseLayer = localStorageBaseLayer || head(possibleLayers);
+const getStoredOverlays = () => {
+  try {
+    const stored = window.localStorage.getItem('selectedOverlays');
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+const selectedOverlays = getStoredOverlays();
 const localStorageOpacity = parseFloat(window.localStorage.getItem('layerOpacity'));
 const selectedOpacity = !isNaN(localStorageOpacity) ? localStorageOpacity : 1;
 
+const usePanes = (layers) => {
+  const map = useMap();
+
+  useEffect(() => {
+    const panes = [...new Set(layers.map(l => l.pane).filter(Boolean))];
+
+    panes.forEach((paneName, index) => {
+      if (!map.getPane(paneName)) {
+        const pane = map.createPane(paneName);
+        pane.style.zIndex = 200 + index * 10;
+      }
+    });
+  }, [map, layers]);
+};
+
 const createWMTSTileLayer = (layer, opacity = 1) => (
   <TileLayer
+    pane={layer.pane}
     attribution={layer.attribution}
     url={layer.url}
     minZoom={layer.minZoom}
@@ -35,45 +61,37 @@ const createWMTSTileLayer = (layer, opacity = 1) => (
   />
 );
 
-const createWMSTileLayer = (layer, opacity = 1) => (
-  <WMSTileLayer
-    attribution={layer.attribution}
-    layers={layer.layers}
-    url={layer.url}
-    opacity={opacity}
-  />
-);
+const createWMSTileLayer = (layer, opacity = 1) => {
+  const {
+    url,
+    layers: wmsLayers,
+    styles = '',
+    format = 'image/png',
+    transparent = true,
+    version = '1.3.0'
+  } = layer;
 
-const OSM_LAYER = layers[0];
-const OSM_TILE_LAYER = createWMTSTileLayer(OSM_LAYER);
-
-const BaseMapLayer = ({ layer, opacity }) => (
-  <LayerGroup>
-    {OSM_TILE_LAYER}
-    {layer !== OSM_LAYER && (
-      <>
-        {layer.type === 'WMTS' && createWMTSTileLayer(layer, opacity)}
-        {layer.type === 'WMS' && createWMSTileLayer(layer, opacity)}
-      </>
-    )}
-  </LayerGroup>
-);
-
-BaseMapLayer.propTypes = {
-  layer: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    attribution: PropTypes.string,
-    url: PropTypes.string,
-    minZoom: PropTypes.number,
-    maxZoom: PropTypes.number,
-    maxNativeZoom: PropTypes.number,
-    bounds: PropTypes.object,
-    layers: PropTypes.string
-  }).isRequired,
-  opacity: PropTypes.number
+  return (
+    <WMSTileLayer
+      pane={layer.pane}
+      url={url}
+      layers={wmsLayers}
+      styles={styles}
+      format={format}
+      transparent={transparent}
+      version={version}
+      opacity={opacity}
+    />
+  );
 };
 
-const ControlContainer = styled('div')(({ isExpanded }) => ({
+const renderLayer = (layer, opacity) => {
+  if (layer.type === 'WMTS') return createWMTSTileLayer(layer, opacity);
+  if (layer.type === 'WMS') return createWMSTileLayer(layer, opacity);
+  return null;
+};
+
+const OpacityControlContainer = styled('div')(({ isExpanded }) => ({
   background: 'white',
   padding: '5px',
   width: isExpanded ? '200px' : 'min-content',
@@ -82,7 +100,7 @@ const ControlContainer = styled('div')(({ isExpanded }) => ({
   maxHeight: isExpanded ? '100px' : '28px'
 }));
 
-const ControlLabel = styled('label')(({ isExpanded }) => ({
+const OpacityControlLabel = styled('label')(({ isExpanded }) => ({
   fontSize: '12px',
   display: 'block',
   marginBottom: isExpanded ? '5px' : '0',
@@ -106,13 +124,13 @@ const OpacityControl = ({ position, opacity, setOpacity }) => {
 
   return (
     <CustomControl position={position} useLeafletControl>
-      <ControlContainer 
+      <OpacityControlContainer
         isExpanded={isExpanded}
         onMouseEnter={() => setIsExpanded(true)}
         onMouseLeave={() => setIsExpanded(false)}>
-        <ControlLabel isExpanded={isExpanded}>
+        <OpacityControlLabel isExpanded={isExpanded}>
           {formatMessage({ id: 'Opacity' })}
-        </ControlLabel>
+        </OpacityControlLabel>
         <OpacitySlider
           type="range"
           min="0"
@@ -121,7 +139,7 @@ const OpacityControl = ({ position, opacity, setOpacity }) => {
           onChange={(e) => setOpacity(e.target.value / 100)}
           isExpanded={isExpanded}
         />
-      </ControlContainer>
+      </OpacityControlContainer>
     </CustomControl>
   );
 };
@@ -133,45 +151,105 @@ OpacityControl.propTypes = {
 };
 
 const LayersControl = ({
-  position = 'topleft',
-  initialLayerChecked = selectedBaseLayer
-}) => {
+                         position = 'topleft',
+                         initialSelectedBaseLayer = selectedBaseLayer,
+                         initialSelectedOverlays = selectedOverlays
+                       }) => {
   const [opacity, setOpacity] = useState(selectedOpacity);
-  const [currentLayer, setCurrentLayer] = useState(initialLayerChecked);
+  const [currentBaseLayer, setCurrentBaseLayer] = useState(initialSelectedBaseLayer);
+  const [currentOverlays, setCurrentOverlays] = useState(initialSelectedOverlays);
+  const [isMapReady, setIsMapReady] = useState(false);
   const map = useMap();
+
+  useEffect(() => {
+    if (map && map.getContainer()) {
+      setIsMapReady(true);
+    }
+  }, [map]);
+
+  usePanes(layers);
 
   useEffect(() => {
     window.localStorage.setItem('layerOpacity', opacity);
   }, [opacity]);
 
+  const baseLayers = useMemo(
+    () => layers.filter(l => l.role === LAYER_ROLE.BASE),
+    []
+  );
+
+  const overlayLayers = useMemo(
+    () => layers.filter(l => l.role === LAYER_ROLE.OVERLAY),
+    []
+  );
+
   useEffect(() => {
-    const handleLayerChange = (e) => {
-      setCurrentLayer(e.name);
+    const onChange = (e) => {
+      setCurrentBaseLayer(e.name);
       window.localStorage.setItem('selectedBaseLayer', e.name);
     };
-
-    map.on('baselayerchange', handleLayerChange);
+    map.on('baselayerchange', onChange);
 
     return () => {
-      map.off('baselayerchange', handleLayerChange);
+      map.off('baselayerchange', onChange);
     };
   }, [map]);
+
+  useEffect(() => {
+    const onAdd = (e) => {
+      setCurrentOverlays(prev => {
+        const updated = Array.isArray(prev) ? [...prev, e.name] : [e.name];
+        window.localStorage.setItem('selectedOverlays', JSON.stringify(updated));
+        return updated;
+      });
+    };
+    const onRemove = (e) => {
+      setCurrentOverlays(prev => {
+        const updated = Array.isArray(prev) ? prev.filter(name => name !== e.name) : [];
+        if (updated.length > 0) {
+          window.localStorage.setItem('selectedOverlays', JSON.stringify(updated));
+        } else {
+          window.localStorage.removeItem('selectedOverlays');
+        }
+        return updated.length > 0 ? updated : null;
+      });
+    };
+    map.on('overlayadd', onAdd);
+    map.on('overlayremove', onRemove);
+
+    return () => {
+      map.off('overlayadd', onAdd);
+      map.off('overlayremove', onRemove);
+    };
+  }, [map]);
+
+  if (!isMapReady) return null;
 
   return (
     <>
       <LeafletLayersControl position={position}>
-        {layers.map(layer => (
+        {baseLayers.map(layer => (
           <LeafletLayersControl.BaseLayer
-            key={layer.name}
-            checked={layer.name === initialLayerChecked}
-            name={layer.name}>
-            <BaseMapLayer layer={layer} opacity={opacity} />
+            key={layer.id}
+            checked={layer.name === initialSelectedBaseLayer}
+            name={layer.name}
+          >
+            {renderLayer(layer, 1)}
           </LeafletLayersControl.BaseLayer>
         ))}
+        {overlayLayers.map(layer => (
+          <LeafletLayersControl.Overlay
+            key={layer.id}
+            name={layer.name}
+            checked={Array.isArray(initialSelectedOverlays) && initialSelectedOverlays.includes(layer.name)}
+          >
+            <LayerGroup>
+              {renderLayer(layer, opacity)}
+            </LayerGroup>
+          </LeafletLayersControl.Overlay>
+        ))}
       </LeafletLayersControl>
-      {currentLayer !== OSM_LAYER.name && (
-        <OpacityControl key={currentLayer} position={position} opacity={opacity} setOpacity={setOpacity} />
-      )}
+      {currentOverlays?.length > 0 && <OpacityControl key={currentBaseLayer} position={position} opacity={opacity} setOpacity={setOpacity} />}
     </>
   );
 };
@@ -183,7 +261,8 @@ LayersControl.propTypes = {
     'bottomright',
     'bottomleft'
   ]),
-  initialLayerChecked: PropTypes.oneOf(possibleLayers)
+  initialSelectedBaseLayer: PropTypes.oneOf(possibleLayers),
+  initialSelectedOverlays: PropTypes.arrayOf(PropTypes.oneOf(possibleLayers))
 };
 
 export default LayersControl;

--- a/packages/web-app/src/components/common/Maps/common/layerEnums.jsx
+++ b/packages/web-app/src/components/common/Maps/common/layerEnums.jsx
@@ -1,0 +1,19 @@
+export const LAYER_ROLE = Object.freeze({
+  BASE: 'base',
+  OVERLAY: 'overlay'
+});
+
+export const LAYER_TYPE = Object.freeze({
+  WMTS: 'WMTS',
+  WMS: 'WMS',
+  VECTOR: 'VECTOR' // future-proof (VectorTileLayer)
+});
+
+export const PANES = Object.freeze({
+  BASEMAP: 'basemap',
+  BASEMAP_RASTER: 'basemap-raster',
+  HILLSHADE: 'hillshade',
+  GEOLOGY: 'geology',
+  VECTOR: 'vector',
+  LABELS: 'labels'
+});

--- a/packages/web-app/src/components/common/Maps/common/mapLayers.js
+++ b/packages/web-app/src/components/common/Maps/common/mapLayers.js
@@ -1,4 +1,5 @@
 import * as L from 'leaflet';
+import { PANES, LAYER_ROLE, LAYER_TYPE } from './layerEnums';
 
 /*
 This files is used to config all the map layers offered.
@@ -11,17 +12,25 @@ If the layer is available for the entire map, we should omit the bounds property
 
 const layers = [
   {
+    id: 'osm',
     name: 'OpenStreetMap Basic',
-    type: 'WMTS',
+    role: LAYER_ROLE.BASE,
+    type: LAYER_TYPE.WMTS,
+    pane: PANES.BASEMAP,
     attribution:
       '« © <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap </a> contributors » under ODbL licence',
     url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    maxZoom: 22,
-    maxNativeZoom: 18
+    maxZoom: 19,
+    maxNativeZoom: 19,
+    base: true
   },
   {
+    id: 'esri_sat',
     name: 'Esri Satellite',
-    type: 'WMTS',
+    role: LAYER_ROLE.BASE,
+    type: LAYER_TYPE.WMTS,
+    pane: PANES.BASEMAP_RASTER,
+    exclusiveGroup: 'basemap-enhancement',
     attribution:
       'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
     url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
@@ -29,50 +38,100 @@ const layers = [
     maxNativeZoom: 19
   },
   {
+    id: 'opentopo',
     name: 'OpenTopoMap',
-    type: 'WMTS',
+    role: LAYER_ROLE.BASE,
+    type: LAYER_TYPE.WMTS,
+    pane: PANES.BASEMAP_RASTER,
+    exclusiveGroup: 'basemap-enhancement',
     attribution:
       'Map data: &copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a target="_blank" href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a target="_blank" href="https://opentopomap.org">OpenTopoMap</a> (<a target="_blank" href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
     url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
-    maxZoom: 22,
+    maxZoom: 17,
     maxNativeZoom: 17
   },
   {
+    id: 'ign_scan25',
     name: 'France - IGN SCAN 25®',
-    type: 'WMTS',
-    attribution: 'IGN-F/Geoportail',
+    role: LAYER_ROLE.BASE,
+    type: LAYER_TYPE.WMTS,
+    pane: PANES.BASEMAP_RASTER,
+    exclusiveGroup: 'basemap-enhancement',
+    attribution: '<a target="_blank" href="https://www.ign.fr/">IGN-F/Geoportail</a>',
     url: 'https://data.geopf.fr/private/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM_6_16&FORMAT=image/jpeg&LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&apikey=ign_scan_ws',
     minZoom: 6,
-    maxZoom: 22,
     maxNativeZoom: 16,
-    bounds: new L.LatLngBounds(
-      new L.LatLng(-46.5029, -178.206),
-      new L.LatLng(51.1751, 77.6492)
-    )
+    maxZoom: 18,
+    bounds: new L.LatLngBounds(new L.LatLng(-46.5029, -178.206), new L.LatLng(51.1751, 77.6492))
   },
   {
+    id: 'fr_lidar_hillshade',
+    name: 'France - MNT LiDAR HD',
+    role: LAYER_ROLE.OVERLAY,
+    type: LAYER_TYPE.WMS,
+    pane: PANES.HILLSHADE,
+    defaultOn: false,
+    attribution: '<a target="_blank" href="https://www.ign.fr/">IGN-F/Geoportail</a>',
+    url: 'https://data.geopf.fr/wms-r/wms',
+    layers: 'IGNF_LIDAR-HD_MNT_ELEVATION.ELEVATIONGRIDCOVERAGE.SHADOW',
+    style: 'normal'
+  },
+  {
+    id: 'usgs_topo',
+    name: 'USA - USGS Topo',
+    role: LAYER_ROLE.BASE,
+    type: LAYER_TYPE.WMTS,
+    pane: PANES.BASEMAP_RASTER,
+    exclusiveGroup: 'basemap-enhancement',
+    attribution: '<a target="_blank" href="https://www.usgs.gov/programs/national-geospatial-program/topographic-maps">USGS The National Map</a>',
+    url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
+    maxZoom: 22,
+    maxNativeZoom: 16
+  },
+  {
+    id: 'us_hillshade',
+    name: 'USA - USGS Hillshade',
+    role: LAYER_ROLE.OVERLAY,
+    type: LAYER_TYPE.WMS,
+    pane: PANES.HILLSHADE,
+    attribution: '<a target="_blank" href="https://www.usgs.gov/3d-elevation-program">USGS The National Map</a>',
+    url: 'https://elevation.nationalmap.gov/arcgis/services/3DEPElevation/ImageServer/WMSServer',
+    layers: '3DEPElevation:Hillshade Multidirectional',
+    bounds: new L.LatLngBounds(new L.LatLng(-15.001663, -180), new L.LatLng(84.001679, 180))
+  },
+  {
+    id: 'world_geology',
     name: 'World - Bedrock and Structural geology',
-    type: 'WMS',
+    role: LAYER_ROLE.OVERLAY,
+    type: LAYER_TYPE.WMS,
+    pane: PANES.GEOLOGY,
     attribution:
       'BRGM - <a target="_blank" href="http://mapsref.brgm.fr/wxs/1GG/CGMW_Bedrock_and_Structural_Geology?version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=World_CGMW_50M_GeologicalUnitsOnshore&format=image/png&STYLE=default">Legend ⧉</a>',
-    url: 'http://mapsref.brgm.fr/wxs/1GG/CGMW_Bedrock_and_Structural_Geology?',
+    url: 'https://mapsref.brgm.fr/wxs/1GG/CGMW_Bedrock_and_Structural_Geology',
     layers: 'World_CGMW_50M_GeologicalUnitsOnshore',
-    bounds: new L.LatLngBounds(
-      new L.LatLng(-5.119629, 42.163403),
-      new L.LatLng(8.789063, 51.179343)
-    )
   },
   {
+    id: 'eu_bedrock_geology',
     name: 'Europe - Bedrock and Structural geology',
-    type: 'WMS',
+    role: LAYER_ROLE.OVERLAY,
+    type: LAYER_TYPE.WMS,
+    pane: PANES.GEOLOGY,
     attribution:
       'BRGM - <a target="_blank" href="http://mapsref.brgm.fr/wxs/1GG/GISEurope_Bedrock_and_Structural_Geology?version=1.3.0&service=WMS&request=GetLegendGraphic&sld_version=1.1.0&layer=Europe_GISEurope_1500K_BedrockAge&format=image/png&STYLE=default">Legend ⧉</a>',
-    url: 'http://mapsref.brgm.fr/wxs/1GG/GISEurope_Bedrock_and_Structural_Geology?',
+    url: 'https://mapsref.brgm.fr/wxs/1GG/GISEurope_Bedrock_and_Structural_Geology',
     layers: 'Europe_GISEurope_1500K_BedrockAge',
-    bounds: new L.LatLngBounds(
-      new L.LatLng(-5.119629, 42.163403),
-      new L.LatLng(8.789063, 51.179343)
-    )
+    bounds: new L.LatLngBounds(new L.LatLng(34.5621, -10.6181), new L.LatLng(62.4007, 34.5858))
+  },
+  {
+    id: 'karst_aquifer',
+    name: 'World - Karst Aquifer Map',
+    role: LAYER_ROLE.OVERLAY,
+    type: LAYER_TYPE.WMS,
+    pane: PANES.GEOLOGY,
+    attribution:
+      '<a target="_blank" href="https://www.whymap.org/whymap/EN/Maps_Data/Wokam/wokam_node_en.html">© BGR / WHYMAP WOKAM</a>',
+    url: 'https://services.bgr.de/wms/grundwasser/whymap_wokam/',
+    layers: '0,1,2,4,5,6',
   }
 ];
 


### PR DESCRIPTION
# Add map layers with overlay support and improved layer management

## 🤔 What

This PR enhances the map layers system by adding:

- Support for overlay layers (hillshade, geology) in addition to base layers
- New layer role system (BASE vs OVERLAY) to distinguish layer types
- Custom pane management for proper z-index control of different layer types
- Persistence of selected overlays in localStorage
- New map layers:
  - France - MNT LiDAR HD (hillshade overlay)
  - USA - USGS Topo (base layer)
  - USA - USGS Hillshade (overlay)
  - World - Karst Aquifer Map (overlay)
- Improved WMS layer configuration with proper parameters (styles, format, transparent, version)
- Layer enums file for better code organization and type safety

## 🤷♂️ Why

The previous implementation only supported base layers, limiting the ability to show additional contextual information like hillshade or geological data on top of the base map. Users needed the ability to:

- Toggle overlay layers independently from base layers
- View multiple data layers simultaneously (e.g., topographic base + hillshade + geology)
- Have proper z-index management to ensure layers render in the correct order
- Persist their overlay selections across sessions

## 🔍 How

**Architecture changes:**

- Created `layerEnums.jsx` with three enums:
  - `LAYER_ROLE`: Distinguishes BASE from OVERLAY layers
  - `LAYER_TYPE`: Defines layer types (WMTS, WMS, VECTOR)
  - `PANES`: Named panes for z-index management

- Refactored `LayersControl.jsx`:
  - Added `usePanes` hook to dynamically create Leaflet panes with proper z-index
  - Split layer rendering into base layers and overlay layers using `useMemo`
  - Added overlay state management with localStorage persistence
  - Improved WMS layer creation with full parameter support
  - Renamed component props for clarity (`initialLayerChecked` → `initialSelectedBaseLayer`)
  - Added `initialSelectedOverlays` prop for overlay initialization
  - Opacity control now only shows when overlays are active

- Enhanced `mapLayers.js`:
  - Added unique `id` field to each layer
  - Added `role` field (BASE or OVERLAY)
  - Added `pane` field for z-index control
  - Improved layer metadata (better attributions, corrected zoom levels, proper bounds)
  - Migrated HTTP URLs to HTTPS for security

**Technical details:**

- Panes are created with z-index starting at 200, incrementing by 10 for each pane
- Overlay selections are stored as JSON array in localStorage
- Base layer opacity is always 1, overlay opacity is user-controlled
- Map readiness check prevents rendering issues during initialization

## 🔗 Related API PR

N/A - Frontend-only changes

## 🧪 Testing

1. Open the map view
2. Click on the layers control (top-left corner)
3. Verify you can switch between base layers (OpenStreetMap, Esri Satellite, etc.)
4. Verify you can toggle overlay layers (hillshade, geology) independently
5. Test the opacity slider appears only when overlays are active
6. Adjust overlay opacity and verify it applies correctly
7. Refresh the page and verify:
   - Selected base layer is remembered
   - Selected overlays are remembered
   - Opacity setting is remembered
8. Test with different base layer + overlay combinations
9. Verify layers render in correct order (base → hillshade → geology)

## 📸 Previews

![overlays](https://github.com/user-attachments/assets/702755c8-55d4-4aef-9d0f-1774c2618566)
