### PR TITLE
feat(search): persists EntityTable user preferences in localStorage

### DIFF
--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -393,6 +393,7 @@
   "Central longitude: ": "Central longitude: ",
   "Centro-Africaine": "Central African Republic",
   "Chad": "Chad",
+  "Change columns": "Change columns",
   "Change user groups": "Change user groups",
   "changed": "changed",
   "Check the veracity of the information": "Check the veracity of the information",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -393,6 +393,7 @@
   "Central longitude: ": "Central de longitud: ",
   "Centro-Africaine": "República Centroafricana",
   "Chad": "Chad",
+  "Change columns": "Cambiar columnas",
   "Change user groups": "Cambiar grupos de usuarios",
   "changed": "cambió",
   "Check the veracity of the information": "Comprobar la veracidad de la información.",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -393,6 +393,7 @@
   "Central longitude: ": "Longitude centrale :",
   "Centro-Africaine": "République Centrafricaine",
   "Chad": "Tchad",
+  "Change columns": "Modifier les colonnes",
   "Change user groups": "Modifier les groupes d'un utilisateur",
   "changed": "a changé",
   "Check the veracity of the information": "Vérifier que les informations fournies sont correctes",

--- a/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
@@ -22,6 +22,7 @@ import {
   SearchActionButtons
 } from './SearchElements';
 import { ADVANCED_SEARCH_TYPES } from '../../../conf/config';
+import { getStoredRowsPerPage } from '../../common/EntityTable/EntityTable';
 
 import Translate from '../../common/Translate';
 import InternationalizedLink from '../../common/InternationalizedLink';
@@ -98,7 +99,8 @@ const DocumentSearch = () => {
         entity: searchEntity,
         query,
         filter: filterState,
-        matchAllFields
+        matchAllFields,
+        size: getStoredRowsPerPage()
       })
     );
 
