### PR TITLE
fix: build the correct snapshot object when "all snapshot" button is pressed

### DIFF
--- a/packages/web-app/src/components/appli/Entry/Snapshots/UtilityFunction.js
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/UtilityFunction.js
@@ -67,7 +67,7 @@ const SnapshotButton = ({
         component={Link}
         to={`/ui/${type}/${id}/snapshots?${[
           isNetwork !== undefined ? `isNetwork=${isNetwork}` : '',
-          getAll ? `getAll=true` : ''
+          getAll ? `all=true` : ''
         ]
           .filter(e => e)
           .join('&')}`}


### PR DESCRIPTION

# Your PR title here

## 🤔 What

closes #1186 
Buton was not redundant, but bugged.


## 🧪 Testing

Local obvious testing.

## 📸 Previews

Correct behavior with the change :

<img width="1728" height="979" alt="image" src="https://github.com/user-attachments/assets/8fa54486-0ce1-496b-be90-d0415ffeb444" />

