### PR TITLE
fix(auth): prevents a loop to be formed when a deleted user attempts to perform an action

### DIFF
--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -68,7 +68,7 @@ export const Entry = ({ isLoading, error, entrance }) => {
   const userId = useUserProperties()?.id ?? null;
   const [isExploredLoading, setIsExploredLoading] = useState(false);
   const [isExplored, setIsExplored] = useState(false);
-  const { person } = useSelector(state => state.person);
+  const { person, error: personError } = useSelector(state => state.person);
   const exploredEntrances = person?.exploredEntrances;
   const exploredNetworks = person?.exploredNetworks;
   const mapPositions = useMemo(() => (entrance ? [entrance] : []), [entrance]);
@@ -96,10 +96,10 @@ export const Entry = ({ isLoading, error, entrance }) => {
   };
 
   useEffect(() => {
-    if (userId && !person) {
+    if (userId && !person && !personError) {
       dispatch(fetchPerson(userId));
     }
-  }, [userId, person, dispatch]);
+  }, [userId, person, personError, dispatch]);
 
   useEffect(() => {
     if (entrance?.id && entrance?.cave?.id) {

--- a/packages/web-app/src/components/appli/Network/index.jsx
+++ b/packages/web-app/src/components/appli/Network/index.jsx
@@ -49,7 +49,7 @@ export const Network = ({ isLoading, error, cave }) => {
   const userId = useUserProperties()?.id ?? null;
   const [isExploredLoading, setIsExploredLoading] = useState(false);
   const [isExplored, setIsExplored] = useState(false);
-  const { person } = useSelector(state => state.person);
+  const { person, error: personError } = useSelector(state => state.person);
   const exploredNetworks = person?.exploredNetworks;
 
   useEffect(() => {
@@ -75,10 +75,10 @@ export const Network = ({ isLoading, error, cave }) => {
   };
 
   useEffect(() => {
-    if (userId && !person) {
+    if (userId && !person && !personError) {
       dispatch(fetchPerson(userId));
     }
-  }, [userId, person, dispatch]);
+  }, [userId, person, personError, dispatch]);
 
   useEffect(() => {
     if (cave?.id) {


### PR DESCRIPTION
# Fix infinite loop when fetching deleted user data

## 🤔 What

- Fixed infinite API request loop in Entry and Network components
- Added error state check before retrying fetchPerson requests
- Prevents repeated 404 requests when a user's token is valid but the user account has been deleted

## 🤷♂️ Why

When a user with a valid token has their account deleted by an admin, the frontend would enter an infinite loop trying to fetch the user's data. This happened because:

1. The useEffect hook checked `if (userId && !person)` to fetch user data
2. When the API returned 404, the reducer set `person: null`
3. Since `!person` was still true, it triggered another fetch
4. This created an infinite loop of 404 requests

This edge case was discovered during testing where a logged-in user's account was deleted while they still had a valid session token.

## 🔍 How

Modified the useEffect hooks in both Entry and Network components to check for the `personError` state:

**Before:**
```javascript
const { person } = useSelector(state => state.person);

useEffect(() => {
  if (userId && !person) {
    dispatch(fetchPerson(userId));
  }
}, [userId, person, dispatch]);
```

**After:**
```javascript
const { person, error: personError } = useSelector(state => state.person);

useEffect(() => {
  if (userId && !person && !personError) {
    dispatch(fetchPerson(userId));
  }
}, [userId, person, personError, dispatch]);
```

This ensures that once a fetch fails with an error, no further attempts are made until the error state is cleared or the userId changes.

## 🔗 Related API PR

None - this is a frontend-only fix.

## 🧪 Testing

To reproduce and verify the fix:

1. Log in as a regular user (e.g., `user@user.com`)
2. Copy the authentication token from browser storage
3. Log out and log in as an admin (e.g., `admin@admin.com`)
4. Delete the regular user account
5. Manually replace the token in browser storage with the copied token
6. Navigate to any entrance or network page
7. **Before fix:** Browser console shows infinite 404 requests to `/api/v1/cavers/:id`
8. **After fix:** Only one 404 request is made, no infinite loop

## 📸 Previews

No UI changes - this is a bug fix for backend request behavior.
