### PR TITLE
feat: improve mobile navigation

### DIFF
--- a/packages/web-app/src/components/appli/QuickSearch.jsx
+++ b/packages/web-app/src/components/appli/QuickSearch.jsx
@@ -14,7 +14,7 @@ import {
   AUTOCOMPLETE_MIN_CHARACTERS
 } from '../../conf/config';
 
-const QuickSearch = ({ hasFixWidth }) => {
+const QuickSearch = ({ hasFixWidth, onClose }) => {
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -38,6 +38,12 @@ const QuickSearch = ({ hasFixWidth }) => {
     else if (_type === 'massif') navigate(`/ui/massifs/${id}`);
 
     setInput('');
+    // Defer both blur and close so MUI Autocomplete's own focus-restore cycle
+    // runs first — otherwise the keyboard re-opens on mobile immediately after.
+    setTimeout(() => {
+      document.activeElement?.blur();
+      onClose?.();
+    }, 0);
   };
 
   useEffect(() => {
@@ -72,5 +78,6 @@ const QuickSearch = ({ hasFixWidth }) => {
 export default QuickSearch;
 
 QuickSearch.propTypes = {
-  hasFixWidth: PropTypes.bool
+  hasFixWidth: PropTypes.bool,
+  onClose: PropTypes.func
 };

--- a/packages/web-app/src/components/common/SideMenu/MenuLinks.jsx
+++ b/packages/web-app/src/components/common/SideMenu/MenuLinks.jsx
@@ -48,40 +48,40 @@ const MenuLinks = ({ isAuth, toggle }) => {
         ItemIcon={() => <MapIcon color="primary" />}
         label={formatMessage({ id: 'Map' })}
         href="/ui/map"
-        onClick={() => {toggle()}}
+        onClick={toggle}
       />
       <LinkedItem
         ItemIcon={() => <SearchIcon color="primary" />}
         label={formatMessage({ id: 'Advanced search' })}
         href="/ui/search"
-        onClick={() => {toggle()}}
+        onClick={toggle}
       />
       <LinkedItem
         ItemIcon={() => <LibraryAddIcon color="primary" />}
         label={formatMessage({ id: 'Contribute' })}
         href="/ui/entity/add"
-        onClick={() => {toggle()}}
+        onClick={toggle}
       />
       {isAuth && (
         <LinkedItem
           ItemIcon={() => <DashboardIcon color="primary" />}
           label={formatMessage({ id: 'Dashboard' })}
           href="/ui"
-          onClick={() => {toggle()}}
+          onClick={toggle}
         />
       )}
       <LinkedItem
         ItemIcon={() => <FlagRounded color="primary" />}
         label={formatMessage({ id: 'Countries' })}
         href="/ui/countries"
-        onClick={() => {toggle()}}
+        onClick={toggle}
       />
     </List>
   );
 };
 MenuLinks.propTypes = {
   isAuth: PropTypes.bool.isRequired,
-  toggle: PropTypes.func.isRequired
+  toggle: PropTypes.func
 };
 
 export default MenuLinks;

--- a/packages/web-app/src/components/common/SideMenu/index.jsx
+++ b/packages/web-app/src/components/common/SideMenu/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Divider, Drawer, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import { isMobile } from 'react-device-detect';
@@ -50,16 +50,17 @@ UserInformation.propTypes = {
 const SideMenu = ({ isOpen, toggle }) => {
   const permissions = usePermissions();
   const dispatch = useDispatch();
+  const handleClose = useCallback(() => dispatch(toggle()), [dispatch, toggle]);
   return (
     <Drawer
-      variant="persistent"
+      variant={isMobile ? 'temporary' : 'persistent'}
       anchor="left"
       open={isOpen}
-      onClose={() => dispatch(toggle())}>
+      onClose={handleClose}>
       <UserInformation isAuth={permissions.isAuth} />
-      <QuickSearch />
+      <QuickSearch onClose={isMobile ? handleClose : undefined} />
       <Divider />
-      <MenuLinks isAuth={permissions.isAuth} toggle={() => isMobile ? dispatch(toggle()) : true} />
+      <MenuLinks isAuth={permissions.isAuth} toggle={isMobile ? handleClose : undefined} />
       <Footer />
       <LanguageSelector />
     </Drawer>


### PR DESCRIPTION
# fix(mobile): improve mobile navigation UX

## Problems fixed

On mobile, the left side menu had three issues:

1. **Menu did not close when tapping outside** — the `Drawer` used `variant="persistent"` which ignores `onClose`. The backdrop and tap-outside-to-close behaviour were not working.

2. **Menu did not close after a QuickSearch selection** — the `QuickSearch` component embedded in the menu had no way to notify the menu to close after navigating to a result.

3. **Virtual keyboard stayed open after a search** — no `blur()` was triggered after result selection.

---

## Changes

### `SideMenu/index.jsx`
- `variant="persistent"` → `variant={isMobile ? 'temporary' : 'persistent'}`: `temporary` enables the MUI backdrop and closes the menu on outside tap on mobile, without changing desktop behaviour (`persistent` keeps pushing content).
- `handleClose` memoized with `useCallback` to avoid unnecessary re-renders in child components.
- `QuickSearch` receives `onClose={handleClose}` on mobile.
- `MenuLinks` receives `toggle={handleClose}` on mobile, replacing the previous inline arrow that duplicated the logic.

### `MenuLinks.jsx`
- `onClick={() => { toggle() }}` → `onClick={toggle}`: direct pass-through, removes unnecessary wrappers.
- `toggle` made optional in PropTypes (`func` instead of `func.isRequired`) — `onClick={undefined}` is natively ignored by React/MUI.

### `QuickSearch.jsx`
- Added `onClose?: () => void` prop.
- In `handleSelection`, after navigation: both `blur()` and `onClose()` are deferred inside a `setTimeout(0)` so that MUI Autocomplete's own focus-restore cycle runs first — otherwise the mobile keyboard would re-open immediately after closing.

---

## Desktop behaviour

No change: the `Drawer` stays in `persistent` mode, `toggle` and `onClose` are `undefined` on desktop — child components call nothing.

---

## Files changed

- `packages/web-app/src/components/common/SideMenu/index.jsx`
- `packages/web-app/src/components/common/SideMenu/MenuLinks.jsx`
- `packages/web-app/src/components/appli/QuickSearch.jsx`
