### PR TITLE
fix(map): fixes entrance edition map that cannot pan on mobile devices

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -48,9 +48,11 @@ const MapBind = ({ center, zoom, onMoveEnd }) => {
   });
 
   useMapEvent('zoomend', () => {
-    // To avoid drift when zooming, we reset the map to the last known valid center
-    lastSetViewTs.current = Date.now();
-    map.setView(lastValidCenter.current, map.getZoom(), { animate: false });
+    if (!isMobile) {
+      // To avoid drift when zooming on desktop, we reset the map to the last known valid center
+      lastSetViewTs.current = Date.now();
+      map.setView(lastValidCenter.current, map.getZoom(), { animate: false });
+    }
   });
 
   useEffect(() => {
@@ -138,7 +140,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
       dragging={!isMobile} // For usability only use two fingers drag/zoom on mobile
       scrollWheelZoom="center" // To avoid losing the coordinate when only zooming
       doubleClickZoom="center"
-      touchZoom="center"
+      touchZoom={true}
       preferCanvas>
       <GeocodingControl onLocationSelect={newLocation => {
         setFormLatitude(newLocation.lat.toFixed(6));


### PR DESCRIPTION
# Fix mobile map panning in entrance editor

## 🤔 What

- Fixed map panning issue on mobile devices in the entrance editor form
- Changed `touchZoom` prop from `"center"` to `true` in MapMarkerSelector
- Conditionally disabled `zoomend` handler on mobile to prevent map reset after panning

## 🤷♂️ Why

On mobile devices, users could only zoom the map in the entrance editor but couldn't pan it. The map would snap back to the original position after attempting to pan with two fingers, making it difficult to select precise coordinates on mobile.

## 🔍 How

The issue was caused by two problems:

1. The `touchZoom="center"` prop was interfering with Leaflet's default two-finger gesture handling. Changed it to `touchZoom={true}` to enable proper touch gestures.

2. The `zoomend` event handler was resetting the map center after every zoom event to prevent coordinate drift on desktop. However, this also triggered during two-finger pan gestures on mobile, causing the map to snap back. Added a conditional check `if (!isMobile)` inside the `zoomend` handler to preserve the desktop behavior while allowing mobile panning.

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Open the entrance editor on a mobile device or using browser dev tools mobile emulation
2. Try to pan the map using two fingers
3. Verify the map stays at the new position after releasing
4. Verify pinch-to-zoom still works correctly
5. On desktop, verify that zooming doesn't cause coordinate drift