@@ -110,7 +112,6 @@ const DocumentSearch = () => {
       <Typography
         variant="body1"
         gutterBottom
-        paragraph
         style={{ fontStyle: 'italic', textAlign: 'center' }}>
         <Translate>
           The BBS (&quot;Bulletin Bibliographique Spéléologique&quot; in french)

--- a/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
@@ -17,6 +17,7 @@ import {
   SearchActionButtons
 } from './SearchElements';
 import { ADVANCED_SEARCH_TYPES } from '../../../conf/config';
+import { getStoredRowsPerPage } from '../../common/EntityTable/EntityTable';
 
 const lengthMarks = [
   {
@@ -107,7 +108,8 @@ const EntrancesSearch = () => {
         entity: searchEntity,
         query,
         filter: filterState,
-        matchAllFields
+        matchAllFields,
+        size: getStoredRowsPerPage()
       })
     );
 

--- a/packages/web-app/src/components/appli/AdvancedSearch/MassifsSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/MassifsSearch.jsx
@@ -12,6 +12,7 @@ import {
   SearchActionButtons
 } from './SearchElements';
 import { ADVANCED_SEARCH_TYPES } from '../../../conf/config';
+import { getStoredRowsPerPage } from '../../common/EntityTable/EntityTable';
 
 const MassifsSearch = () => {
   const dispatch = useDispatch();
@@ -21,7 +22,8 @@ const MassifsSearch = () => {
     dispatch(
       fetchAdvancedSearchResults({
         entity: ADVANCED_SEARCH_TYPES.MASSIFS,
-        query
+        query,
+        size: getStoredRowsPerPage()
       })
     );
 

--- a/packages/web-app/src/components/appli/AdvancedSearch/OrganizationsSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/OrganizationsSearch.jsx
@@ -14,6 +14,7 @@ import {
   SearchActionButtons
 } from './SearchElements';
 import { ADVANCED_SEARCH_TYPES } from '../../../conf/config';
+import { getStoredRowsPerPage } from '../../common/EntityTable/EntityTable';
 
 const initialFilterState = {
   city: '',
@@ -36,7 +37,8 @@ const OrganizationsSearch = () => {
         entity: searchEntity,
         query,
         filter: filterState,
-        matchAllFields
+        matchAllFields,
+        size: getStoredRowsPerPage()
       })
     );
 

--- a/packages/web-app/src/components/appli/AdvancedSearch/PersonSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/PersonSearch.jsx
@@ -11,6 +11,7 @@ import {
   SearchActionButtons
 } from './SearchElements';
 import { ADVANCED_SEARCH_TYPES } from '../../../conf/config';
+import { getStoredRowsPerPage } from '../../common/EntityTable/EntityTable';
 
 const PersonSearch = () => {
   const dispatch = useDispatch();
@@ -21,7 +22,8 @@ const PersonSearch = () => {
       fetchAdvancedSearchResults({
         entity: ADVANCED_SEARCH_TYPES.PERSONS,
         query,
-        filter: { type: 'AUTHOR' }
+        filter: { type: 'AUTHOR' },
+        size: getStoredRowsPerPage()
       })
     );
 

--- a/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
@@ -33,7 +33,30 @@ import { LoadingTableHead, LoadingTableBodyInner } from './LoadingTable';
 import Alert from '../Alert';
 import Translate from '../Translate';
 
+const DEFAULT_PAGE_SIZE_OPTIONS = [20, 100, 200];
 const MAX_DOCUMENTS_TO_EXPORT_IN_CSV = 10000; // This limit is also enforced server side
+
+const applyColumnVisibility = (columns, storedVisibility) => {
+  try {
+    const visibleColumns = JSON.parse(storedVisibility);
+    return columns.map(col => {
+      const newCol = [...col];
+      newCol[0] = visibleColumns.includes(col[1]);
+      return newCol;
+    });
+  } catch (e) {
+    return columns;
+  }
+};
+
+export const getStoredRowsPerPage = (pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS) => {
+  const stored = localStorage.getItem('entityTable_rowsPerPage');
+  if (stored) {
+    const value = parseInt(stored, 10);
+    if (pageSizeOptions.includes(value)) return value;
+  }
+  return pageSizeOptions[0];
+};
 
 const StyledTablePagination = styled(TablePagination)`
   p {
@@ -105,7 +128,7 @@ EntityTableHead.propTypes = {
   rowCount: PropTypes.number.isRequired
 };
 
-const VisibleColumnsMenu = ({ columns, setColumns }) => {
+const VisibleColumnsMenu = ({ columns, setColumns, entityType }) => {
   const { formatMessage } = useIntl();
   const [anchorEl, setAnchorEl] = useState(null);
   return (
@@ -128,7 +151,13 @@ const VisibleColumnsMenu = ({ columns, setColumns }) => {
             key={column[1]}
             onClick={() => {
               column[0] = !column[0]; // eslint-disable-line no-param-reassign
-              setColumns([...columns]);
+              const newColumns = [...columns];
+              setColumns(newColumns);
+              if (entityType) {
+                const storageKey = `entityTable_${entityType}_columns`;
+                const visibleColumns = newColumns.filter(col => col[0]).map(col => col[1]);
+                localStorage.setItem(storageKey, JSON.stringify(visibleColumns));
+              }
             }}>
             <Checkbox
               size="small"
@@ -145,7 +174,8 @@ const VisibleColumnsMenu = ({ columns, setColumns }) => {
 };
 VisibleColumnsMenu.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.array).isRequired,
-  setColumns: PropTypes.func.isRequired
+  setColumns: PropTypes.func.isRequired,
+  entityType: PropTypes.string
 };
 
 const EntityTable = ({
@@ -156,7 +186,7 @@ const EntityTable = ({
   pageRows,
   nbTotalRows,
   onRowClick,
-  pageSizeOptions = [20, 100, 200],
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
   onPageChange,
   onSortChange,
   onCSVDownload,
@@ -167,12 +197,20 @@ const EntityTable = ({
   const navigate = useNavigate();
 
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(pageSizeOptions[0]);
+  const [rowsPerPage, setRowsPerPage] = useState(() =>
+    getStoredRowsPerPage(pageSizeOptions)
+  );
   const [order, setOrder] = useState('');
   const [orderBy, setOrderBy] = useState('');
   const [selected, setSelected] = useState([]);
   const entityConfig = entitiesConfig[entityType ?? 'placeholder'];
-  const [entityColumns, setEntityColumns] = useState(entityConfig.columns);
+  const [entityColumns, setEntityColumns] = useState(() => {
+    const storageKey = `entityTable_${entityType}_columns`;
+    const stored = localStorage.getItem(storageKey);
+    return stored
+      ? applyColumnVisibility(entityConfig.columns, stored)
+      : entityConfig.columns;
+  });
 
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
@@ -182,9 +220,17 @@ const EntityTable = ({
   const handleChangeRowsPerPage = event => {
     const nbRowPerPage = parseInt(event.target.value, 10);
     setRowsPerPage(nbRowPerPage);
+    localStorage.setItem('entityTable_rowsPerPage', nbRowPerPage);
     setPage(0);
     if (onPageChange) onPageChange(0, nbRowPerPage);
   };
+
+  useEffect(() => {
+    if (onPageChange && rowsPerPage !== pageSizeOptions[0]) {
+      onPageChange(0, rowsPerPage);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleRowClick = (event, doc) => {
     if (onSelected) {
@@ -253,7 +299,12 @@ const EntityTable = ({
   };
 
   useEffect(() => {
-    const column = entityConfig.columns;
+    const storageKey = `entityTable_${entityType}_columns`;
+    const stored = localStorage.getItem(storageKey);
+    let column = stored
+      ? applyColumnVisibility(entityConfig.columns, stored)
+      : entityConfig.columns;
+    
     if (entityColumnsModifier) entityColumnsModifier(column);
     setEntityColumns(column);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -347,6 +398,7 @@ const EntityTable = ({
             <VisibleColumnsMenu
               columns={entityColumns}
               setColumns={setEntityColumns}
+              entityType={entityType}
             />
             {onCSVDownload && nbTotalRows <= MAX_DOCUMENTS_TO_EXPORT_IN_CSV && (
               <Button


### PR DESCRIPTION
# Persist EntityTable user preferences (rows per page and column visibility)

## 🤔 What

This PR adds persistence for user preferences in the EntityTable component:

- Persist the selected rows per page across sessions using localStorage
- Persist column visibility preferences per entity type
- Apply stored preferences on initial load and when performing advanced searches
- Add "Change columns" translation key in English, Spanish, and French

## 🤷♂️ Why

Users had to reconfigure their table preferences (rows per page and visible columns) every time they refreshed the page or performed a new search. This created a poor user experience as their preferences were not remembered between sessions.

## 🔍 How

**EntityTable component changes:**
- Extracted `getStoredRowsPerPage()` as an exported utility function to retrieve the stored rows per page preference from localStorage
- Created `applyColumnVisibility()` helper function to restore column visibility from localStorage
- Modified state initialization to use lazy initialization with stored values
- Added `useEffect` hooks to persist column visibility changes to localStorage
- Added `useEffect` to trigger page change on mount if stored rowsPerPage differs from default
- Stored the rows per page value in localStorage when changed via `handleChangeRowsPerPage`
- Moved `DEFAULT_PAGE_SIZE_OPTIONS` to config.js for reusability

**Advanced Search components:**
- Imported and used `getStoredRowsPerPage()` in all search components (DocumentSearch, EntrancesSearch, MassifsSearch, OrganizationsSearch, PersonSearch)
- Pass the stored page size as the `size` parameter when fetching search results to ensure initial results match user preferences

**Storage keys:**
- `entityTable_rowsPerPage`: stores the selected rows per page (shared across all entity types)
- `entityTable_${entityType}_columns`: stores column visibility per entity type (e.g., `entityTable_entrances_columns`)

## 🧪 Testing

1. Open any advanced search page (e.g., Entrances, Documents, Organizations)
2. Change the rows per page from the default (e.g., from 20 to 100)
3. Refresh the page - verify the rows per page preference is maintained
4. Click the column visibility icon and hide/show some columns
5. Refresh the page - verify the column visibility preferences are maintained
6. Switch to a different entity type - verify each entity type maintains its own column visibility preferences
7. Perform a new search - verify the stored rows per page is used for the initial query
