### PR TITLE
feat(documents): add parent document file links with page ranges

### DIFF
--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1254,6 +1254,7 @@
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Page where the document ends if it's part of another document (ex: an article in a magazine).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).",
   "Pages": "Pages",
+  "Pages {start}-{end} of {title}": "Pages {start}-{end} of {title}",
   "Pakistan": "Pakistan",
   "Palau": "Palau",
   "Paleontospeleology": "Paleontospeleology",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1253,6 +1253,7 @@
   "Page of all types of revision history for this entrance": "Page of all types of revision history for this entrance",
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Page where the document ends if it's part of another document (ex: an article in a magazine).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).",
+  "Page {start} of {title}": "Page {start} of {title}",
   "Pages": "Pages",
   "Pages {start}-{end} of {title}": "Pages {start}-{end} of {title}",
   "Pakistan": "Pakistan",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1254,6 +1254,7 @@
   "Page of all types of revision history for this entrance": "Página de todos los tipos de historial de revisiones para esta entrada",
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Página donde termina el documento si es parte de otro documento (por ej., un artículo en una revista).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Página donde empieza el documento si es parte de otro documento (ej: un artículo de una revista). Déjelo en blanco si sólo quiere mencionar el número total de páginas (ej.: un libro).",
+  "Page {start} of {title}": "Página {start} de {title}",
   "Pages": "Páginas",
   "Pages {start}-{end} of {title}": "Páginas {start}-{end} de {title}",
   "Pakistan": "Pakistán",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1255,6 +1255,7 @@
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Página donde termina el documento si es parte de otro documento (por ej., un artículo en una revista).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Página donde empieza el documento si es parte de otro documento (ej: un artículo de una revista). Déjelo en blanco si sólo quiere mencionar el número total de páginas (ej.: un libro).",
   "Pages": "Páginas",
+  "Pages {start}-{end} of {title}": "Páginas {start}-{end} de {title}",
   "Pakistan": "Pakistán",
   "Palau": "Palaos",
   "Paleontospeleology": "Paleontoespeleología",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1254,6 +1254,7 @@
   "Page of all types of revision history for this entrance": "Page avec l'historique de tous les types de révisions réalisées sur cette entrée",
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Page où se termine le document s'il fait partie d'un autre document (ex : un article dans un magazine).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Page où le document commence s'il fait partie d'un autre document (ex : un article dans un magazine). Laissez cette page vide si vous souhaitez simplement mentionner le nombre total de pages (ex : un livre).",
+  "Page {start} of {title}": "Page {start} de {title}",
   "Pages": "Pages",
   "Pages {start}-{end} of {title}": "Pages {start}-{end} de {title}",
   "Pakistan": "Pakistan",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1255,6 +1255,7 @@
   "Page where the document ends if it's part of another document (ex: an article in a magazine).": "Page où se termine le document s'il fait partie d'un autre document (ex : un article dans un magazine).",
   "Page where the document starts if it's part of another document (ex: an article in a magazine). Leave it blank if you just want to mention the total number of pages (ex: a book).": "Page où le document commence s'il fait partie d'un autre document (ex : un article dans un magazine). Laissez cette page vide si vous souhaitez simplement mentionner le nombre total de pages (ex : un livre).",
   "Pages": "Pages",
+  "Pages {start}-{end} of {title}": "Pages {start}-{end} de {title}",
   "Pakistan": "Pakistan",
   "Palau": "Palaos",
   "Paleontospeleology": "Paléontospéléologie",

--- a/packages/web-app/src/pages/DocumentDetails/Section.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/Section.jsx
@@ -91,6 +91,18 @@ ListElement.propTypes = {
   url: PropTypes.string
 };
 
