### PR TITLE
feat(Massif): adapt UI to massif area limit API changes

### DIFF
--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -76,11 +76,18 @@
     "@storybook/addon-viewport": "8.6.14",
     "@storybook/react": "8.6.14",
     "@storybook/react-webpack5": "8.6.14",
+    "@testing-library/dom": "^10.4.1",
+    "fast-check": "^4.5.3",
     "storybook": "^8.6.15",
     "storybook-react-router": "1.0.8"
   },
   "engines": {
     "node": "20"
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!fast-check|@fast-check)"
+    ]
   },
   "browserslist": {
     "production": [

--- a/packages/web-app/src/__mocks__/react-router-dom.js
+++ b/packages/web-app/src/__mocks__/react-router-dom.js
@@ -1,0 +1,12 @@
+const mockNavigate = jest.fn();
+
+module.exports = {
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/', search: '', hash: '' }),
+  useParams: () => ({}),
+  MemoryRouter: ({ children }) => children,
+  Link: ({ children, to }) => {
+    const React = require('react');
+    return React.createElement('a', { href: to }, children);
+  }
+};

--- a/packages/web-app/src/actions/utils.makeUrl.property.test.js
+++ b/packages/web-app/src/actions/utils.makeUrl.property.test.js
@@ -1,0 +1,71 @@
+import fc from 'fast-check';
+import { makeUrl } from './utils';
+
+/**
+ * Property 2: makeUrl includes all criteria keys
+ *
+ * For any criteria object passed to makeUrl, every key in the object
+ * SHALL appear as a query parameter in the resulting URL, and no extra
+ * query parameters SHALL be present.
+ *
+ * Validates: Requirements 4.1, 4.2
+ */
+describe('makeUrl property tests', () => {
+  const baseUrl = 'https://api.example.com/endpoint';
+
+  it('should include every criteria key as a query parameter and no extras', () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(
+          fc.stringMatching(/^[a-zA-Z_][a-zA-Z0-9_]*$/).filter(
+            (s) => s.length > 0
+          ),
+          fc.oneof(
+            fc.string(),
+            fc.integer(),
+            fc.float({ noNaN: true, noDefaultInfinity: true })
+          )
+        ),
+        (criteria) => {
+          const url = makeUrl(baseUrl, criteria);
+          const keys = Object.keys(criteria);
+
+          if (keys.length === 0) {
+            // Empty object still produces '?' with no params
+            expect(url).toBe(`${baseUrl}?`);
+            return;
+          }
+
+          // Parse the query string from the result
+          const queryString = url.split('?')[1];
+          const params = new URLSearchParams(queryString);
+          const paramKeys = [...params.keys()];
+
+          // Every criteria key appears as a query parameter
+          keys.forEach((key) => {
+            expect(paramKeys).toContain(key);
+          });
+
+          // No extra query parameters beyond the criteria keys
+          expect(paramKeys.length).toBe(keys.length);
+
+          // Each value is the URI-encoded version of the original
+          keys.forEach((key) => {
+            expect(params.get(key)).toBe(
+              String(criteria[key])
+            );
+          });
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return the base URL unchanged when criteria is undefined', () => {
+    expect(makeUrl(baseUrl, undefined)).toBe(baseUrl);
+  });
+
+  it('should return the base URL unchanged when criteria is null', () => {
+    expect(makeUrl(baseUrl, null)).toBe(baseUrl);
+  });
+});

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifFormError.test.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifFormError.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import FormProgressInfo from '../utils/FormProgressInfo';
+
+// --- Helpers ---
+
+const areaErrorMessage =
+  'The massif polygon area (12345 km²) exceeds the maximum allowed size of 8000 km².';
+
+const messages = {
+  Retry: 'Retry',
+  [areaErrorMessage]: areaErrorMessage
+};
+
+const renderWithIntl = (ui) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      {ui}
+    </IntlProvider>
+  );
+
+// --- Tests ---
+
+describe('MassifForm area validation error display', () => {
+  it('displays the specific area validation error message', () => {
+    renderWithIntl(
+      <FormProgressInfo
+        isLoading={false}
+        isError={true}
+        labelLoading="Creating massif..."
+        labelError={areaErrorMessage}
+        resetFn={jest.fn()}
+        getRedirectFn={() => ''}
+      />
+    );
+
+    expect(screen.getByText(areaErrorMessage)).toBeInTheDocument();
+  });
+
+  it('allows retry after an area validation error', async () => {
+    const resetFn = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithIntl(
+      <FormProgressInfo
+        isLoading={false}
+        isError={true}
+        labelLoading="Creating massif..."
+        labelError={areaErrorMessage}
+        resetFn={resetFn}
+        getRedirectFn={() => ''}
+      />
+    );
+
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    expect(retryButton).toBeInTheDocument();
+
+    await user.click(retryButton);
+    expect(resetFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -175,7 +175,11 @@ const PolygonMap = ({ onChange, data }) => {
   const [hoveredLayerId, setHoveredLayerId] = useState(null);
   const hasCoordinates = data?.coordinates?.length > 0;
   const initialCenter = hasCoordinates
-    ? getMultiPolygonCentroid(data.coordinates[0][0])
+    ? getMultiPolygonCentroid(
+        data.type === 'Polygon'
+          ? data.coordinates[0]
+          : data.coordinates[0][0]
+      )
     : geoLocation;
   const ZOOM_LEVEL = hasCoordinates || hasLocation ? focusZoom : defaultZoom;
 
@@ -452,8 +456,13 @@ const PolygonMap = ({ onChange, data }) => {
       const editableFG = ref;
       const allPolygons = [];
 
+      // Normalize: for Polygon type, wrap coordinates in an extra array
+      // so the iteration logic works the same as MultiPolygon.
+      const polygons =
+        data.type === 'Polygon' ? [data.coordinates] : data.coordinates;
+
       // eslint-disable-next-line no-restricted-syntax
-      for (const polygon of data.coordinates) {
+      for (const polygon of polygons) {
         // Add outer ring (first ring of each polygon)
         const outerRing = polygon[0].map(coords => [coords[1], coords[0]]);
         const leafletPolygon = L.polygon(outerRing, { color: 'green' });

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/index.jsx
@@ -165,9 +165,12 @@ export const MassifForm = ({ massifValues }) => {
         isError={!!(massifError || nameError || descriptionError)}
         labelLoading={isNewMassif ? 'Creating massif...' : 'Updating massif...'}
         labelError={
-          isNewMassif
+          massifError?.message ||
+          nameError?.message ||
+          descriptionError?.message ||
+          (isNewMassif
             ? 'An error occurred when creating a massif.'
-            : 'An error occurred when updating a massif.'
+            : 'An error occurred when updating a massif.')
         }
         resetFn={handleReset}
         getRedirectFn={() => (massifData ? `/ui/massifs/${massifData.id}` : '')}

--- a/packages/web-app/src/components/appli/Massif/MapMassif.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.jsx
@@ -1,43 +1,120 @@
-import React, { useEffect, useMemo } from 'react';
-import { GeoJSON, Marker, Popup, useMap } from 'react-leaflet';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { GeoJSON, useMap, useMapEvents } from 'react-leaflet';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
 
 import CustomMapContainer from '../../common/Maps/common/MapContainer';
-import EntranceMarker from '../../common/Maps/common/Markers/Components/EntranceMarker';
-import EntrancePopup from '../../common/Maps/common/Markers/Components/EntrancePopup';
+import useHeatLayer, {
+  HexGlobalCss
+} from '../../common/Maps/MapClusters/useHeatLayer';
+import useMarkers, {
+  MarkerGlobalCss
+} from '../../common/Maps/common/Markers/useMarkers';
+import {
+  EntranceMarker,
+  EntrancePopup
+} from '../../common/Maps/common/Markers/Components';
+import { MARKERS_LIMIT } from '../../common/Maps/MapClusters/constants';
+import { makeUrl } from '../../../actions/utils';
+import {
+  getMapEntrancesCoordinatesUrl,
+  getMapEntrancesUrl
+} from '../../../conf/apiRoutes';
 
-// Needed because useMap is only accessible from inside <MapContainer>
-const MapBind = ({ geoJson }) => {
+const MapInternals = ({ geoJson, massifId }) => {
   const map = useMap();
+  const zoomRef = useRef(map.getZoom());
+  const { updateHeatData } = useHeatLayer();
+
+  const updateEntranceMarkers = useMarkers({
+    icon: EntranceMarker,
+    popupContent: entrance => <EntrancePopup entrance={entrance} />,
+    tooltipContent: entrance => entrance?.name
+  });
+
+  // Keep refs to the latest updater functions so fetchData never
+  // captures a stale closure (hexLayer may not be ready on first render).
+  const heatRef = useRef(updateHeatData);
+  heatRef.current = updateHeatData;
+  const markersRef = useRef(updateEntranceMarkers);
+  markersRef.current = updateEntranceMarkers;
+
+  const fetchData = useCallback(() => {
+    const bounds = map.getBounds();
+    const zoom = map.getZoom();
+    zoomRef.current = zoom;
+    /* eslint-disable no-underscore-dangle */
+    const criteria = {
+      sw_lat: bounds._southWest.wrap().lat,
+      sw_lng: bounds._southWest.wrap().lng,
+      ne_lat: bounds._northEast.wrap().lat,
+      ne_lng: bounds._northEast.wrap().lng,
+      massif: massifId
+    };
+    /* eslint-enable no-underscore-dangle */
+
+    const isHighZoom = zoom >= MARKERS_LIMIT;
+    const url = isHighZoom
+      ? getMapEntrancesUrl
+      : getMapEntrancesCoordinatesUrl;
+
+    fetch(makeUrl(url, criteria))
+      .then(response => {
+        if (!response.ok) return [];
+        return response.json();
+      })
+      .then(data => {
+        if (!Array.isArray(data)) return;
+        if (isHighZoom) {
+          heatRef.current([]);
+          markersRef.current(data);
+        } else {
+          markersRef.current(null);
+          heatRef.current(data);
+        }
+      })
+      .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, massifId]);
+
+  useMapEvents({
+    zoomend: fetchData,
+    dragend: fetchData
+  });
+
   useEffect(() => {
     const bounds = L.geoJSON(geoJson).getBounds();
     if (bounds.isValid()) {
       map.fitBounds(bounds);
     }
-  }, [map, geoJson]);
+    fetchData();
+  }, [map, geoJson, fetchData]);
 
-  return null;
-};
-MapBind.propTypes = {
-  geoJson: PropTypes.shape({
-    coordinates: PropTypes.arrayOf(
-      PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)))
-    )
-  }).isRequired
+  return (
+    <>
+      {HexGlobalCss}
+      {MarkerGlobalCss}
+    </>
+  );
 };
 
-const MapMassif = ({ entrances, geogPolygon }) => {
-  const geoJson = JSON.parse(geogPolygon);
-  
-  // Convert MultiPolygon to FeatureCollection for proper union display
+MapInternals.propTypes = {
+  geoJson: PropTypes.shape({}).isRequired,
+  massifId: PropTypes.number.isRequired
+};
+
+const MapMassif = ({ massifId, geogPolygon }) => {
+  const geoJson = useMemo(() => JSON.parse(geogPolygon), [geogPolygon]);
+
+  // Normalize to a displayable GeoJSON.
+  // Leaflet's GeoJSON layer handles Polygon natively.
+  // For MultiPolygon with multiple polygons, convert to FeatureCollection
+  // so each polygon renders as a separate feature (proper union display).
   const displayGeoJson = useMemo(() => {
-    if (geoJson.coordinates.length === 1) {
-      return geoJson; // Single polygon, no conversion needed
+    if (geoJson.type === 'Polygon' || geoJson.coordinates.length === 1) {
+      return geoJson;
     }
-    
-    // Create FeatureCollection with individual polygons
-    // Leaflet will render them as separate features, showing union behavior
+
     return {
       type: 'FeatureCollection',
       features: geoJson.coordinates.map(coords => ({
@@ -58,34 +135,14 @@ const MapMassif = ({ entrances, geogPolygon }) => {
       viewport={null}
       scrollWheelZoom={false}>
       <GeoJSON data={displayGeoJson} />
-      {entrances.map(
-        entrance =>
-          entrance.latitude &&
-          entrance.longitude && (
-            <Marker
-              key={entrance.id}
-              position={[entrance.latitude, entrance.longitude]}
-              icon={EntranceMarker}>
-              <Popup>
-                <EntrancePopup entrance={entrance} />
-              </Popup>
-            </Marker>
-          )
-      )}
-      <MapBind geoJson={geoJson} />
+      <MapInternals geoJson={geoJson} massifId={massifId} />
     </CustomMapContainer>
   );
 };
 
 MapMassif.propTypes = {
   geogPolygon: PropTypes.string.isRequired,
-  entrances: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number,
-      latitude: PropTypes.number,
-      longitude: PropTypes.number
-    })
-  )
+  massifId: PropTypes.number.isRequired
 };
 
 export default MapMassif;

--- a/packages/web-app/src/components/appli/Massif/MapMassif.property.test.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.property.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import fc from 'fast-check';
+
+import MapMassif from './MapMassif';
+
+// --- Mocks (same pattern as MapMassif.test.jsx) ---
+
+const mockUpdateHeatData = jest.fn();
+const mockUpdateEntranceMarkers = jest.fn();
+
+jest.mock('react-leaflet', () => {
+  const React = require('react');
+  return {
+    useMap: () => ({
+      getZoom: () => 8,
+      getBounds: () => ({
+        _southWest: { wrap: () => ({ lat: -10, lng: -10 }) },
+        _northEast: { wrap: () => ({ lat: 10, lng: 10 }) }
+      }),
+      fitBounds: jest.fn()
+    }),
+    useMapEvents: () => null,
+    GeoJSON: () => React.createElement('div', { 'data-testid': 'geojson' })
+  };
+});
+
+jest.mock('leaflet', () => ({
+  geoJSON: () => ({
+    getBounds: () => ({ isValid: () => true })
+  })
+}));
+
+jest.mock('../../common/Maps/common/MapContainer', () => {
+  const React = require('react');
+  return ({ children }) =>
+    React.createElement('div', { 'data-testid': 'map-container' }, children);
+});
+
+jest.mock('../../common/Maps/MapClusters/useHeatLayer', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => ({ updateHeatData: mockUpdateHeatData }),
+    HexGlobalCss: React.createElement('div')
+  };
+});
+
+jest.mock('../../common/Maps/common/Markers/useMarkers', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => mockUpdateEntranceMarkers,
+    MarkerGlobalCss: React.createElement('div')
+  };
+});
+
+jest.mock('../../common/Maps/common/Markers/Components', () => ({
+  EntranceMarker: 'entrance-marker',
+  EntrancePopup: () => null
+}));
+
+jest.mock('../../common/Maps/MapClusters/constants', () => ({
+  MARKERS_LIMIT: 13
+}));
+
+jest.mock('../../../conf/apiRoutes', () => ({
+  getMapEntrancesCoordinatesUrl: '/api/v1/geoloc/entrancesCoordinates',
+  getMapEntrancesUrl: '/api/v1/geoloc/entrances'
+}));
+
+const samplePolygon = JSON.stringify({
+  type: 'MultiPolygon',
+  coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]]
+});
+
+beforeEach(() => {
+  mockUpdateHeatData.mockClear();
+  mockUpdateEntranceMarkers.mockClear();
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+/**
+ * Property 1: updateHeatData receives the same data the API returned
+ *
+ * For any array of entrance coordinates returned by the
+ * Geoloc_Endpoint (including the empty array), the MapMassif
+ * component SHALL pass exactly that data to updateHeatData
+ * (at low zoom, coordinates go to the heat layer).
+ *
+ * Validates: Requirements 2.3, 2.4
+ */
+describe('MapMassif property tests', () => {
+  jest.setTimeout(30000);
+
+  const coordArb = fc.array(
+    fc.tuple(
+      fc.float({ noNaN: true, noDefaultInfinity: true }),
+      fc.float({ noNaN: true, noDefaultInfinity: true })
+    )
+  );
+
+  it('passes all fetched coordinates to updateHeatData', async () => {
+    await fc.assert(
+      fc.asyncProperty(coordArb, async coords => {
+        mockUpdateHeatData.mockClear();
+        mockUpdateEntranceMarkers.mockClear();
+
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(coords)
+        });
+
+        const { unmount } = render(
+          <MapMassif massifId={1} geogPolygon={samplePolygon} />
+        );
+
+        await waitFor(() => {
+          expect(mockUpdateHeatData).toHaveBeenCalledWith(coords);
+        });
+
+        unmount();
+      }),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/packages/web-app/src/components/appli/Massif/MapMassif.test.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.test.jsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import MapMassif from './MapMassif';
+
+// --- Mocks ---
+
+const mockUpdateHeatData = jest.fn();
+const mockUpdateEntranceMarkers = jest.fn();
+let mockZoom = 8;
+
+jest.mock('react-leaflet', () => {
+  const React = require('react');
+  return {
+    useMap: () => ({
+      getZoom: () => mockZoom,
+      getBounds: () => ({
+        _southWest: { wrap: () => ({ lat: -10, lng: -10 }) },
+        _northEast: { wrap: () => ({ lat: 10, lng: 10 }) }
+      }),
+      fitBounds: jest.fn()
+    }),
+    useMapEvents: () => null,
+    GeoJSON: () => React.createElement('div', { 'data-testid': 'geojson' })
+  };
+});
+
+jest.mock('leaflet', () => ({
+  geoJSON: () => ({
+    getBounds: () => ({ isValid: () => true })
+  })
+}));
+
+jest.mock('../../common/Maps/common/MapContainer', () => {
+  const React = require('react');
+  return ({ children }) =>
+    React.createElement('div', { 'data-testid': 'map-container' }, children);
+});
+
+jest.mock('../../common/Maps/MapClusters/useHeatLayer', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => ({ updateHeatData: mockUpdateHeatData }),
+    HexGlobalCss: React.createElement('div')
+  };
+});
+
+jest.mock('../../common/Maps/common/Markers/useMarkers', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => mockUpdateEntranceMarkers,
+    MarkerGlobalCss: React.createElement('div')
+  };
+});
+
+jest.mock('../../common/Maps/common/Markers/Components', () => ({
+  EntranceMarker: 'entrance-marker',
+  EntrancePopup: () => null
+}));
+
+jest.mock('../../common/Maps/MapClusters/constants', () => ({
+  MARKERS_LIMIT: 13
+}));
+
+jest.mock('../../../conf/apiRoutes', () => ({
+  getMapEntrancesCoordinatesUrl: '/api/v1/geoloc/entrancesCoordinates',
+  getMapEntrancesUrl: '/api/v1/geoloc/entrances'
+}));
+
+// --- Test data ---
+
+const samplePolygon = JSON.stringify({
+  type: 'MultiPolygon',
+  coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]]
+});
+
+// --- Tests ---
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  mockUpdateHeatData.mockClear();
+  mockUpdateEntranceMarkers.mockClear();
+  mockZoom = 8;
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+describe('MapMassif', () => {
+  describe('at low zoom (< MARKERS_LIMIT)', () => {
+    it('calls updateHeatData with coordinates', async () => {
+      const coords = [[5.5, 44.1], [6.2, 43.8], [7.0, 45.0]];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(coords)
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(mockUpdateHeatData).toHaveBeenCalledWith(coords);
+      });
+    });
+
+    it('clears markers when receiving coordinates', async () => {
+      const coords = [[5.5, 44.1]];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(coords)
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(mockUpdateEntranceMarkers).toHaveBeenCalledWith(null);
+      });
+    });
+
+    it('fetches from entrancesCoordinates endpoint', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      expect(global.fetch.mock.calls[0][0]).toContain(
+        'entrancesCoordinates'
+      );
+    });
+  });
+
+  describe('at high zoom (>= MARKERS_LIMIT)', () => {
+    beforeEach(() => {
+      mockZoom = 14;
+    });
+
+    it('fetches from entrances endpoint', async () => {
+      const entrances = [
+        { id: 1, name: 'Cave A', latitude: 44.1, longitude: 5.5 }
+      ];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(entrances)
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      expect(global.fetch.mock.calls[0][0]).toContain('/entrances?');
+      expect(global.fetch.mock.calls[0][0]).not.toContain(
+        'entrancesCoordinates'
+      );
+    });
+
+    it('calls updateEntranceMarkers with entrance objects', async () => {
+      const entrances = [
+        { id: 1, name: 'Cave A', latitude: 44.1, longitude: 5.5 },
+        { id: 2, name: 'Cave B', latitude: 45.0, longitude: 6.2 }
+      ];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(entrances)
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(mockUpdateEntranceMarkers).toHaveBeenCalledWith(
+          entrances
+        );
+      });
+    });
+
+    it('clears heat data when showing markers', async () => {
+      const entrances = [
+        { id: 1, name: 'Cave A', latitude: 44.1, longitude: 5.5 }
+      ];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(entrances)
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(mockUpdateHeatData).toHaveBeenCalledWith([]);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('renders polygon when fetch returns empty array', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('geojson')).toBeInTheDocument();
+    });
+
+    it('renders polygon when fetch returns 404', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ message: 'Not found' })
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('geojson')).toBeInTheDocument();
+    });
+
+    it('renders polygon when fetch returns 500', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ message: 'Server error' })
+      });
+
+      render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('geojson')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web-app/src/components/appli/Massif/Massif.jsx
+++ b/packages/web-app/src/components/appli/Massif/Massif.jsx
@@ -172,11 +172,11 @@ const Massif = ({ isLoading, error, massif }) => {
                   />
                 )}
               </Box>
