### PR TITLE
fix(map): removes onFocus from DataControl to prevent mobile touch interference

### DIFF
--- a/packages/web-app/src/components/common/Maps/MapClusters/DataControl.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/DataControl.jsx
@@ -81,7 +81,6 @@ const DataControl = ({ updateHeatmap, updateMarkers, ...props }) => {
           aria-label={formatMessage({ id: 'data-control' })}
           onMouseOver={handleOpenMenu}
           onClick={handleOpenMenu}
-          onFocus={handleOpenMenu}
           // TODO enable on fullscreen as it's currently hidden
           disabled={fullScreen}
           size="large">


### PR DESCRIPTION
# Fix mobile menu closing issue in DataControl component

## 🤔 What

- Fixed the data control menu not closing on mobile devices when tapping outside
- Removed the `onFocus` event handler from the IconButton component
- Preserved desktop hover functionality with `onMouseOver` and click functionality

## 🤷♂️ Why

On mobile devices, when users tapped outside the data control menu to close it, the menu would remain open and become unresponsive. This created a poor user experience where users couldn't dismiss the menu without refreshing the page.

The root cause was the `onFocus` event handler interfering with mobile touch events, causing the menu to reopen immediately after closing.

## 🔍 How

The fix involved removing the `onFocus={handleOpenMenu}` event handler from the IconButton component in `DataControl.jsx`. This prevents focus events triggered by mobile touch interactions from interfering with the menu closing mechanism.

The solution is minimal and surgical:
- Removed only the problematic `onFocus` event handler
- Kept `onMouseOver` for desktop hover functionality  
- Kept `onClick` for click/tap functionality
- No changes to menu behavior or styling

## 🔗 Related API PR

N/A - This is a frontend-only fix.

## 🧪 Testing

**Desktop testing:**
1. Navigate to `/ui/map/`
2. Hover over the data control button (eye icon) - menu should open
3. Move mouse away from menu - menu should close
4. Click the button - menu should open/close

**Mobile testing:**
1. Navigate to `/ui/map/` on a mobile device
2. Tap the data control button (eye icon) - menu should open
3. Tap anywhere outside the menu - menu should close properly
4. Verify menu selections work correctly (radio buttons and checkboxes)

## 📸 Previews

The visual appearance remains unchanged. The fix addresses the functional behavior of the menu closing mechanism on mobile devices.