+export const FileListElement = ({ fileName, filePath }) => (
+  <ListElement
+    icon={<Description color="primary" />}
+    value={fileName}
+    url={filePath}
+  />
+);
+FileListElement.propTypes = {
+  fileName: PropTypes.string.isRequired,
+  filePath: PropTypes.string.isRequired
+};
+
 export const TextLink = ({ value, url }) =>
   url ? (
     <GCLink href={url} internal={url.startsWith('/ui')}>
@@ -208,12 +220,7 @@ export const SectionFilesPreview = ({ title, files }) => {
       <SectionTitle>{title}</SectionTitle>
       {files.map(e => (
         <Fragment key={e.completePath}>
-          <ListElement
-            key={e.completePath}
-            icon={<Description color="primary" />}
-            value={e.fileName}
-            url={e.completePath}
-          />
+          <FileListElement fileName={e.fileName} filePath={e.completePath} />
           {PREVIEW_EXTENTIONS.includes(getExtention(e.completePath)) && (
             <SectionFilesPreviewIfFrame src={e.completePath} />
           )}

--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Chip, Skeleton } from '@mui/material';
-import { Description, Terrain } from '@mui/icons-material';
+import { Terrain } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -102,19 +102,29 @@ const Document = ({
 
     if (documentData?.parent?.files?.length > 0) {
       const file = documentData.parent.files[0];
-      for (const page of documentData?.pages?.match(/(\d+)-(\d+)/g) ?? []) {
-        const [start, end] = page.split('-');
-        const path = `${file.completePath}#page=${start}`;
-        allFiles.push(
-          <FileListElement
-            key={path}
-            fileName={formatMessage(
-              { id: 'Pages {start}-{end} of {title}' },
-              { start, end, title: documentData.parent.title }
-            )}
-            filePath={path}
-          />
-        );
+      const pageRegex = /^(\d+)(?:-(\d+))?$/;
+      const segments = String(documentData?.pages)
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+
+      for (const segment of segments) {
+        const match = segment.match(pageRegex);
+        if (match) {
+          const start = parseInt(match[1], 10);
+          const end = match[2] ? parseInt(match[2], 10) : null;
+          const path = `${file.completePath}#page=${start}`;
+          allFiles.push(
+            <FileListElement
+              key={path}
+              fileName={formatMessage(
+                { id: end ? 'Pages {start}-{end} of {title}' : 'Page {start} of {title}' },
+                { start, end, title: documentData.parent.title }
+              )}
+              filePath={path}
+            />
+          );
+        }
       }
     }
     for (const author of documentData?.authors ?? []) {

--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -1,24 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Chip, Skeleton } from '@mui/material';
-import { Terrain } from '@mui/icons-material';
+import { Description, Terrain } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import Linkify from 'linkify-react';
 
 import { loadLanguages } from '../../actions/Language';
 
 import {
-  SectionDivider,
-  SectionText,
-  SectionDetails,
-  SectionList,
-  SectionTitleLink,
-  SectionFilesPreview,
-  ItemString,
+  FileListElement,
   ItemList,
+  ItemString,
   ListElement,
+  SectionDetails,
+  SectionDivider,
+  SectionFilesPreview,
+  SectionList,
+  SectionText,
+  SectionTitleLink,
   TextLink
 } from './Section';
 import CustomIcon from '../../components/common/CustomIcon';
@@ -30,10 +31,10 @@ import { usePermissions } from '../../hooks';
 import FixedContent from '../../components/common/Layouts/Fixed/FixedContent';
 import Alert from '../../components/common/Alert';
 import {
-  Deleted,
-  DeletedCard,
   DeleteConfirmationDialog,
-  DELETED_ENTITIES
+  Deleted,
+  DELETED_ENTITIES,
+  DeletedCard
 } from '../../components/common/card/Deleted';
 import AuthorAndDate from '../../components/common/Contribution/AuthorAndDate';
 import {
@@ -89,6 +90,7 @@ const Document = ({
   };
 
   const allAuthors = [];
+  const allFiles = [];
   const childIssues = [];
   const childArticles = [];
   const childOther = [];
@@ -98,6 +100,23 @@ const Document = ({
     // eslint-disable-next-line no-param-reassign
     if (documentData?.mainLanguage === '000') documentData.mainLanguage = null;
 
+    if (documentData?.parent?.files?.length > 0) {
+      const file = documentData.parent.files[0];
+      for (const page of documentData?.pages?.match(/(\d+)-(\d+)/g) ?? []) {
+        const [start, end] = page.split('-');
+        const path = `${file.completePath}#page=${start}`;
+        allFiles.push(
+          <FileListElement
+            key={path}
+            fileName={formatMessage(
+              { id: 'Pages {start}-{end} of {title}' },
+              { start, end, title: documentData.parent.title }
+            )}
+            filePath={path}
+          />
+        );
+      }
+    }
     for (const author of documentData?.authors ?? []) {
       allAuthors.push(
         <TextLink
@@ -330,6 +349,11 @@ const Document = ({
               <SectionList title={formatMessage({ id: 'Linked entities' })}>
                 {linkedEntities}
               </SectionList>
+              {allFiles.length > 0 && (
+                <SectionList title={formatMessage({ id: 'Files' })}>
+                  {allFiles}
+                </SectionList>
+              )}
               <SectionList title={formatMessage({ id: 'Articles' })}>
                 {childArticles?.map(doc => (
                   <ListElement


### PR DESCRIPTION
# Add parent document linked to page

Closes issue #811

## 🤔 What

This PR adds functionality to display parent document files with page references in the document details page.

- Added a new `FileListElement` component to display file links
- Display parent document files with page ranges when a document is part of another document
- Added translation key `Pages {start}-{end} of {title}` in English, Spanish, and French
- Refactored file preview section to use the new `FileListElement` component

## 🤷♂️ Why

When a document (e.g., an article) is part of a parent document (e.g., a magazine), users need to be able to access the specific pages of the parent document where the child document appears. This improves navigation and makes it easier to view the actual content.

## 🔍 How

- Created a new `FileListElement` component in `Section.jsx` that accepts `fileName` and `filePath` props
- In the document details page, parse the `pages` field using regex to extract page ranges (e.g., "10-15")
- For each page range, create a file link pointing to the parent document's file with a `#page={start}` anchor
- Display these links in a new "Files" section on the document details page
- Refactored existing file preview code to use the new `FileListElement` component for consistency

## 🔗 Related API PR

_No related API changes required._

## 🧪 Testing

1. Navigate to a document that is part of a parent document (e.g., an article in a magazine)
2. Verify that the "Files" section appears with links to the parent document
3. Click on a file link and verify it opens the parent document at the correct page
4. Test with documents that have multiple page ranges
5. Verify translations work correctly in English, Spanish, and French

Here are usable samples:
| Format Description | Sample document IDs (prod DB) |
| -- | -- |
| Page Range (start-end,) - with comma (e.g., 11-12,) | 114837, 114760, 95835 |
| Page Range (start-end) - no comma (e.g., 22-37) | 224037, 230282, 146485 |
| Single Page (number,) - with comma (e.g., 12,) | 126848, 103301, 117785 |
| Single Page (number) - no comma (e.g., 19) | 230385, 231131, 142379 |
| Multiple Pages/Ranges (A, B, ...) | 87137 |
| Truly Malformed/Other | 112853 |
| Null/NaN | 144926 |

## 📸 Previews

<img width="1176" height="1004" alt="Screenshot 2025-12-11 at 6 05 31 p m" src="https://github.com/user-attachments/assets/de4c5f8f-5d37-46bf-afe7-31e2ea30902d" />
