### PR TITLE
fix(map): remove geolocation blocking on map load and pan to user location when accepted

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -31,7 +31,7 @@ const PolygonMap = ({ onChange, data }) => {
   const { formatMessage } = useIntl();
   const isMounted = useRef(true);
   const displayValue = useRef(false);
-  const { location: geoLocation, isReady, hasError } = useGeolocation();
+  const { location: geoLocation, hasLocation } = useGeolocation();
   const [map, setMap] = useState();
 
   // Configure Leaflet Draw text
@@ -75,23 +75,20 @@ const PolygonMap = ({ onChange, data }) => {
   }, [formatMessage]);
 
   const [mapLayers, setMapLayers] = useState([]);
-  const [center, setCenter] = useState(
-    data
-      ? getMultiPolygonCentroid(data.coordinates[0][0])
-      : geoLocation
-  );
-  const ZOOM_LEVEL = !data && hasError ? defaultZoom : focusZoom;
+  const initialCenter = data
+    ? getMultiPolygonCentroid(data.coordinates[0][0])
+    : geoLocation;
+  const ZOOM_LEVEL = (data || hasLocation) ? focusZoom : defaultZoom;
 
   useEffect(() => {
     if (map) {
-      if (data && data.coordinates && data.coordinates[0] && data.coordinates[0][0]) {
+      if (data?.coordinates?.[0]?.[0]) {
         map.fitBounds(data.coordinates[0][0].map(e => [e[1], e[0]]));
-      } else if (isReady) {
+      } else if (hasLocation) {
         map.setView(geoLocation, ZOOM_LEVEL);
-        setCenter(geoLocation);
       }
     }
-  }, [isReady, geoLocation, data, map, ZOOM_LEVEL]);
+  }, [hasLocation, geoLocation, data, map, ZOOM_LEVEL]);
 
   const mapTOGeoJson = layers => {
     const geoJson = {};
@@ -198,7 +195,7 @@ const PolygonMap = ({ onChange, data }) => {
 
   return (
     <MapContainer
-      center={center}
+      center={initialCenter}
       zoom={ZOOM_LEVEL}
       ref={ref => {
         if (ref) setMap(ref);

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -79,7 +79,7 @@ const toFloat = value => {
 const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   const DEBOUNCE_TIME_MS = 300;
   const lastSetFormTs = useRef(0);
-  const { location: geoLocation, hasError: geoHasError } = useGeolocation();
+  const { location: geoLocation, hasLocation } = useGeolocation();
   const [currentPosition, setCurrentPosition] = useState(geoLocation);
   const [shouldUpdate, setShouldUpdate] = useState(false);
   const dispatch = useDispatch();
@@ -107,6 +107,12 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   const validLatitude = boundMinMax(-90, 90, toFloat(latitude));
   const validLongitude = boundMinMax(-180, 180, toFloat(longitude));
 
+  useEffect(() => {
+    if (hasLocation && !shouldUpdate) {
+      setCurrentPosition(geoLocation);
+    }
+  }, [hasLocation, geoLocation, shouldUpdate]);
+
   // Binding form -> map
   useEffect(() => {
     // Prevent dispatching a setCurrentPosition event triggered by a setForm below
@@ -118,10 +124,9 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
       setCurrentPosition({ lat: validLatitude, lng: validLongitude });
       setShouldUpdate(true);
     } else if (!isValid) {
-      setCurrentPosition(geoLocation);
       setShouldUpdate(false);
     }
-  }, [validLatitude, validLongitude, geoLocation]);
+  }, [validLatitude, validLongitude]);
 
   // Binding form <- map
   const onMoveEnd = newLocation => {
@@ -130,7 +135,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
     setFormLongitude(newLocation.lng.toFixed(6));
   };
 
-  const ZOOM_LEVEL = shouldUpdate ? focusZoom : (geoHasError ? defaultZoom : focusZoom);
+  const ZOOM_LEVEL = (shouldUpdate || hasLocation) ? focusZoom : defaultZoom;
 
   return (
     <StyledMapContainer

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -135,13 +135,14 @@ const HydratedMap = ({
   );
 };
 
-const Index = ({ center, zoom, isSideMenuOpen, ...props }) => (
+const Index = ({ center, zoom, isSideMenuOpen, mapRef, ...props }) => (
   <CustomMapContainer
     center={center}
     zoom={zoom}
     isFullscreenAllowed={false}
     isSideMenuOpen={isSideMenuOpen}
-    isLocateControl>
+    isLocateControl
+    mapRef={mapRef}>
     <HydratedMap {...props} zoom={zoom} />
   </CustomMapContainer>
 );
@@ -167,6 +168,7 @@ HydratedMap.propTypes = {
 Index.propTypes = {
   isSideMenuOpen: PropTypes.bool,
   center: PropTypes.arrayOf(PropTypes.number),
+  mapRef: PropTypes.shape({ current: PropTypes.any }),
   ...HydratedMap.propTypes
 };
 

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -84,7 +84,7 @@ const HydratedMap = ({
       heat: visibleHeat === 'none' ? null : visibleHeat,
       markers: visibleMarkers,
       zoom: map.getZoom(),
-      center: map.getBounds().getCenter(),
+      center: map.getCenter(),
       bounds: map.getBounds()
     });
   };

--- a/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
+++ b/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
@@ -25,11 +25,11 @@ ${$wholePage && `height: calc(100vh - ${theme.appBarHeight}px);`}
 
 // The Map, once mounted, doesn't change its center: this Centerer forces it
 // See https://github.com/PaulLeCam/react-leaflet/issues/796#issuecomment-743181396
-const Centerer = ({ center }) => {
+const Centerer = ({ center, zoom }) => {
   const map = useMap();
   useEffect(() => {
-    map.setView(center);
-  }, [center, map]);
+    map.setView(center, zoom);
+  }, [center, zoom, map]);
   return null;
 };
 
@@ -53,7 +53,8 @@ const handleResize = map => {
 };
 
 Centerer.propTypes = {
-  center: PropTypes.arrayOf(PropTypes.number)
+  center: PropTypes.arrayOf(PropTypes.number),
+  zoom: PropTypes.number
 };
 
 const FullscreenInteraction = ({ dragging, scrollWheelZoom }) => {
@@ -100,7 +101,8 @@ const CustomMapContainer = ({
   shouldChangeControlInFullscreen = true,
   style,
   children,
-  forceCentering
+  forceCentering,
+  mapRef
 }) => (
   <Wrapper $wholePage={wholePage}>
     <MapContainer
@@ -112,7 +114,10 @@ const CustomMapContainer = ({
       scrollWheelZoom={scrollWheelZoom}
       isSideMenuOpen={isSideMenuOpen}
       minZoom={1}
-      ref={handleResize}
+      ref={(ref) => {
+        handleResize(ref);
+        if (mapRef) mapRef.current = ref;
+      }}
       preferCanvas>
       {isFullscreenAllowed && shouldChangeControlInFullscreen && (
         <FullscreenInteraction dragging={dragging} scrollWheelZoom={scrollWheelZoom} />
@@ -120,7 +125,7 @@ const CustomMapContainer = ({
       {isFullscreenAllowed && !shouldChangeControlInFullscreen && (
         <FullscreenControl forceSeparateButton="true" />
       )}
-      {forceCentering && <Centerer center={center} />}
+      {forceCentering && <Centerer center={center} zoom={zoom} />}
       {isLocateControl && <LocateControl />}
       <ScaleControl position="bottomright" />
       <LayersControl />
@@ -141,7 +146,8 @@ CustomMapContainer.propTypes = {
   isFullscreenAllowed: PropTypes.bool,
   shouldChangeControlInFullscreen: PropTypes.bool,
   style: PropTypes.shape({}),
-  forceCentering: PropTypes.bool
+  forceCentering: PropTypes.bool,
+  mapRef: PropTypes.shape({ current: PropTypes.any })
 };
 
 export default CustomMapContainer;

--- a/packages/web-app/src/hooks/useGeolocation.js
+++ b/packages/web-app/src/hooks/useGeolocation.js
@@ -3,31 +3,21 @@ import { defaultCoord } from '../conf/config';
 
 const useGeolocation = () => {
   const [location, setLocation] = useState(defaultCoord);
-  const [isReady, setIsReady] = useState(false);
-  const [hasError, setHasError] = useState(false);
+  const [hasLocation, setHasLocation] = useState(false);
 
   useEffect(() => {
     if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setLocation({
-            lat: position.coords.latitude,
-            lng: position.coords.longitude
-          });
-          setIsReady(true);
-        },
-        () => {
-          setHasError(true);
-          setIsReady(true);
-        }
-      );
-    } else {
-      setHasError(true);
-      setIsReady(true);
+      navigator.geolocation.getCurrentPosition((position) => {
+        setLocation({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude
+        });
+        setHasLocation(true);
+      });
     }
   }, []);
 
-  return { location, isReady, hasError };
+  return { location, hasLocation };
 };
 
 export default useGeolocation;

--- a/packages/web-app/src/pages/Map.jsx
+++ b/packages/web-app/src/pages/Map.jsx
@@ -63,7 +63,7 @@ const Map = () => {
     });
     navigate(newPath, { replace: true });
     dispatch(changeLocation(center));
-    dispatch(changeZoom(zoom));
+    dispatch(changeZoom(newZoom));
 
     const criteria = {
       /* eslint-disable no-underscore-dangle */
@@ -93,6 +93,10 @@ const Map = () => {
 
   useEffect(() => {
     dispatch(fetchProjections());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     const target = decodeMapTarget(params.target);
     if (target) {
       dispatch(changeLocation({ lat: target.lat, lng: target.lng }));

--- a/packages/web-app/src/pages/Map.jsx
+++ b/packages/web-app/src/pages/Map.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, Suspense } from 'react';
+import React, { useEffect, useRef, Suspense } from 'react';
 import { includes } from 'ramda';
 import { useNavigate, generatePath, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,7 +16,7 @@ import {
 import { fetchProjections } from '../actions/Projections';
 import useGeolocation from '../hooks/useGeolocation';
 import 'leaflet/dist/leaflet.css';
-import { defaultZoom, focusZoom } from '../conf/config';
+import { defaultZoom, defaultCoord, focusZoom } from '../conf/config';
 
 const MapClusters = React.lazy(
   () => import('../components/common/Maps/MapClusters')
@@ -40,7 +40,8 @@ const Map = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const params = useParams();
-  const { location: geoLocation, isReady: isGeoReady, hasError: geoHasError } = useGeolocation();
+  const { location: geoLocation, hasLocation } = useGeolocation();
+  const mapRef = useRef(null);
   const {
     location,
     zoom,
@@ -92,26 +93,24 @@ const Map = () => {
 
   useEffect(() => {
     dispatch(fetchProjections());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (!isGeoReady) return;
-    
     const target = decodeMapTarget(params.target);
     if (target) {
       dispatch(changeLocation({ lat: target.lat, lng: target.lng }));
       dispatch(changeZoom(target.zoom));
     } else {
       dispatch(changeLocation(geoLocation));
-      dispatch(changeZoom(geoHasError ? defaultZoom : focusZoom));
+      dispatch(changeZoom(defaultZoom));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isGeoReady]);
+  }, [dispatch, params.target, geoLocation]);
 
-  if (!isGeoReady) {
-    return <PageLoader />;
-  }
+  useEffect(() => {
+    const target = decodeMapTarget(params.target);
+    const isDefaultTarget = target?.lat === defaultCoord.lat && target?.lng === defaultCoord.lng && target?.zoom === defaultZoom;
+    
+    if (hasLocation && (!params.target || isDefaultTarget) && mapRef.current) {
+      mapRef.current.setView([geoLocation.lat, geoLocation.lng], focusZoom);
+    }
+  }, [hasLocation, geoLocation, params.target]);
 
   return (
     <Suspense fallback={<PageLoader />}>
@@ -126,6 +125,7 @@ const Map = () => {
         onUpdate={handleUpdate}
         isSideMenuOpen={open}
         projectionsList={projections}
+        mapRef={mapRef}
       />
     </Suspense>
   );


### PR DESCRIPTION
# Fix map loading behavior with geolocation

## 🤔 What

- Changed map loading behavior to no longer block on geolocation permission
- Maps now load immediately with default coordinates or existing data
- When user accepts location sharing, maps pan to user location (only if no other data exists)
- Removed unused `hasError` property from `useGeolocation` hook
- Simplified zoom level logic across all map components

## 🤷♂️ Why

Previously, all maps (Map.jsx, MapMarkerSelector.jsx, PolygonMap.jsx) would show a loading spinner until the user accepted or denied location sharing. This created a poor user experience where:
- Users had to wait before seeing any map
- The map wouldn't load if geolocation was blocked or unavailable
- Users couldn't interact with the map while the permission dialog was open

## 🔍 How

### Core Changes

1. **useGeolocation hook** (`hooks/useGeolocation.js`)
   - Changed from `isReady` to `hasLocation` flag
   - No longer blocks - returns immediately with default coordinates
   - Sets `hasLocation: true` only when user accepts and GPS coordinates are acquired
   - Removed unused `hasError` property
   - Removed optional error callback (not needed)

2. **Map.jsx** (main map page)
   - Loads immediately with default coordinates (0,0) at zoom 2
   - When user accepts location sharing AND no target coordinates exist, pans to user location with zoom 13
   - Treats URL target `0,0,2` as "no real target" to allow panning to user location
   - Uses `mapRef` to directly call `map.setView()` for programmatic panning

3. **MapMarkerSelector.jsx** (entry/cave forms)
   - Loads immediately with form coordinates or default coordinates
   - Pans to user location only when accepted AND no valid form data exists
   - Simplified zoom level logic using logical OR

4. **PolygonMap.jsx** (massif forms)
   - Loads immediately with polygon centroid or default coordinates
   - Pans to user location only when accepted AND no polygon data exists
   - Simplified to use `initialCenter` instead of stateful `center`
   - Removed unnecessary `setCenter` calls
   - Simplified zoom level logic using logical OR

5. **CustomMapContainer** (`common/Maps/common/MapContainer.jsx`)
   - Added `mapRef` prop support to expose Leaflet map instance
   - Kept `forceCentering` and `Centerer` component for Region/Country components

## 🔗 Related API PR

None - frontend only changes.

## 🧪 Testing

### Map.jsx (Main map at `/ui/map`)
- [ ] Load `/ui/map` without location permission → map shows at (0,0) zoom 2
- [ ] Accept location sharing → map pans to user location with zoom 13, URL updates
- [ ] Deny location sharing → map stays at (0,0) zoom 2
- [ ] Load `/ui/map/48.8566,2.3522,13` → map loads at those coordinates, ignores user location
- [ ] Manual panning/zooming → smooth interaction, URL updates correctly
- [ ] Refresh page after panning → map loads at URL coordinates

### MapMarkerSelector.jsx (Entry/cave forms)
- [ ] Load form with empty lat/lng → map shows at default coordinates zoom 2
- [ ] Load form with existing lat/lng → map centers on those coordinates zoom 13
- [ ] Accept location sharing with empty form → map pans to user location zoom 13
- [ ] Accept location sharing with filled form → map stays on form coordinates
- [ ] Drag map → form lat/lng fields update correctly
- [ ] Type in lat/lng fields → map updates position

### PolygonMap.jsx (Massif forms)
- [ ] Load form with existing polygon → map fits bounds to polygon
- [ ] Load form without polygon → map shows at default coordinates zoom 2
- [ ] Accept location sharing without polygon → map pans to user location zoom 13
- [ ] Accept location sharing with polygon → map stays on polygon bounds
- [ ] Draw/edit polygon → smooth interaction

### Edge Cases
- [ ] Browser without geolocation support → maps load at defaults, no errors
