### PR TITLE
fix(massif): fix multipolygon UI bugs for separate polygons, holes, overlaps, and map bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "20.0.0",
+    "baseline-browser-mapping": "^2.9.19",
     "cross-env": "10.1.0",
     "eslint": "8.57.1",
     "eslint-config-airbnb": "19.0.4",

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -82,8 +82,11 @@ const PolygonMap = ({ onChange, data }) => {
 
   useEffect(() => {
     if (map) {
-      if (data?.coordinates?.[0]?.[0]) {
-        map.fitBounds(data.coordinates[0][0].map(e => [e[1], e[0]]));
+      if (data?.coordinates) {
+        const bounds = L.geoJSON(data).getBounds();
+        if (bounds.isValid()) {
+          map.fitBounds(bounds);
+        }
       } else if (hasLocation) {
         map.setView(geoLocation, ZOOM_LEVEL);
       }
@@ -93,21 +96,52 @@ const PolygonMap = ({ onChange, data }) => {
   const mapTOGeoJson = layers => {
     const geoJson = {};
     geoJson.type = 'MultiPolygon';
-    geoJson.coordinates = [[[]]];
-    let i = 0;
-    // eslint-disable-next-line no-restricted-syntax
-    for (const polygon of layers) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const coord of polygon.latlngs instanceof Array
-        ? polygon.latlngs
-        : polygon.latlngs[0]) {
-        geoJson.coordinates[0][i].push([coord.lng, coord.lat]);
-      }
-      geoJson.coordinates[0][i].push(geoJson.coordinates[0][i][0]);
-      i += 1;
-      geoJson.coordinates[0].push([]);
-    }
-    geoJson.coordinates[0].pop();
+    geoJson.coordinates = [];
+    
+    // Group polygons by containment relationships
+    const polygons = layers.map(layer => ({
+      coords: layer.latlngs instanceof Array ? layer.latlngs : layer.latlngs[0],
+      layer,
+      bounds: L.polygon(layer.latlngs instanceof Array ? layer.latlngs : layer.latlngs[0]).getBounds()
+    }));
+    
+    // Sort by area (largest first) to process outer polygons before inner ones
+    polygons.sort((a, b) => {
+      const areaA = (a.bounds.getEast() - a.bounds.getWest()) * (a.bounds.getNorth() - a.bounds.getSouth());
+      const areaB = (b.bounds.getEast() - b.bounds.getWest()) * (b.bounds.getNorth() - b.bounds.getSouth());
+      return areaB - areaA;
+    });
+    
+    const processed = new Set();
+    
+    polygons.forEach((outerPoly, i) => {
+      if (processed.has(i)) return;
+      
+      const outerCoords = outerPoly.coords.map(coord => [coord.lng, coord.lat]);
+      outerCoords.push(outerCoords[0]); // Close polygon
+      
+      const holes = [];
+      
+      // Check if other polygons are holes inside this one
+      polygons.forEach((innerPoly, j) => {
+        if (i === j || processed.has(j)) return;
+        
+        // Use bounding box containment as a simple approximation
+        const isHole = outerPoly.bounds.contains(innerPoly.bounds);
+        
+        if (isHole) {
+          const innerCoords = innerPoly.coords.map(coord => [coord.lng, coord.lat]);
+          innerCoords.push(innerCoords[0]); // Close hole
+          holes.push(innerCoords);
+          processed.add(j);
+        }
+      });
+      
+      // Create polygon with holes or separate polygon
+      geoJson.coordinates.push([outerCoords, ...holes]);
+      processed.add(i);
+    });
+    
     return geoJson;
   };
 
@@ -176,10 +210,18 @@ const PolygonMap = ({ onChange, data }) => {
     if (ref && !displayValue.current) {
       const editableFG = ref;
       // eslint-disable-next-line no-restricted-syntax
-      for (const polygon of data.coordinates[0]) {
-        const reverseCoords = polygon.map(coords => [coords[1], coords[0]]);
-        const leafletPolygon = L.polygon(reverseCoords, { color: 'green' });
+      for (const polygon of data.coordinates) {
+        // Add outer ring
+        const outerRing = polygon[0].map(coords => [coords[1], coords[0]]);
+        const leafletPolygon = L.polygon(outerRing, { color: 'green' });
         editableFG.addLayer(leafletPolygon);
+        
+        // Add holes as separate polygons
+        for (let i = 1; i < polygon.length; i++) {
+          const hole = polygon[i].map(coords => [coords[1], coords[0]]);
+          const leafletHole = L.polygon(hole, { color: 'green' });
+          editableFG.addLayer(leafletHole);
+        }
       }
       editableFG.eachLayer(layer => {
         const myObj = {

--- a/packages/web-app/src/components/appli/Massif/MapMassif.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { GeoJSON, Marker, Popup, useMap } from 'react-leaflet';
 import PropTypes from 'prop-types';
+import L from 'leaflet';
 
 import CustomMapContainer from '../../common/Maps/common/MapContainer';
 import EntranceMarker from '../../common/Maps/common/Markers/Components/EntranceMarker';

--- a/packages/web-app/src/components/appli/Massif/MapMassif.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { GeoJSON, Marker, Popup, useMap } from 'react-leaflet';
 import PropTypes from 'prop-types';
 
@@ -7,20 +7,48 @@ import EntranceMarker from '../../common/Maps/common/Markers/Components/Entrance
 import EntrancePopup from '../../common/Maps/common/Markers/Components/EntrancePopup';
 
 // Needed because useMap is only accessible from inside <MapContainer>
-const MapBind = ({ positions }) => {
+const MapBind = ({ geoJson }) => {
   const map = useMap();
   useEffect(() => {
-    map.fitBounds(positions.map(e => [e[1], e[0]]));
-  }, [map, positions]);
+    const bounds = L.geoJSON(geoJson).getBounds();
+    if (bounds.isValid()) {
+      map.fitBounds(bounds);
+    }
+  }, [map, geoJson]);
 
   return null;
 };
 MapBind.propTypes = {
-  positions: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired
+  geoJson: PropTypes.shape({
+    coordinates: PropTypes.arrayOf(
+      PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)))
+    )
+  }).isRequired
 };
 
 const MapMassif = ({ entrances, geogPolygon }) => {
   const geoJson = JSON.parse(geogPolygon);
+  
+  // Convert MultiPolygon to FeatureCollection for proper union display
+  const displayGeoJson = useMemo(() => {
+    if (geoJson.coordinates.length === 1) {
+      return geoJson; // Single polygon, no conversion needed
+    }
+    
+    // Create FeatureCollection with individual polygons
+    // Leaflet will render them as separate features, showing union behavior
+    return {
+      type: 'FeatureCollection',
+      features: geoJson.coordinates.map(coords => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: coords
+        },
+        properties: {}
+      }))
+    };
+  }, [geoJson]);
 
   return (
     <CustomMapContainer
@@ -28,7 +56,7 @@ const MapMassif = ({ entrances, geogPolygon }) => {
       dragging
       viewport={null}
       scrollWheelZoom={false}>
-      <GeoJSON data={geoJson} />
+      <GeoJSON data={displayGeoJson} />
       {entrances.map(
         entrance =>
           entrance.latitude &&
@@ -43,7 +71,7 @@ const MapMassif = ({ entrances, geogPolygon }) => {
             </Marker>
           )
       )}
-      <MapBind positions={geoJson.coordinates[0][0]} />
+      <MapBind geoJson={geoJson} />
     </CustomMapContainer>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6694,6 +6694,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"baseline-browser-mapping@npm:^2.9.19":
+  version: 2.9.19
+  resolution: "baseline-browser-mapping@npm:2.9.19"
+  bin:
+    baseline-browser-mapping: dist/cli.js
+  checksum: 10/8d7bbb7fe3d1ad50e04b127c819ba6d059c01ed0d2a7a5fc3327e23a8c42855fa3a8b510550c1fe1e37916147e6a390243566d3ef85bf6130c8ddfe5cc3db530
+  languageName: node
+  linkType: hard
+
 "batch@npm:0.6.1":
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
@@ -10843,6 +10852,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": "npm:^20.1.0"
     "@commitlint/config-conventional": "npm:20.0.0"
+    baseline-browser-mapping: "npm:^2.9.19"
     cross-env: "npm:10.1.0"
     eslint: "npm:8.57.1"
     eslint-config-airbnb: "npm:19.0.4"


### PR DESCRIPTION
# Fix multipolygon UI bugs for separate polygons, holes, overlaps, and map bounds

## 🤔 What

- Fixed multipolygon geometry creation to generate separate polygons instead of single polygon with holes
- Added spatial containment detection to properly distinguish between polygon holes and separate polygons
- Fixed overlapping polygon display to show union behavior instead of holes in view mode
- Implemented proper hole detection using Leaflet bounding box containment
- Added polygon sorting by area to ensure proper hole detection when adding containing polygons
- Fixed map bounds fitting to include all polygons instead of just the first one

## 🤷♂️ Why

The massif editing UI had several critical bugs:
1. When users drew 2 separate polygons, they were incorrectly stored as a single polygon with a hole
2. Overlapping polygons displayed as holes in view mode, contradicting the API's union behavior
3. Map viewport only showed the first polygon, leaving others out of view
4. Hole detection failed when adding a large polygon containing smaller ones

These issues made it impossible to properly create and edit massifs with multiple polygons or holes.

## 🔍 How

**PolygonMap.jsx (Edit mode):**
- Replaced simple polygon concatenation with spatial containment analysis
- Added polygon sorting by bounding box area (largest first) for proper processing order
- Used Leaflet's `getBounds().contains()` for hole detection
- Fixed map bounds to use `L.geoJSON(data).getBounds()` for all polygons
- Enhanced polygon loading to handle both outer rings and holes as separate editable layers

**MapMassif.jsx (View mode):**
- Converted MultiPolygon to FeatureCollection for proper union display of overlapping polygons
- Updated MapBind component to use `L.geoJSON().getBounds()` for comprehensive bounds calculation
- Simplified bounds computation using Leaflet's built-in methods

## 🔗 Related API PR

None - this is a frontend-only fix addressing UI geometry handling bugs.

## 🧪 Testing

1. **Separate polygons**: Draw 2 non-overlapping polygons → should save as MultiPolygon with 2 separate geometries
2. **Polygon holes**: Draw 1 polygon inside another → should save as single polygon with hole
3. **Overlapping polygons**: Draw 2 overlapping polygons → view mode should show union (no holes in overlap)
4. **Map bounds**: Create massif with multiple distant polygons → both view and edit modes should show all polygons
5. **Complex scenario**: Create 2 separate polygons, then add a large polygon containing both → should detect the 2 as holes

## 📸 Previews

<img width="946" height="968" alt="Screenshot 2026-02-09 at 11 55 45 a m" src="https://github.com/user-attachments/assets/bf266920-b301-4275-882e-980771efaab8" />

<img width="951" height="959" alt="Screenshot 2026-02-09 at 11 56 27 a m" src="https://github.com/user-attachments/assets/c3948b12-e87e-4a90-9bb9-fd99daa13aea" />