-              {massif?.geogPolygon && massif?.entrances && (
+              {massif?.geogPolygon && (
                 <>
                   <hr />
                   <MapMassif
-                    entrances={massif?.entrances}
+                    massifId={parseInt(massifId, 10)}
                     geogPolygon={massif?.geogPolygon}
                   />
                 </>

--- a/packages/web-app/src/types/massif.type.js
+++ b/packages/web-app/src/types/massif.type.js
@@ -16,7 +16,6 @@ export const MassifTypes = PropTypes.shape({
   language: PropTypes.string,
   geogPolygon: PropTypes.string,
   descriptions: PropTypes.arrayOf(DescriptionSimpleTypes),
-  entrances: PropTypes.arrayOf(PropTypes.shape({})),
   networks: PropTypes.arrayOf(PropTypes.shape({})),
   documents: PropTypes.arrayOf(PropTypes.shape({}))
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,6 +2537,7 @@ __metadata:
     "@storybook/addon-viewport": "npm:8.6.14"
     "@storybook/react": "npm:8.6.14"
     "@storybook/react-webpack5": "npm:8.6.14"
+    "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
@@ -2545,6 +2546,7 @@ __metadata:
     d3-hexbin: "npm:^0.2.2"
     date-fns: "npm:^4.1.0"
     diff: "npm:^8.0.2"
+    fast-check: "npm:^4.5.3"
     isomorphic-fetch: "npm:^3.0.0"
     leaflet: "npm:^1.9.4"
     leaflet-draw: "npm:^1.0.4"
@@ -4696,6 +4698,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10/7f93e09ea015f151f8b8f42cbab0b2b858999b5445f15239a72a612ef7716e672b14c40c421218194cf191cbecbde0afa6f3dc2cc83dda93ff6a4fb0237df6e6
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:^6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
@@ -4766,6 +4784,13 @@ __metadata:
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 10/7379713eca480ac0d9b6c7b063e06b00a7eac57092354556c81027066eb65b61ea141a69d0cc2e15d32e05b2834d4c9c2184793a5e36bbf5daf05ee5676af18c
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10/c0084c389dc030daeaf0115a92ce43a3f4d42fc8fef2d0e22112d87a42798d4a15aac413019d4a63f868327d52ad6740ab99609462b442fe6b9286b172d2e82e
   languageName: node
   linkType: hard
 
@@ -6180,6 +6205,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10/18640244e641a417ec75a9bd38b0b2b6b95af5199aa241b131d4b2fb206f334d7ecc600bd194861610a5579084978bfcbb02baa399dbe442d56d0ae5e60dbaef
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10/c3e1ed127cc6886fea4732e97dd6d3c3938e64180803acfb9df8955517c4943760746ffaf4020ce8f7ffaa7556a3b5f85c3769a1f5ca74a1288e02d042f9ae4e
   languageName: node
   linkType: hard
 
@@ -8622,7 +8656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:^2.0.2":
+"dequal@npm:^2.0.2, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10/6ff05a7561f33603df87c45e389c9ac0a95e3c056be3da1a0c4702149e3a7f6fe5ffbb294478687ba51a9e95f3a60e8b6b9005993acd79c292c7d15f71964b6b
@@ -8724,6 +8758,13 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10/b4b28f1df5c563f7d876e7461254a4597b8cabe915abe94d7c5d1633fed263fcf9a85e8d3836591fc2d040108e822b0d32758e5ec1fe31c590dc7e08086e3e48
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10/377b4a7f9eae0a5d72e1068c369c99e0e4ca17fdfd5219f3abd32a73a590749a267475a59d7b03a891f9b673c27429133a818c44b2e47e32fec024b34274e2ca
   languageName: node
   linkType: hard
 
@@ -10032,6 +10073,15 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: 10/bfd6d55f3c0c04d826fe0213264b383c03f32825af6b1ff777f3f2dc49467e599361993568d75b7b19a8ea1bb08c8e7cd8c3d87d179ced91bb0dcf81ca6938e0
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^4.5.3":
+  version: 4.5.3
+  resolution: "fast-check@npm:4.5.3"
+  dependencies:
+    pure-rand: "npm:^7.0.0"
+  checksum: 10/005117cc3fbaf8f5bbe153f8f989337d36b85953cefae1973ab0c51e9e259a7a0456155e742716f8609ab74c4e18ee9fb9dcd618c52a9014cd4bd3952a296188
   languageName: node
   linkType: hard
 
@@ -13445,6 +13495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10/e86f0280e99a8d8cd4eef24d8601ddae15ce54e43ac9990dfcb79e1e081c255ad24424a30d78d2ad8e51a8ce82a66a930047fed4b4aa38c6f0b392ff9300edfc
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.25.0, magic-string@npm:^0.25.7":
   version: 0.25.9
   resolution: "magic-string@npm:0.25.9"
@@ -14646,17 +14705,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^0.2.1":
   version: 0.2.1
   resolution: "picocolors@npm:0.2.1"
   checksum: 10/3b0f441f0062def0c0f39e87b898ae7461c3a16ffc9f974f320b44c799418cabff17780ee647fda42b856a1dc45897e2c62047e1b546d94d6d5c6962f45427b2
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "picocolors@npm:1.1.1"
-  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -15629,7 +15688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.5.1":
+"pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
   dependencies:
@@ -15791,6 +15850,13 @@ __metadata:
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10/febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "pure-rand@npm:7.0.1"
+  checksum: 10/c61a576fda5032ec9763ecb000da4a8f19263b9e2f9ae9aa2759c8fbd9dc6b192b2ce78391ebd41abb394a5fedb7bcc4b03c9e6141ac8ab20882dd5717698b80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# feat(Massif): adapt UI to massif area limit API changes

## 🤔 What

- Removed `entrances` field from the massif data model and detail page (field removed from `GET /api/v1/massifs/:id`)
- Rewrote `MapMassif` to use the shared heatmap/markers infrastructure (`useHeatLayer`, `useMarkers`) with zoom-based endpoint switching — matching the Global Map Page behavior
- Fixed Polygon vs MultiPolygon handling in `MapMassif` and `PolygonMap` (edit form)
- Surfaced specific API error messages (including area validation) on the massif create/edit forms
- Closes #1179

## 🤷‍♂️ Why

The API PR [GrottoCenter/grottocenter-api#1470](https://github.com/GrottoCenter/grottocenter-api/pull/1470) introduces breaking changes:
1. `entrances` field removed from massif GET response
2. New optional `massif` query parameter on geoloc endpoints
3. Area validation (8,000 km² limit) on massif POST/PUT with HTTP 400

## 🔍 How

- **MassifTypes** (`src/types/massif.type.js`): Removed `entrances` from PropTypes shape.
- **Massif.jsx**: Removed `massif?.entrances` from the map rendering guard. Passes `massifId` instead of `entrances` to `MapMassif`.
- **MapMassif.jsx**: Complete rewrite using shared infrastructure:
  - Uses `useHeatLayer` for hex heatmap at zoom < 13 (coordinates endpoint)
  - Uses `useMarkers` with `EntranceMarker`/`EntrancePopup` at zoom ≥ 13 (entrances endpoint)
  - Direct `fetch` + refs (not Redux) to avoid polluting `state.map` used by the global map
  - Refs (`heatRef`, `markersRef`) solve stale closure issue where `updateHeatData` was captured before `hexLayer` initialized
  - Handles both `Polygon` and `MultiPolygon` GeoJSON types
- **PolygonMap.jsx** (edit form): Fixed `getMultiPolygonCentroid`, `initialCenter`, and `onFeatureGroupReady` to handle `Polygon` type (not just `MultiPolygon`)
- **MassifForm** (`index.jsx`): `labelError` now prefers `massifError?.message` over the generic fallback, surfacing the area validation message directly

## 🔗 Related API PR

- [GrottoCenter/grottocenter-api#1470](https://github.com/GrottoCenter/grottocenter-api/pull/1470)

## 🧪 Testing

15 unit/property tests across 4 suites:
- `MapMassif.test.jsx` — low zoom (heatmap), high zoom (markers), error handling (9 tests)
- `MapMassif.property.test.jsx` — verifies all fetched coordinates reach `updateHeatData` (100 iterations)
- `MassifFormError.test.jsx` — area validation error display + retry (2 tests)
- `utils.makeUrl.property.test.js` — verifies all criteria keys appear as query params (100 iterations)

Manual testing:
1. Open a massif detail page — hex heatmap at low zoom, entrance markers with popups at zoom ≥ 13
2. Edit a massif with Polygon geometry (not just MultiPolygon) — map should center and display correctly
3. Create/edit a massif with polygon > 8,000 km² — specific API error message should display
4. Verify the global map (`/ui/map`) still works as before

## 📸 Previews


<img width="630" height="437" alt="Screenshot 2026-02-18 at 6 53 09 p m" src="https://github.com/user-attachments/assets/f62e4d4b-c5a7-4db6-9bb8-8f980122e7b1" />
<img width="624" height="422" alt="Screenshot 2026-02-18 at 6 53 33 p m" src="https://github.com/user-attachments/assets/7d764fbf-c629-48dc-a433-b7283f7fafd7" />
