### PR TITLE
feat: optimize map performances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ typings/
 AGENTS.md
 .amazonq
 .kiro
+.claude

--- a/packages/web-app/src/actions/Map.js
+++ b/packages/web-app/src/actions/Map.js
@@ -9,8 +9,8 @@ import {
 import makeErrorMessage from '../helpers/makeErrorMessage';
 import { makeUrl } from './utils';
 
-export const FETCH_MAP_START_LOADING = 'FETCH_MAP_LOADING';
-export const FETCH_MAP_END_LOADING = 'FETCH_MAP_LOADING';
+export const FETCH_MAP_START_LOADING = 'FETCH_MAP_START_LOADING';
+export const FETCH_MAP_END_LOADING = 'FETCH_MAP_END_LOADING';
 export const FETCH_MAP_NETWORKS_SUCCESS = 'FETCH_MAP_NETWORKS_SUCCESS';
 export const FETCH_MAP_NETWORKS_FAILURE = 'FETCH_MAP_NETWORKS_FAILURE';
 export const FETCH_MAP_NETWORKS_COORDINATES_SUCCESS =
@@ -27,10 +27,6 @@ export const FETCH_MAP_ORGANIZATIONS_SUCCESS =
   'FETCH_MAP_ORGANIZATIONS_SUCCESS';
 export const FETCH_MAP_ORGANIZATIONS_FAILURE =
   'FETCH_MAP_ORGANIZATIONS_FAILURE';
-export const CHANGE_LOCATION = 'CHANGE_LOCATION';
-export const CHANGE_ZOOM = 'CHANGE_ZOOM';
-export const FOCUS_ON_LOCATION = 'FOCUS_ON_LOCATION';
-
 export const LOADINGS = {
   NETWORKS: 'networks',
   NETWORKS_COORDINATES: 'networks_coordinates',
@@ -39,51 +35,65 @@ export const LOADINGS = {
   ORGANIZATIONS: 'organizations'
 };
 
-export const fetchNetworksCoordinates = criteria => {
-  const thunkToDebounce = function (dispatch) {
-    dispatch({
-      type: FETCH_MAP_START_LOADING,
-      key: LOADINGS.NETWORKS_COORDINATES
-    });
-    const completedUrl = makeUrl(getMapCavesCoordinatesUrl, criteria);
-    return fetch(completedUrl)
+// Heatmap coordinates are fetched once at startup with world-wide bounds rather than
+// on every moveend. The @asymmetrik/leaflet-d3 hexbin layer filters points client-side,
+// so it only renders hexagons visible in the current viewport regardless of dataset size.
+//
+// Benchmark (2025): ~130k entrances → ~2.6 MB uncompressed, ~700 KB gzipped.
+// One-time cost on page load vs. a bounded API call on every pan/zoom
+
+// Retries the fetch up to maxRetries times with exponential backoff (1 s, 2 s, 4 s…).
+// Rejects only after all attempts are exhausted.
+const fetchWithRetry = (url, maxRetries = 3) => {
+  const attempt = (retriesLeft, delay) =>
+    fetch(url)
       .then(response => {
-        if (response.status >= 400) {
-          throw new Error(response.status);
-        }
+        if (response.status >= 400) throw new Error(response.status);
         return response.text();
       })
-      .then(text => {
-        dispatch({
-          type: FETCH_MAP_NETWORKS_COORDINATES_SUCCESS,
-          data: JSON.parse(text)
-        });
-      })
       .catch(error => {
-        dispatch({
-          type: FETCH_MAP_NETWORKS_COORDINATES_FAILURE,
-          error: makeErrorMessage(
-            error.message,
-            `Fetching networks coordinates`
-          )
-        });
-      })
-      .finally(() => {
-        dispatch({
-          type: FETCH_MAP_END_LOADING,
-          key: LOADINGS.NETWORKS_COORDINATES
-        });
+        if (retriesLeft === 0) throw error;
+        return new Promise(resolve => setTimeout(resolve, delay)).then(() =>
+          attempt(retriesLeft - 1, delay * 2)
+        );
       });
-  };
+  return attempt(maxRetries, 1000);
+};
 
-  thunkToDebounce.meta = {
-    debounce: {
-      time: 500,
-      key: 'FETCH_MAP_NETWORKS_COORDINATES'
-    }
-  };
+const MAX_BOUNDS = {
+  sw_lat: -90,
+  sw_lng: -180,
+  ne_lat: 90,
+  ne_lng: 180
+};
 
-  return thunkToDebounce;
+export const fetchAllNetworksCoordinates = () => dispatch => {
+  dispatch({
+    type: FETCH_MAP_START_LOADING,
+    key: LOADINGS.NETWORKS_COORDINATES
+  });
+  return fetchWithRetry(makeUrl(getMapCavesCoordinatesUrl, MAX_BOUNDS))
+    .then(text => {
+      dispatch({
+        type: FETCH_MAP_NETWORKS_COORDINATES_SUCCESS,
+        data: JSON.parse(text)
+      });
+    })
+    .catch(error => {
+      dispatch({
+        type: FETCH_MAP_NETWORKS_COORDINATES_FAILURE,
+        error: makeErrorMessage(
+          error.message,
+          `Fetching all networks coordinates`
+        )
+      });
+    })
+    .finally(() => {
+      dispatch({
+        type: FETCH_MAP_END_LOADING,
+        key: LOADINGS.NETWORKS_COORDINATES
+      });
+    });
 };
 
 export const fetchNetworks = criteria => {
@@ -124,51 +134,33 @@ export const fetchNetworks = criteria => {
   return thunkToDebounce;
 };
 
-export const fetchEntrancesCoordinates = criteria => {
-  const thunkToDebounce = function (dispatch) {
-    dispatch({
-      type: FETCH_MAP_START_LOADING,
-      key: LOADINGS.ENTRANCES_COORDINATES
-    });
-    const completedUrl = makeUrl(getMapEntrancesCoordinatesUrl, criteria);
-    return fetch(completedUrl)
-      .then(response => {
-        if (response.status >= 400) {
-          throw new Error(response.status);
-        }
-        return response.text();
-      })
-      .then(text => {
-        dispatch({
-          type: FETCH_MAP_ENTRANCES_COORDINATES_SUCCESS,
-          data: JSON.parse(text)
-        });
-      })
-      .catch(error => {
-        dispatch({
-          type: FETCH_MAP_ENTRANCES_COORDINATES_FAILURE,
-          error: makeErrorMessage(
-            error.message,
-            `Fetching entrances coordinates`
-          )
-        });
-      })
-      .finally(() => {
-        dispatch({
-          type: FETCH_MAP_END_LOADING,
-          key: LOADINGS.ENTRANCES_COORDINATES
-        });
+export const fetchAllEntrancesCoordinates = () => dispatch => {
+  dispatch({
+    type: FETCH_MAP_START_LOADING,
+    key: LOADINGS.ENTRANCES_COORDINATES
+  });
+  return fetchWithRetry(makeUrl(getMapEntrancesCoordinatesUrl, MAX_BOUNDS))
+    .then(text => {
+      dispatch({
+        type: FETCH_MAP_ENTRANCES_COORDINATES_SUCCESS,
+        data: JSON.parse(text)
       });
-  };
-
-  thunkToDebounce.meta = {
-    debounce: {
-      time: 500,
-      key: 'FETCH_MAP_ENTRANCES'
-    }
-  };
-
-  return thunkToDebounce;
+    })
+    .catch(error => {
+      dispatch({
+        type: FETCH_MAP_ENTRANCES_COORDINATES_FAILURE,
+        error: makeErrorMessage(
+          error.message,
+          `Fetching all entrances coordinates`
+        )
+      });
+    })
+    .finally(() => {
+      dispatch({
+        type: FETCH_MAP_END_LOADING,
+        key: LOADINGS.ENTRANCES_COORDINATES
+      });
+    });
 };
 
 export const fetchEntrances = criteria => {
@@ -249,18 +241,3 @@ export const fetchOrganizations = criteria => {
 
   return thunkToDebounce;
 };
-
-export const changeZoom = zoom => ({
-  type: CHANGE_ZOOM,
-  zoom
-});
-
-export const focusOnLocation = location => ({
-  type: FOCUS_ON_LOCATION,
-  location
-});
-
-export const changeLocation = location => ({
-  type: CHANGE_LOCATION,
-  location
-});

--- a/packages/web-app/src/components/appli/Massif/MapMassif.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { GeoJSON, useMap, useMapEvents } from 'react-leaflet';
+import { GeoJSON, useMap, useMapEvent } from 'react-leaflet';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
 
@@ -10,39 +10,65 @@ import useHeatLayer, {
 import useMarkers, {
   MarkerGlobalCss
 } from '../../common/Maps/common/Markers/useMarkers';
+import { EntrancePopup } from '../../common/Maps/common/Markers/Components';
 import {
-  EntranceMarker,
-  EntrancePopup
-} from '../../common/Maps/common/Markers/Components';
-import { MARKERS_LIMIT } from '../../common/Maps/MapClusters/constants';
+  MARKERS_LIMIT,
+  getEntranceCircleStyle
+} from '../../common/Maps/MapClusters/constants';
 import { makeUrl } from '../../../actions/utils';
 import {
   getMapEntrancesCoordinatesUrl,
   getMapEntrancesUrl
 } from '../../../conf/apiRoutes';
 
+const entrancePopup = entrance => <EntrancePopup entrance={entrance} />;
+const entranceTip = entrance => entrance?.name;
+
 const MapInternals = ({ geoJson, massifId }) => {
   const map = useMap();
-  const zoomRef = useRef(map.getZoom());
   const { updateHeatData } = useHeatLayer();
 
   const updateEntranceMarkers = useMarkers({
-    icon: EntranceMarker,
-    popupContent: entrance => <EntrancePopup entrance={entrance} />,
-    tooltipContent: entrance => entrance?.name
+    circleMarkerStyle: getEntranceCircleStyle,
+    popupContent: entrancePopup,
+    tooltipContent: entranceTip
   });
 
-  // Keep refs to the latest updater functions so fetchData never
-  // captures a stale closure (hexLayer may not be ready on first render).
+  // Refs to latest updaters — keeps fetchMarkers free of their unstable identities.
   const heatRef = useRef(updateHeatData);
   heatRef.current = updateHeatData;
   const markersRef = useRef(updateEntranceMarkers);
   markersRef.current = updateEntranceMarkers;
 
-  const fetchData = useCallback(() => {
-    const bounds = map.getBounds();
+  const heatCoordinatesRef = useRef([]);
+  const abortRef = useRef(null);
+
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    []
+  );
+
+  // Computed once; both the heat fetch and fitBounds need it.
+  const massifBounds = useMemo(() => L.geoJSON(geoJson).getBounds(), [geoJson]);
+
+  // moveend: at high zoom fetch viewport markers; at low zoom restore heatmap from cache.
+  const fetchMarkers = useCallback(() => {
     const zoom = map.getZoom();
-    zoomRef.current = zoom;
+    if (zoom < MARKERS_LIMIT) {
+      markersRef.current(null);
+      heatRef.current(heatCoordinatesRef.current);
+      return;
+    }
+
+    heatRef.current([]);
+
+    if (abortRef.current) abortRef.current.abort();
+    abortRef.current = new AbortController();
+    const { signal } = abortRef.current;
+
+    const bounds = map.getBounds();
     /* eslint-disable no-underscore-dangle */
     const criteria = {
       sw_lat: bounds._southWest.wrap().lat,
@@ -53,42 +79,69 @@ const MapInternals = ({ geoJson, massifId }) => {
     };
     /* eslint-enable no-underscore-dangle */
 
-    const isHighZoom = zoom >= MARKERS_LIMIT;
-    const url = isHighZoom
-      ? getMapEntrancesUrl
-      : getMapEntrancesCoordinatesUrl;
-
-    fetch(makeUrl(url, criteria))
-      .then(response => {
-        if (!response.ok) return [];
-        return response.json();
-      })
+    fetch(makeUrl(getMapEntrancesUrl, criteria), { signal })
+      .then(r => (r.ok ? r.json() : []))
       .then(data => {
-        if (!Array.isArray(data)) return;
-        if (isHighZoom) {
-          heatRef.current([]);
-          markersRef.current(data);
-        } else {
-          markersRef.current(null);
-          heatRef.current(data);
-        }
+        if (Array.isArray(data)) markersRef.current(data);
       })
-      .catch(() => {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+      .catch(err => {
+        if (err.name !== 'AbortError')
+          console.error('Failed to fetch map markers:', err); // eslint-disable-line no-console
+      });
   }, [map, massifId]);
 
-  useMapEvents({
-    zoomend: fetchData,
-    dragend: fetchData
-  });
+  // fetchMarkersRef lets effects call the latest fetchMarkers without adding it as a dep.
+  const fetchMarkersRef = useRef(null);
+  fetchMarkersRef.current = fetchMarkers;
 
+  useMapEvent('moveend', fetchMarkers);
+
+  // One-shot heat fetch for the entire massif bbox.
+  // The hexbin layer filters client-side; no re-fetch needed on pan/zoom.
+  // After storing the data, re-run the current zoom logic (via fetchMarkersRef) so the
+  // heatmap is displayed immediately if still at low zoom - avoids reading map.getZoom()
+  // asynchronously (race condition).
+  //
+  // Dep note: massifBounds is derived from geoJson via useMemo, and geoJson itself is
+  // memoized on geogPolygon (a string prop) in MapMassif. Leaflet's LatLngBounds has no
+  // referential equality, so this effect re-fires whenever massifBounds is a new object ;
+  // which only happens when geoJson changes reference. As long as geoJson stays stable
+  // (string prop → parsed once), this fires exactly once. If geoJson ever comes from
+  // Redux or a fetch, ensure its reference is stable to avoid double-fetching here.
   useEffect(() => {
-    const bounds = L.geoJSON(geoJson).getBounds();
-    if (bounds.isValid()) {
-      map.fitBounds(bounds);
+    if (!massifBounds.isValid()) return;
+    const sw = massifBounds.getSouthWest();
+    const ne = massifBounds.getNorthEast();
+    const controller = new AbortController();
+    fetch(
+      makeUrl(getMapEntrancesCoordinatesUrl, {
+        sw_lat: sw.lat,
+        sw_lng: sw.lng,
+        ne_lat: ne.lat,
+        ne_lng: ne.lng,
+        massif: massifId
+      }),
+      { signal: controller.signal }
+    )
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (!Array.isArray(data)) return;
+        heatCoordinatesRef.current = data;
+        fetchMarkersRef.current();
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [massifBounds, massifId]);
+
+  // Fit the map to the massif bounds once, triggering moveend → fetchMarkers.
+  // If there's no polygon, moveend won't fire, so we call fetchMarkers manually.
+  useEffect(() => {
+    if (!massifBounds.isValid()) {
+      fetchMarkersRef.current();
+      return;
     }
-    fetchData();
-  }, [map, geoJson, fetchData]);
+    map.fitBounds(massifBounds);
+  }, [massifBounds, map]);
 
   return (
     <>

--- a/packages/web-app/src/components/appli/Massif/MapMassif.property.test.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.property.test.jsx
@@ -20,14 +20,19 @@ jest.mock('react-leaflet', () => {
       }),
       fitBounds: jest.fn()
     }),
-    useMapEvents: () => null,
+    useMapEvent: jest.fn(),
+    useMapEvents: jest.fn(),
     GeoJSON: () => React.createElement('div', { 'data-testid': 'geojson' })
   };
 });
 
 jest.mock('leaflet', () => ({
   geoJSON: () => ({
-    getBounds: () => ({ isValid: () => true })
+    getBounds: () => ({
+      isValid: () => true,
+      getSouthWest: () => ({ lat: -10, lng: -10 }),
+      getNorthEast: () => ({ lat: 10, lng: 10 })
+    })
   })
 }));
 

--- a/packages/web-app/src/components/appli/Massif/MapMassif.test.jsx
+++ b/packages/web-app/src/components/appli/Massif/MapMassif.test.jsx
@@ -20,14 +20,19 @@ jest.mock('react-leaflet', () => {
       }),
       fitBounds: jest.fn()
     }),
-    useMapEvents: () => null,
+    useMapEvent: jest.fn(),
+    useMapEvents: jest.fn(),
     GeoJSON: () => React.createElement('div', { 'data-testid': 'geojson' })
   };
 });
 
 jest.mock('leaflet', () => ({
   geoJSON: () => ({
-    getBounds: () => ({ isValid: () => true })
+    getBounds: () => ({
+      isValid: () => true,
+      getSouthWest: () => ({ lat: -10, lng: -10 }),
+      getNorthEast: () => ({ lat: 10, lng: 10 })
+    })
   })
 }));
 
@@ -153,14 +158,12 @@ describe('MapMassif', () => {
 
       render(<MapMassif massifId={42} geogPolygon={samplePolygon} />);
 
+      // At high zoom: heat coordinates are fetched first, then after the response
+      // fetchMarkers fires and fetches viewport entrance markers.
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
+        const urls = global.fetch.mock.calls.map(([url]) => url);
+        expect(urls.some(url => url.includes('/entrances?'))).toBe(true);
       });
-
-      expect(global.fetch.mock.calls[0][0]).toContain('/entrances?');
-      expect(global.fetch.mock.calls[0][0]).not.toContain(
-        'entrancesCoordinates'
-      );
     });
 
     it('calls updateEntranceMarkers with entrance objects', async () => {

--- a/packages/web-app/src/components/common/AppBar/User.jsx
+++ b/packages/web-app/src/components/common/AppBar/User.jsx
@@ -115,7 +115,7 @@ const UserMenu = ({
           <Typography variant="body2" color="text.primary">
             <Translate
               id="Logged as {userNickname}"
-              values={{ userNickname: <strong>{userNickname}</strong> }}
+              values={{ userNickname: <strong key="userNickname">{userNickname}</strong> }}
             />
           </Typography>
           <Typography variant="caption" color="text.secondary">

--- a/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
@@ -1,13 +1,12 @@
 import React, { useEffect } from 'react';
 import { includes, values } from 'ramda';
 import PropTypes from 'prop-types';
-
 import { heatmapTypes } from './DataControl';
 import useMarkers, { MarkerGlobalCss } from '../common/Markers/useMarkers';
+import { getEntranceCircleStyle } from './constants';
 import {
   OrganizationMarker,
   OrganizationPopup,
-  EntranceMarker,
   EntrancePopup,
   NetworkMarker,
   NetworkPopup
@@ -22,6 +21,15 @@ const isEntrances = includes(markerTypes.ENTRANCES);
 const isNetworks = includes(markerTypes.NETWORKS);
 const isOrganizations = includes(markerTypes.ORGANIZATIONS);
 
+const entrancePopup = entrance => <EntrancePopup entrance={entrance} />;
+const entranceTip = entrance => entrance?.name;
+const networkPopup = network => <NetworkPopup network={network} />;
+const networkTip = network => network?.name;
+const organizationPopup = organization => (
+  <OrganizationPopup organization={organization} />
+);
+const organizationTip = organization => organization?.name;
+
 const Markers = ({
   visibleMarkers,
   organizations = [],
@@ -29,49 +37,34 @@ const Markers = ({
   networks = []
 }) => {
   const updateEntranceMarkers = useMarkers({
-    icon: EntranceMarker,
-    popupContent: entrance => <EntrancePopup entrance={entrance} />,
-    tooltipContent: entrance => entrance?.name
+    circleMarkerStyle: getEntranceCircleStyle,
+    popupContent: entrancePopup,
+    tooltipContent: entranceTip
   });
   const updateNetworkMarkers = useMarkers({
     icon: NetworkMarker,
-    popupContent: network => <NetworkPopup network={network} />,
-    tooltipContent: network => network?.name
+    popupContent: networkPopup,
+    tooltipContent: networkTip
   });
   const updateOrganizationMarkers = useMarkers({
     icon: OrganizationMarker,
-    popupContent: organization => (
-      <OrganizationPopup organization={organization} />
-    ),
-    tooltipContent: organization => organization?.name
+    popupContent: organizationPopup,
+    tooltipContent: organizationTip
   });
 
   useEffect(() => {
-    if (isEntrances(visibleMarkers)) {
-      updateEntranceMarkers(entrances);
-    } else {
-      updateEntranceMarkers(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entrances, visibleMarkers]);
+    updateEntranceMarkers(isEntrances(visibleMarkers) ? entrances : null);
+  }, [entrances, visibleMarkers, updateEntranceMarkers]);
 
   useEffect(() => {
-    if (isNetworks(visibleMarkers)) {
-      updateNetworkMarkers(networks);
-    } else {
-      updateNetworkMarkers(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [networks, visibleMarkers]);
+    updateNetworkMarkers(isNetworks(visibleMarkers) ? networks : null);
+  }, [networks, visibleMarkers, updateNetworkMarkers]);
 
   useEffect(() => {
-    if (isOrganizations(visibleMarkers)) {
-      updateOrganizationMarkers(organizations);
-    } else {
-      updateOrganizationMarkers(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [organizations, visibleMarkers]);
+    updateOrganizationMarkers(
+      isOrganizations(visibleMarkers) ? organizations : null
+    );
+  }, [organizations, visibleMarkers, updateOrganizationMarkers]);
 
   return MarkerGlobalCss;
 };

--- a/packages/web-app/src/components/common/Maps/MapClusters/constants.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/constants.js
@@ -1,15 +1,60 @@
 import { blue, brown } from '@mui/material/colors';
 
+export const CAVE_SIZE = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large'
+};
+
+// Circle marker styles per cave size category (radius in px, colors from brown palette).
+const CAVE_SIZE_STYLE = {
+  [CAVE_SIZE.SMALL]: {
+    radius: 6,
+    color: brown[700],
+    weight: 1,
+    fillColor: brown[400],
+    fillOpacity: 0.85
+  },
+  [CAVE_SIZE.MEDIUM]: {
+    radius: 10,
+    color: brown[900],
+    weight: 1,
+    fillColor: brown[700],
+    fillOpacity: 0.85
+  },
+  [CAVE_SIZE.LARGE]: {
+    radius: 14,
+    color: brown[900],
+    weight: 1,
+    fillColor: brown[900],
+    fillOpacity: 0.85
+  }
+};
+
+export const getCaveSize = entrance => {
+  const depth = entrance.depth ?? 0;
+  const length = entrance.length ?? 0;
+  // Define thresholds for cave size categories based on depth and length.
+  if (depth >= 100 || length >= 1000) return CAVE_SIZE.LARGE;
+  if (depth >= 30 || length >= 200) return CAVE_SIZE.MEDIUM;
+  return CAVE_SIZE.SMALL;
+};
+
+export const getEntranceCircleStyle = entrance =>
+  CAVE_SIZE_STYLE[getCaveSize(entrance)];
+
 export const MARKERS_LIMIT = 13;
 
 // Related to Heat map
-const HEX_MIN_RADIUS = 8;
-export const HEX_OPACITY = 0.65;
+const HEX_MIN_RADIUS = 10;
+export const HEX_OPACITY = 0.75;
 export const HEX_MAX_RADIUS = 14;
 export const HEX_FLY_TO_DURATION = 1;
 export const HEX_RADIUS_RANGE = [HEX_MIN_RADIUS, HEX_MAX_RADIUS];
-export const ENTRANCE_HEAT_COLORS = [brown[100], brown[900]];
-export const NETWORK_HEAT_COLORS = [blue[100], blue[900]];
+// Start at [200] to avoid near-white shades that disappear
+// on light OSM tiles, especially combined with the hex opacity.
+export const ENTRANCE_HEAT_COLORS = [brown[200], brown[900]];
+export const NETWORK_HEAT_COLORS = [blue[200], blue[900]];
 export const HEX_LAYER_OPTIONS = {
   radius: HEX_MAX_RADIUS,
   opacity: HEX_OPACITY,
@@ -17,7 +62,7 @@ export const HEX_LAYER_OPTIONS = {
 };
 
 // For visibility we changes the options on
-export const HEX_DETAILS_OPACITY = 0.75;
+export const HEX_DETAILS_OPACITY = 0.85;
 export const HEX_DETAILS_ZOOM = 8;
 const HEX_DETAILS_MIN_RADIUS = 10;
 export const HEX_DETAILS_RADIUS_RANGE = [

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useMapEvent } from 'react-leaflet';
+import { useMap, useMapEvent } from 'react-leaflet';
 import { without, pipe, append, uniq } from 'ramda';
 
 import DataControl, { heatmapTypes, markerTypes } from './DataControl';
@@ -23,7 +23,6 @@ const HydratedMap = ({
   networkMarkers = [],
   organizations,
   projectionsList,
-  zoom,
   onUpdate
 }) => {
   const { updateHeatData } = useHeatLayer(entrances);
@@ -38,15 +37,31 @@ const HydratedMap = ({
         .map(([k]) => k),
     [selectedMarkers]
   );
-  const [visibleHeat, setVisibleHeat] = useState(selectedHeat);
-  const [visibleMarkers, setVisibleMarkers] = useState([]);
-  const zoomState = useRef(ZOOM_STATE.HEAT);
-  const prevZoom = useRef(zoom);
+  const map = useMap();
+  const initialZoom = useRef(map.getZoom()).current;
+  const isInitiallyZoomedIn = initialZoom >= MARKERS_LIMIT;
+  const [visibleHeat, setVisibleHeat] = useState(isInitiallyZoomedIn ? heatmapTypes.NONE : selectedHeat);
+  const [visibleMarkers, setVisibleMarkers] = useState(isInitiallyZoomedIn ? [selectedHeat] : []);
+  const zoomState = useRef(isInitiallyZoomedIn ? ZOOM_STATE.MARKERS : ZOOM_STATE.HEAT);
+  const prevZoom = useRef(initialZoom);
   // Refs to avoid stale closures in event handlers (zoomend, handleUpdateHeat)
   const selectedHeatRef = useRef(selectedHeat);
   selectedHeatRef.current = selectedHeat;
   const selectedMarkersListRef = useRef(selectedMarkersList);
   selectedMarkersListRef.current = selectedMarkersList;
+
+  // Keep onUpdate ref-stable so handleUpdate's useCallback doesn't depend on it
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+
+  const handleUpdate = useCallback(() => {
+    onUpdateRef.current({
+      markers: visibleMarkers,
+      zoom: map.getZoom(),
+      center: map.getCenter(),
+      bounds: map.getBounds()
+    });
+  }, [visibleMarkers, map]);
 
   useEffect(() => {
     if (zoomState.current === ZOOM_STATE.MARKERS) {
@@ -81,8 +96,10 @@ const HydratedMap = ({
     }
   }, []);
 
-  // on zoom handle what is visible between heat & markers
-  const map = useMapEvent('zoomend', () => {
+  // zoomend: manages heatmap ↔ markers visibility only.
+  // It does NOT call handleUpdate directly - moveend fires right after zoomend
+  // and handles that, ensuring the correct final position is always used.
+  useMapEvent('zoomend', () => {
     const currentZoom = map.getZoom();
     const isZoomingIn = prevZoom.current < currentZoom;
     // When close enough we want to display disable heatmap ans show markers
@@ -99,9 +116,8 @@ const HydratedMap = ({
         setVisibleHeat('none');
         zoomState.current = ZOOM_STATE.MARKERS;
       }
-    }
-    // When too far we want to switch back to the heatmap
-    if (!isZoomingIn && currentZoom < MARKERS_LIMIT) {
+    } else if (!isZoomingIn && currentZoom < MARKERS_LIMIT) {
+      // When too far we want to switch back to the heatmap
       setVisibleHeat(selectedHeatRef.current);
       setVisibleMarkers(selectedMarkersListRef.current);
       zoomState.current = ZOOM_STATE.HEAT;
@@ -109,27 +125,18 @@ const HydratedMap = ({
     prevZoom.current = currentZoom;
   });
 
-  const handleUpdate = () => {
-    onUpdate({
-      heat: visibleHeat === 'none' ? null : visibleHeat,
-      markers: visibleMarkers,
-      zoom: map.getZoom(),
-      center: map.getCenter(),
-      bounds: map.getBounds()
-    });
-  };
+  // moveend fires after ALL map movement has finished - including mobile inertia.
+  // Using moveend instead of dragend ensures map.getBounds() returns the final
+  // resting position, not a mid-inertia snapshot. It also covers zoom events
+  // since Leaflet fires moveend after zoomend.
+  useMapEvent('moveend', handleUpdate);
 
-  // Update data on leaflet events or user events
-  useMapEvent('zoomend', () => {
-    handleUpdate();
-  });
-  useMapEvent('dragend', () => {
-    handleUpdate();
-  });
+  // Called when visibility changes (zoom threshold crossing or DataControl change).
+  // handleUpdate is stable as long as visibleMarkers doesn't change,
+  // so this effect only re-runs when the markers to fetch actually change.
   useEffect(() => {
     handleUpdate();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visibleMarkers, visibleHeat]);
+  }, [handleUpdate]);
 
   // Update visible heat layer
   useEffect(() => {
@@ -174,7 +181,7 @@ const Index = ({ center, zoom, isSideMenuOpen, mapRef, ...props }) => (
     isSideMenuOpen={isSideMenuOpen}
     isLocateControl
     mapRef={mapRef}>
-    <HydratedMap {...props} zoom={zoom} />
+    <HydratedMap {...props} />
   </CustomMapContainer>
 );
 
@@ -192,13 +199,13 @@ HydratedMap.propTypes = {
   networkMarkers: PropTypes.arrayOf(markerType),
   organizations: PropTypes.arrayOf(markerType),
   projectionsList: PropTypes.arrayOf(PropTypes.shape({})),
-  zoom: PropTypes.number.isRequired,
   onUpdate: PropTypes.func
 };
 
 Index.propTypes = {
   isSideMenuOpen: PropTypes.bool,
   center: PropTypes.arrayOf(PropTypes.number),
+  zoom: PropTypes.number,
   mapRef: PropTypes.shape({ current: PropTypes.any }),
   ...HydratedMap.propTypes
 };

--- a/packages/web-app/src/components/common/Maps/MapClusters/useHeatLayer.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/useHeatLayer.js
@@ -25,6 +25,9 @@ import {
 export const HexGlobalCss = (
   <GlobalStyles
     styles="
+& .hexbin-grid {
+  cursor: pointer;
+}
 & .hexbin-hexagon {
   stroke: #000;
   stroke-width: .5px;
@@ -50,10 +53,20 @@ export const HexGlobalCss = (
 const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
   const { formatMessage } = useIntl();
   const [hexLayer, setHexLayer] = useState();
-  const lastMoveEndTs = useRef(0);
+  const isDraggingRef = useRef(false);
+  // Pending requestAnimationFrame id - coalesces rapid .data() calls into one frame.
+  const rafRef = useRef(null);
+  const dragEndTimerRef = useRef(null);
+  // Skip colorRange + hoverHandler re-registration when the type hasn't changed.
+  const lastTypeRef = useRef(null);
 
   // On zoom lvl, hex opacity and size can change
   const map = useMapEvent('zoomend', () => {
+    // Hide any visible tooltip - the hovered hex may disappear mid-zoom
+    // leaving no mouseout to clean it up. We hide rather than remove so the
+    // div stays alive in the hoverHandler's closure and can be reused on next hover.
+    d3.selectAll('.hexbin-tooltip').style('visibility', 'hidden');
+
     if (!isNil(hexLayer)) {
       if (map.getZoom() > HEX_DETAILS_ZOOM) {
         hexLayer
@@ -65,12 +78,20 @@ const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
     }
   });
 
+  // Reset type cache when the hexLayer is (re)initialized.
+  useEffect(() => {
+    lastTypeRef.current = null;
+  }, [hexLayer]);
+
   const updateHeatData = useCallback(
     (newData, newType = type) => {
-      if (!isNil(hexLayer)) {
+      if (isNil(hexLayer)) return;
+
+      // colorRange and hoverHandler only need updating when the type switches.
+      // Skipping the D3 event re-registration on every pan saves work.
+      if (newType !== lastTypeRef.current) {
         // Remove previous tooltip (avoid some bug)
         d3.selectAll('.hexbin-tooltip').remove();
-
         hexLayer
           .colorRange(
             newType === heatmapTypes.NETWORKS
@@ -87,21 +108,37 @@ const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
                 })
               ]
             })
-          )
-          .data(newData);
+          );
+        lastTypeRef.current = newType;
       }
+
+      // Coalesce rapid calls into a single frame - cancels any pending RAF
+      // so only the latest data update is rendered, without blocking the current frame.
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        hexLayer.data(newData);
+      });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [hexLayer]
   );
 
-  useMapEvent('moveend', () => {
-    lastMoveEndTs.current = Date.now();
+  useMapEvent('dragstart', () => {
+    isDraggingRef.current = true;
+  });
+
+  useMapEvent('dragend', () => {
+    // Defer reset past the click event that may fire synchronously on the
+    // mouseup/touchend that ends the drag, preventing a spurious flyTo.
+    dragEndTimerRef.current = setTimeout(() => {
+      dragEndTimerRef.current = null;
+      isDraggingRef.current = false;
+    }, 0);
   });
 
   const flyToHex = (_, hexPoints) => {
-    const timeSinceMapMoveMs = Date.now() - lastMoveEndTs.current;
-    if (timeSinceMapMoveMs < 20) return; // Prevent drag click
+    if (isDraggingRef.current) return;
 
     d3.selectAll('.hexbin-tooltip').attr('opacity', 0);
     const bounds = new L.LatLngBounds(
@@ -117,6 +154,8 @@ const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
     // Add hex layer to the map
     setHexLayer(L.hexbinLayer(HEX_LAYER_OPTIONS).addTo(map));
     return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (dragEndTimerRef.current) clearTimeout(dragEndTimerRef.current);
       // Remove tooltip
       d3.selectAll('.hexbin-tooltip').remove();
     };
@@ -125,8 +164,8 @@ const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
 
   useEffect(() => {
     if (!isNil(hexLayer)) {
-      // Initialize Hex scaling
-      hexLayer.colorScale();
+      // Initialize Hex scaling with sqrt to amplify differences at low densities
+      hexLayer.colorScale(d3.scaleSqrt());
 
       hexLayer
         .radiusRange(HEX_RADIUS_RANGE)

--- a/packages/web-app/src/components/common/Maps/common/GeocodingControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/GeocodingControl.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useMap } from 'react-leaflet';
-import * as L from 'leaflet';
 import { styled } from '@mui/material/styles';
 import { TextField, Paper, List, ListItem, ListItemAvatar, ListItemText, CircularProgress, InputAdornment } from '@mui/material';
 import { LocationOn } from '@mui/icons-material';
@@ -122,16 +121,25 @@ const GeocodingControl = ({ onLocationSelect, onOrganizationSelect }) => {
 
     const { lat, lng } = selectedEntrance;
 
-    const isTargetMarker = layer =>
-      layer instanceof L.Marker &&
-      Math.abs(layer.getLatLng().lat - lat) < 0.001 &&
-      Math.abs(layer.getLatLng().lng - lng) < 0.001;
+    const isTargetMarker = layer => {
+      if (!layer.getLatLng || !layer.getPopup || !layer.getPopup()) return false;
+      const pos = layer.getLatLng();
+      return (
+        Math.abs(pos.lat - lat) < 0.001 &&
+        Math.abs(pos.lng - lng) < 0.001
+      );
+    };
+
+    const safeOpenPopup = layer => {
+      // RAF ensures canvas-rendered CircleMarkers are drawn before popup opens
+      requestAnimationFrame(() => layer.openPopup());
+    };
 
     // Check markers already on the map
     let found = false;
     map.eachLayer(layer => {
       if (!found && isTargetMarker(layer)) {
-        layer.openPopup();
+        safeOpenPopup(layer);
         found = true;
       }
     });
@@ -143,7 +151,7 @@ const GeocodingControl = ({ onLocationSelect, onOrganizationSelect }) => {
     // Otherwise listen for new layers being added
     const onLayerAdd = e => {
       if (isTargetMarker(e.layer)) {
-        e.layer.openPopup();
+        safeOpenPopup(e.layer);
         setSelectedEntrance(null);
         map.off('layeradd', onLayerAdd);
       }

--- a/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
+++ b/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { styled } from '@mui/material/styles';
 import {
   MapContainer,
@@ -36,21 +36,6 @@ const Centerer = ({ center, zoom }) => {
 
 const baseLayerChange = event => {
   window.localStorage.setItem('selectedBaseLayer', event.name);
-};
-
-const handleResize = map => {
-  if (!map) return;
-  const myObserver = new ResizeObserver(() => {
-    setTimeout(() => {
-      try {
-        map.invalidateSize(true);
-      } catch (e) {
-        // Silently ignore errors during invalidateSize
-      }
-    }, 100);
-  });
-  myObserver.observe(map.getContainer());
-  map.on('baselayerchange', baseLayerChange);
 };
 
 Centerer.propTypes = {
@@ -104,36 +89,83 @@ const CustomMapContainer = ({
   children,
   forceCentering,
   mapRef
-}) => (
-  <Wrapper $wholePage={wholePage}>
-    <MapContainer
-      style={{ height: '100%', width: '100%', ...style }}
-      wholePage={wholePage}
-      center={center}
-      zoom={zoom}
-      dragging={dragging}
-      scrollWheelZoom={scrollWheelZoom}
-      isSideMenuOpen={isSideMenuOpen}
-      minZoom={1}
-      ref={(ref) => {
-        handleResize(ref);
-        if (mapRef) mapRef.current = ref;
-      }}
-      preferCanvas>
-      {isFullscreenAllowed && shouldChangeControlInFullscreen && (
-        <FullscreenInteraction dragging={dragging} scrollWheelZoom={scrollWheelZoom} />
-      )}
-      {isFullscreenAllowed && !shouldChangeControlInFullscreen && (
-        <FullscreenControl forceSeparateButton="true" />
-      )}
-      {forceCentering && <Centerer center={center} zoom={zoom} />}
-      {isLocateControl && <LocateControl />}
-      <ScaleControl position="bottomright" />
-      <LayersControl />
-      {children}
-    </MapContainer>
-  </Wrapper>
-);
+}) => {
+  const observerRef = useRef(null);
+  const mapInstanceRef = useRef(null);
+  const pendingStabilizeRef = useRef(null);
+  const mapRefPropRef = useRef(mapRef);
+  mapRefPropRef.current = mapRef;
+
+  const mapRefCallback = useCallback((map) => {
+    if (mapRefPropRef.current) mapRefPropRef.current.current = map;
+    if (!map || map === mapInstanceRef.current) return;
+    mapInstanceRef.current = map;
+
+    // Clean up previous observer and any pending timeout
+    clearTimeout(pendingStabilizeRef.current);
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    const container = map.getContainer();
+
+    // Two-phase resize handling:
+    // Phase 1 (during transition): invalidateSize({ pan: false }) on every notification
+    //   → Leaflet redraws tiles for the growing container without panning,
+    //     so the map reveals more geographic area smoothly. No moveend fired.
+    // Phase 2 (after transition): one invalidateSize({ animate: false }) once size
+    //   settles → corrects the geographic center, fires moveend once.
+    const observer = new ResizeObserver(() => {
+      try { map.invalidateSize({ animate: false, pan: false }); } catch (e) { /* ignore */ }
+      clearTimeout(pendingStabilizeRef.current);
+      pendingStabilizeRef.current = setTimeout(() => {
+        pendingStabilizeRef.current = null;
+        try { map.invalidateSize({ animate: false }); } catch (e) { /* ignore */ }
+      }, 100);
+    });
+    observer.observe(container);
+    observerRef.current = observer;
+
+    map.on('baselayerchange', baseLayerChange);
+  }, []);
+
+  // Disconnect observer and remove listeners on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(pendingStabilizeRef.current);
+      observerRef.current?.disconnect();
+      mapInstanceRef.current?.off('baselayerchange', baseLayerChange);
+    };
+  }, []);
+
+  return (
+    <Wrapper $wholePage={wholePage}>
+      <MapContainer
+        style={{ height: '100%', width: '100%', ...style }}
+        wholePage={wholePage}
+        center={center}
+        zoom={zoom}
+        dragging={dragging}
+        scrollWheelZoom={scrollWheelZoom}
+        isSideMenuOpen={isSideMenuOpen}
+        minZoom={1}
+        ref={mapRefCallback}
+        preferCanvas>
+        {isFullscreenAllowed && shouldChangeControlInFullscreen && (
+          <FullscreenInteraction dragging={dragging} scrollWheelZoom={scrollWheelZoom} />
+        )}
+        {isFullscreenAllowed && !shouldChangeControlInFullscreen && (
+          <FullscreenControl forceSeparateButton="true" />
+        )}
+        {forceCentering && <Centerer center={center} zoom={zoom} />}
+        {isLocateControl && <LocateControl />}
+        <ScaleControl position="bottomright" />
+        <LayersControl />
+        {children}
+      </MapContainer>
+    </Wrapper>
+  );
+};
 
 CustomMapContainer.propTypes = {
   wholePage: PropTypes.bool,

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/CoordinatesMarker.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/CoordinatesMarker.jsx
@@ -20,7 +20,7 @@ export const CoordinatesMarker = L.divIcon({
   html: renderToString(<CoordinatesIcon />),
   iconSize: new L.Point(25, 41),
   iconAnchor: [12.5, 41],
-  className: 'fade-in-markers'
+  className: ''
 });
 
 export default CoordinatesMarker;

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/EntranceMarker.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/EntranceMarker.jsx
@@ -20,7 +20,7 @@ export const EntranceMarker = L.divIcon({
   html: renderToString(<EntranceIconMap />),
   iconSize: new L.Point(12.5, 25),
   iconAnchor: [6.25, 25],
-  className: 'fade-in-markers'
+  className: ''
 });
 
 export default EntranceMarker;

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/NetworkMarker.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/NetworkMarker.jsx
@@ -20,7 +20,7 @@ export const NetworkMarker = L.divIcon({
   html: renderToString(<NetworkIcon />),
   iconSize: [24, 24],
   iconAnchor: [12, 24],
-  className: 'fade-in-markers'
+  className: ''
 });
 
 export default NetworkMarker;

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationMarker.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationMarker.jsx
@@ -24,7 +24,7 @@ export const OrganizationMarker = L.divIcon({
   html: renderToString(<OrganizationIcon />),
   iconSize: [24, 24],
   iconAnchor: [12, 24],
-  className: 'fade-in-markers'
+  className: ''
 });
 
 export default OrganizationMarker;

--- a/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
+++ b/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
@@ -1,35 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { useMap } from 'react-leaflet';
 import * as L from 'leaflet';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router';
-import {
-  ThemeProvider,
-  StyledEngineProvider,
-  keyframes,
-  css
-} from '@mui/material/styles';
+import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { GlobalStyles } from '@mui/material';
 import { IntlProvider } from 'react-intl';
 import { useSelector } from 'react-redux';
 import grottoTheme from '../../../../../conf/grottoTheme';
 
-const fadeIn = keyframes`
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-`;
-
 export const MarkerGlobalCss = (
   <GlobalStyles
-    styles={css`
-      & .fade-in-markers {
-        animation: 0.3s ${fadeIn} ease-out;
-      }
-
+    styles={`
       .leaflet-container {
         font-size: 1rem;
       }
@@ -39,63 +21,132 @@ export const MarkerGlobalCss = (
 
 const useMarkers = ({
   icon,
+  circleMarkerStyle,
   popupContent = null,
   tooltipContent = null,
   shouldFitMapBound = false
 }) => {
   const map = useMap();
-  const [canvas] = useState(L.canvas());
-  const [markers, setMarkers] = useState([]);
+  // Map<id, L.Marker> for O(1) lookups during diff
+  const markersRef = useRef(new Map());
   const { locale, messages } = useSelector(state => state.intl);
-  const options = { icon, renderer: canvas };
 
-  const makeMarkers = newMarkers =>
-    newMarkers.map(marker => {
+  // Store locale/messages in refs so renderPopupHtml never goes stale
+  // but doesn't invalidate the callback chain either
+  const localeRef = useRef(locale);
+  const messagesRef = useRef(messages);
+  localeRef.current = locale;
+  messagesRef.current = messages;
+
+  const renderPopupHtml = useCallback(
+    marker => {
+      const loc = localeRef.current;
+      const msgs = messagesRef.current;
+      return renderToString(
+        <IntlProvider locale={loc} messages={msgs[loc]}>
+          <StaticRouter location="/">
+            <StyledEngineProvider injectFirst>
+              <ThemeProvider theme={grottoTheme}>
+                {popupContent(marker)}
+              </ThemeProvider>
+            </StyledEngineProvider>
+          </StaticRouter>
+        </IntlProvider>
+      );
+    },
+    [popupContent]
+  );
+
+  const createLeafletMarker = useCallback(
+    marker => {
       const { latitude, longitude } = marker;
-      const markerEl = L.marker([latitude, longitude], options);
 
+      let markerEl;
+      if (circleMarkerStyle) {
+        const style =
+          typeof circleMarkerStyle === 'function'
+            ? circleMarkerStyle(marker)
+            : circleMarkerStyle;
+        markerEl = L.circleMarker([latitude, longitude], style);
+      } else {
+        markerEl = L.marker([latitude, longitude], { icon });
+      }
+
+      // Lazy popup: content is rendered only when the popup is opened
       if (popupContent) {
-        markerEl.bindPopup(
-          renderToString(
-            // Without theme provider the CSS doesn't work properly
-            // It's makes the map slower when there is a lot of markers
-            // One way to optimize it would be to not use MUI for the markers
-            <IntlProvider locale={locale} messages={messages[locale]}>
-              <StaticRouter location="/">
-                <StyledEngineProvider injectFirst>
-                  <ThemeProvider theme={grottoTheme}>
-                    {popupContent(marker)}
-                  </ThemeProvider>
-                </StyledEngineProvider>
-              </StaticRouter>
-            </IntlProvider>
-          )
-        );
+        markerEl.bindPopup(() => renderPopupHtml(marker));
       }
 
       if (tooltipContent) {
         markerEl.bindTooltip(`${tooltipContent(marker)}`, {});
+        // On touch devices a tap fires both tooltip and popup; hide tooltip on click
+        // (fires before popupopen, works reliably for both L.marker and L.circleMarker)
+        markerEl.on('click', () => markerEl.closeTooltip());
       }
 
       return markerEl;
-    });
+    },
+    [icon, circleMarkerStyle, popupContent, renderPopupHtml, tooltipContent]
+  );
 
+  const updateMarkers = useCallback(
+    newMarkers => {
+      const currentMap = markersRef.current;
+
+      if (!newMarkers || newMarkers.length === 0) {
+        // Remove all markers
+        for (const m of currentMap.values()) m.remove();
+        currentMap.clear();
+        return;
+      }
+
+      const newIds = new Set();
+      for (const m of newMarkers) newIds.add(m.id);
+
+      // Remove markers no longer present
+      for (const [id, leafletMarker] of currentMap) {
+        if (!newIds.has(id)) {
+          leafletMarker.remove();
+          currentMap.delete(id);
+        }
+      }
+
+      // Add markers that are new
+      let addedCount = 0;
+      for (const marker of newMarkers) {
+        if (!currentMap.has(marker.id)) {
+          const leafletMarker = createLeafletMarker(marker);
+          leafletMarker.addTo(map);
+          currentMap.set(marker.id, leafletMarker);
+          addedCount += 1;
+        }
+      }
+
+      // Fit bounds on initial load if requested
+      if (
+        shouldFitMapBound &&
+        currentMap.size > 0 &&
+        addedCount === currentMap.size
+      ) {
+        map.fitBounds(
+          Array.from(currentMap.values()).map(m => m.getLatLng()),
+          { padding: [40, 40], maxZoom: 16 }
+        );
+      }
+    },
+    [map, createLeafletMarker, shouldFitMapBound]
+  );
+
+  // Cleanup all markers on unmount
   useEffect(() => {
-    for (const marker of markers) marker.addTo(map);
+    const currentMarkers = markersRef.current;
+    return () => {
+      for (const m of currentMarkers.values()) m.remove();
+      currentMarkers.clear();
+    };
+  }, []);
 
-    if (shouldFitMapBound && markers.length > 0) {
-      map.fitBounds(
-        markers.map(e => e.getLatLng()),
-        { padding: [40, 40], maxZoom: 16 }
-      );
-    }
-  }, [markers, map, shouldFitMapBound]);
-
-  return newMarkers => {
-    for (const marker of markers) marker.remove(map);
-    if (newMarkers && newMarkers.length > 0)
-      setMarkers(makeMarkers(newMarkers));
-  };
+  return updateMarkers;
 };
 
 export default useMarkers;

--- a/packages/web-app/src/pages/Map.jsx
+++ b/packages/web-app/src/pages/Map.jsx
@@ -1,17 +1,15 @@
-import React, { useEffect, useRef, Suspense } from 'react';
+import React, { useCallback, useEffect, useRef, Suspense, useState } from 'react';
 import { includes } from 'ramda';
 import { useNavigate, generatePath, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import PageLoader from '../components/common/PageLoader';
 
 import {
-  changeLocation,
-  changeZoom,
   fetchNetworks,
-  fetchNetworksCoordinates,
+  fetchAllNetworksCoordinates,
   fetchOrganizations,
   fetchEntrances,
-  fetchEntrancesCoordinates
+  fetchAllEntrancesCoordinates
 } from '../actions/Map';
 import { fetchProjections } from '../actions/Projections';
 import useGeolocation from '../hooks/useGeolocation';
@@ -42,29 +40,26 @@ const Map = () => {
   const params = useParams();
   const { location: geoLocation, hasLocation } = useGeolocation();
   const mapRef = useRef(null);
-  const {
-    location,
-    zoom,
-    // TODO handle loading
-    // eslint-disable-next-line no-unused-vars
-    loadings,
-    networks,
-    networksCoordinates,
-    organizations,
-    entrances,
-    entrancesCoordinates
-  } = useSelector(state => state.map);
+  const [location, setLocation] = useState(defaultCoord);
+  const [zoom, setZoom] = useState(defaultZoom);
+  const networks = useSelector(state => state.map.networks);
+  const networksCoordinates = useSelector(
+    state => state.map.networksCoordinates
+  );
+  const organizations = useSelector(state => state.map.organizations);
+  const entrances = useSelector(state => state.map.entrances);
+  const entrancesCoordinates = useSelector(
+    state => state.map.entrancesCoordinates
+  );
   const { open } = useSelector(state => state.sideMenu);
   const { projections } = useSelector(state => state.projections);
 
-  const handleUpdate = ({ heat, markers, zoom: newZoom, center, bounds }) => {
-    const newPath = generatePath('/ui/map/:target', {
-      target: encodeMapTarget(center, newZoom)
-    });
-    navigate(newPath, { replace: true });
-    dispatch(changeLocation(center));
-    dispatch(changeZoom(newZoom));
+  // urlDebounceRef: update the URL only once the user has truly settled,
+  // avoiding lagging due to URL updates.
+  // Leaflet always handles the visual movement immediately on its own.
+  const urlDebounceRef = useRef(null);
 
+  const handleUpdate = useCallback(({ markers, zoom: newZoom, center, bounds }) => {
     const criteria = {
       /* eslint-disable no-underscore-dangle */
       sw_lat: bounds._southWest.wrap().lat,
@@ -83,34 +78,55 @@ const Map = () => {
     if (includes('entrances', markers)) {
       dispatch(fetchEntrances(criteria));
     }
-    if (heat === 'networks') {
-      dispatch(fetchNetworksCoordinates(criteria));
-    }
-    if (heat === 'entrances') {
-      dispatch(fetchEntrancesCoordinates(criteria));
-    }
-  };
+
+    // Update the shareable URL after the user has settled
+    if (urlDebounceRef.current) clearTimeout(urlDebounceRef.current);
+    urlDebounceRef.current = setTimeout(() => {
+      urlDebounceRef.current = null;
+      navigate(
+        generatePath('/ui/map/:target', {
+          target: encodeMapTarget(center, newZoom)
+        }),
+        { replace: true }
+      );
+    }, 1000);
+  }, [dispatch, navigate]);
 
   useEffect(() => {
-    dispatch(fetchProjections());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      if (urlDebounceRef.current) clearTimeout(urlDebounceRef.current);
+    };
   }, []);
 
   useEffect(() => {
-    const target = decodeMapTarget(params.target);
+    dispatch(fetchProjections());
+    dispatch(fetchAllEntrancesCoordinates());
+    dispatch(fetchAllNetworksCoordinates());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Capture the URL target present when the component first mounts.
+  // The initial position only needs to be set once; after that Leaflet owns its position.
+  const initialTargetRef = useRef(params.target);
+
+  useEffect(() => {
+    const target = decodeMapTarget(initialTargetRef.current);
     if (target) {
-      dispatch(changeLocation({ lat: target.lat, lng: target.lng }));
-      dispatch(changeZoom(target.zoom));
+      setLocation({ lat: target.lat, lng: target.lng });
+      setZoom(target.zoom);
     } else {
-      dispatch(changeLocation(geoLocation));
-      dispatch(changeZoom(defaultZoom));
+      setLocation(geoLocation);
+      setZoom(defaultZoom);
     }
-  }, [dispatch, params.target, geoLocation]);
+  }, [geoLocation]);
 
   useEffect(() => {
     const target = decodeMapTarget(params.target);
-    const isDefaultTarget = target?.lat === defaultCoord.lat && target?.lng === defaultCoord.lng && target?.zoom === defaultZoom;
-    
+    const isDefaultTarget =
+      target?.lat === defaultCoord.lat &&
+      target?.lng === defaultCoord.lng &&
+      target?.zoom === defaultZoom;
+
     if (hasLocation && (!params.target || isDefaultTarget) && mapRef.current) {
       mapRef.current.setView([geoLocation.lat, geoLocation.lng], focusZoom);
     }

--- a/packages/web-app/src/reducers/Map.js
+++ b/packages/web-app/src/reducers/Map.js
@@ -1,7 +1,5 @@
 import { lensProp, set } from 'ramda';
 import {
-  CHANGE_LOCATION,
-  CHANGE_ZOOM,
   FETCH_MAP_ENTRANCES_COORDINATES_FAILURE,
   FETCH_MAP_ENTRANCES_COORDINATES_SUCCESS,
   FETCH_MAP_ENTRANCES_FAILURE,
@@ -12,12 +10,10 @@ import {
   FETCH_MAP_NETWORKS_SUCCESS,
   FETCH_MAP_ORGANIZATIONS_FAILURE,
   FETCH_MAP_ORGANIZATIONS_SUCCESS,
-  FOCUS_ON_LOCATION,
   FETCH_MAP_START_LOADING,
   FETCH_MAP_END_LOADING,
   LOADINGS
 } from '../actions/Map';
-import { defaultCoord, defaultZoom, focusZoom } from '../conf/config';
 
 const initialState = {
   networksCoordinates: [],
@@ -25,8 +21,6 @@ const initialState = {
   entrancesCoordinates: [],
   entrances: [],
   organizations: [],
-  location: defaultCoord,
-  zoom: defaultZoom,
   error: undefined,
   loadings: {
     [LOADINGS.NETWORKS]: false,
@@ -95,12 +89,6 @@ const reducer = (state = initialState, action) => {
       };
     case FETCH_MAP_ORGANIZATIONS_FAILURE:
       return { ...state, error: action.error };
-    case CHANGE_LOCATION:
-      return { ...state, location: action.location };
-    case CHANGE_ZOOM:
-      return { ...state, zoom: action.zoom };
-    case FOCUS_ON_LOCATION:
-      return { ...state, location: action.location, zoom: focusZoom };
     default:
       return state;
   }


### PR DESCRIPTION
# Optimize map performances

## 🤔 What

- Improve the display of zones with lot of markers, and markers display strategy globally
- Improve the display by not re-rendering the map at each move when not necessary
- Load all entrancesCoordinates at once (~700Ko) to populate heatmaps. **Really** more efficicent than big calls (anyway, the first worldwild call already fetched all coordinates when full unzoomed...)
- Give priority to map moving over markers display to avoid "freezeing"
- Replace cave markers with colored circle for better performances (and evolutivity, for potential filter/sort capability based on color, etc.)
- The colored circles are displayed differently depending on the *size* of the cave
- Fix remaining orphan tooltip when zooin
- Fix on mobiles devices, both popup and tooltipe where displayed
- Fix prevent clicking (on desktop) on an hex while panning. Also change cursor to pointer when hoovering an hex.
- (Internal) code cleaning

## 🤷‍♂️ Why

See https://github.com/GrottoCenter/grottocenter-front/issues/1073

I think whith heatmap full load, https://github.com/GrottoCenter/grottocenter-front/issues/892 is no more relevant. It doesn't apply for heatmap, only when zoomin with not pan for juste entrances. This precise case is very rare, and in such case the API response qui quite short (not a lot of points).

## 🔍 How

Biggest points where :
- global display strategy 
- load once all heatmap points
- using circles over svg markers.

## 🧪 Testing

Tested manually on mobile and desktop. Really better for high densit zone markers, now the bottleneck is rather the heatmap hex display due to long API calls.


## 📸 Previews

<img width="1738" height="942" alt="image" src="https://github.com/user-attachments/assets/dd20af14-56b1-4586-b26f-8c068630fb5e" />
