### PR TITLE
fix(documents): fixes the document snapshot page. Adds translations

### DIFF
--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/DocumentSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/DocumentSnapshots.jsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
-  TableContainer,
+  styled,
   Table,
-  TableHead,
   TableBody,
-  TableRow,
   TableCell,
-  styled
+  TableContainer,
+  TableHead,
+  TableRow
 } from '@mui/material';
 import { useIntl } from 'react-intl';
 import { pathOr } from 'ramda';
@@ -68,13 +68,11 @@ const DocumentSnapshots = ({ document, previous }) => {
           <Property
             name={formatMessage({ id: 'Document type' })}
             value={formatMessage({
-              id: pathOr(
-                formatMessage({ id: INFORMATION_NOT_FOUND }),
-                ['name'],
-                type
-              )
+              id: type ?? INFORMATION_NOT_FOUND
             })}
-            oldValue={previous?.type.name}
+            oldValue={formatMessage({
+              id: previous?.type ?? INFORMATION_NOT_FOUND
+            })}
           />
           <Property
             name={formatMessage({ id: 'Title and description language' })}

--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -271,7 +271,7 @@ const Document = ({
               <SectionDetails title={formatMessage({ id: 'Details' })}>
                 <ItemString
                   label={formatMessage({ id: 'Type' })}
-                  value={<Chip color="primary" label={documentData.type} />}
+                  value={<Chip color="primary" label={formatMessage({ id: documentData.type })} />}
                 />
                 <ItemString
                   label={formatMessage({ id: 'Language' })}


### PR DESCRIPTION
# Fix document snapshot page fails to load

## 🤔 What

Fixed the document snapshot page that was failing to load due to incorrect data access patterns.

- Fixed document type display in DocumentSnapshots component
- Removed incorrect `pathOr` usage that was trying to access `type.name` when `type` is already a string
- Added proper translation for document type in DocumentDetails page

## 🤷♂️ Why

The document snapshot page was crashing because the code was attempting to access `type.name` and `previous?.type.name` when the `type` field is actually a string identifier, not an object. This caused the page to fail to load when viewing document snapshots.

## 🔍 How

- Changed `DocumentSnapshots.jsx` to use `type` directly as a string instead of trying to access `type.name`
- Updated both current and previous type values to use the string directly with fallback to `INFORMATION_NOT_FOUND`
- Added `formatMessage` wrapper in `DocumentDetails/index.jsx` to properly translate the document type chip label

## 🔗 Related API PR

N/A - This is a frontend-only fix

## 🧪 Testing

1. Navigate to a document details page
2. View the document snapshots/history
3. Verify that the page loads without errors
4. Verify that the document type is displayed correctly with proper translation
5. Check that previous document type values are shown correctly in the comparison view

Samples to test (document IDs):
- `93183`, `99469`, `32481`
- `138906`, `167190`, `132045`
- `196507`, `207367`, `223922`
- `4902`, `7911`, `235`
