### PR TITLE
Modernize header bar

### DIFF
--- a/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
@@ -14,13 +14,15 @@ const Icon = styled('img')`
 
 const StyledMenuItem = styled(MenuItem, {
   shouldForwardProp: (prop) => !prop.startsWith('$')
-})(({ $isRead, theme, $width }) => ({
+})(({ $isRead, theme }) => ({
   background: !$isRead && theme.palette.secondary.veryLight,
   whiteSpace: 'normal',
-  width: `${$width}px`
+  width: '100%',
+  margin: 0,
+  borderRadius: 0
 }));
 
-const NotificationsMenuItem = ({ notification, onClick, width }) => {
+const NotificationsMenuItem = ({ notification, onClick }) => {
   const { formatDate, formatMessage, formatTime } = useIntl();
   const {
     dateInscription,
@@ -41,7 +43,6 @@ const NotificationsMenuItem = ({ notification, onClick, width }) => {
     <StyledMenuItem
       dense
       $isRead={isRead}
-      $width={width}
       component={Link}
       to={link}
       onClick={handleOnClick}>
@@ -98,8 +99,7 @@ NotificationsMenuItem.propTypes = {
   notification: PropTypes.shape({
     id: PropTypes.number.isRequired
   }).isRequired,
-  onClick: PropTypes.func,
-  width: PropTypes.number.isRequired
+  onClick: PropTypes.func
 };
 
 export default NotificationsMenuItem;

--- a/packages/web-app/src/components/appli/NotificationMenu/NotificationsIcon.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/NotificationsIcon.jsx
@@ -44,7 +44,7 @@ const NotificationsIcon = ({ onClick }) => {
         overlap="rectangular"
         color={status === REDUCER_STATUS.FAILED ? 'error' : 'secondary'}
         badgeContent={getBadgeContent(nbNotifications, status)}>
-        <MuiNotificationsIcon />
+        <MuiNotificationsIcon sx={{ fontSize: 28 }} />
       </Badge>
     </IconButton>
   );

--- a/packages/web-app/src/components/appli/NotificationMenu/index.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/index.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import {
   Box,
+  Chip,
   Divider,
   Menu,
   MenuItem,
@@ -10,7 +11,6 @@ import {
 } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-
 import { useIntl } from 'react-intl';
 import { styled } from '@mui/material/styles';
 import { usePermissions } from '../../../hooks';
@@ -24,14 +24,12 @@ import { countUnreadNotifications } from '../../../actions/Notifications/CountUn
 const NOTIFICATION_WIDTH = 320;
 const NUMBER_OF_NOTIFICATIONS = 10;
 
-const SeeAllMenuItem = styled(MenuItem)`
-  ${({ theme }) => `
-    color: ${theme.palette.primary.main};
-    font-weight: bold;
-    justify-content: center;
-    padding: ${theme.spacing(3)};
-  `}
-`;
+const SeeAllMenuItem = styled(MenuItem)(({ theme }) => ({
+  color: theme.palette.primary.main,
+  fontWeight: 'bold',
+  justifyContent: 'center',
+  padding: theme.spacing(2)
+}));
 
 const createSkeletons = n =>
   [...Array(n)].map((e, i) => (
@@ -54,42 +52,86 @@ const NotificationMenu = () => {
     state => state.countUnreadNotifications
   );
 
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const handleCloseMenu = () => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, []);
 
-  const handleOnMenuClick = event => {
-    dispatch(fetchMenuNotifications({ size: NUMBER_OF_NOTIFICATIONS }));
-    dispatch(countUnreadNotifications());
-    setAnchorEl(event.currentTarget);
-  };
+  const handleOpen = useCallback(
+    event => {
+      dispatch(fetchMenuNotifications({ size: NUMBER_OF_NOTIFICATIONS }));
+      dispatch(countUnreadNotifications());
+      setAnchorEl(event.currentTarget);
+    },
+    [dispatch]
+  );
 
-  const handleOnNotificationClick = notification => {
-    if (!notification.dateReadAt) {
-      dispatch(readNotification(notification.id));
-    }
-    handleCloseMenu();
-  };
+  const handleNotificationClick = useCallback(
+    notification => {
+      if (!notification.dateReadAt) {
+        dispatch(readNotification(notification.id));
+      }
+      handleClose();
+    },
+    [dispatch, handleClose]
+  );
 
-  const handleOnSeeAllLinkClick = () => {
-    handleCloseMenu();
+  const handleSeeAllClick = useCallback(() => {
+    handleClose();
     navigate('/ui/notifications');
-  };
+  }, [handleClose, navigate]);
 
   if (!isAuth) return '';
   return (
     <>
-      <NotificationsIcon onClick={handleOnMenuClick} />
+      <NotificationsIcon onClick={handleOpen} />
       <Menu
         id="notifications-menu"
         anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right'
+        }}
         keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleCloseMenu}
-        MenuListProps={{
-          style: { padding: 0 }
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}
+        open={open}
+        onClose={handleClose}
+        slotProps={{
+          list: { disablePadding: true },
+          paper: { sx: { mt: '4px', minWidth: NOTIFICATION_WIDTH } }
         }}>
+        {/* Header */}
+        <Box
+          sx={{
+            px: 2,
+            py: 2,
+            bgcolor: 'action.hover',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between'
+          }}>
+          <Typography variant="body2" color="text.primary">
+            {formatMessage({ id: 'Notifications' })}
+          </Typography>
+          {nbNotifications > 0 && (
+            <Chip
+              label={nbNotifications}
+              color="secondary"
+              size="small"
+            />
+          )}
+        </Box>
+
+        {(status === REDUCER_STATUS.LOADING || notifications !== null) && (
+          <Divider />
+        )}
+
+        {/* Notifications list */}
         {status === REDUCER_STATUS.LOADING &&
           !notifications &&
           // Arbitrary number (3) of notifications if real number is not available
@@ -102,24 +144,38 @@ const NotificationMenu = () => {
               <div key={notification.id}>
                 <NotificationsMenuItem
                   notification={notification}
-                  onClick={handleOnNotificationClick}
-                  width={NOTIFICATION_WIDTH}
+                  onClick={handleNotificationClick}
                 />
                 {idx !== notifications.length - 1 && <Divider />}
               </div>
             ))}
+
+        {/* Empty state */}
         {notifications && notifications.length === 0 && (
-          <MenuItem disabled>
-            <Box flexDirection="row" display="flex">
-              <NotificationsOffIcon />
-              <Typography>
-                {formatMessage({ id: 'You have no notifications.' })}
-              </Typography>
-            </Box>
-          </MenuItem>
+          <Box
+            sx={{
+              px: 2,
+              py: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              color: 'action.active'
+            }}>
+            <NotificationsOffIcon />
+            <Typography variant="body2">
+              {formatMessage({ id: 'You have no notifications.' })}
+            </Typography>
+          </Box>
         )}
-        <SeeAllMenuItem onClick={handleOnSeeAllLinkClick}>
-          {formatMessage({ id: 'See all notifications' }).toUpperCase()}
+
+        {(status === REDUCER_STATUS.LOADING || notifications !== null) && (
+          <Divider />
+        )}
+
+        {/* Footer action */}
+        <SeeAllMenuItem onClick={handleSeeAllClick}>
+          {formatMessage({ id: 'See all notifications' })}
         </SeeAllMenuItem>
       </Menu>
     </>

--- a/packages/web-app/src/components/common/AppBar/User.jsx
+++ b/packages/web-app/src/components/common/AppBar/User.jsx
@@ -1,15 +1,28 @@
-import { Button, IconButton, Menu, MenuItem } from '@mui/material';
-import AccountCircle from '@mui/icons-material/AccountCircle';
-import React from 'react';
+import {
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  Box,
+  Typography,
+  Divider,
+  Alert,
+  ListItemIcon
+} from '@mui/material';
+import LogoutIcon from '@mui/icons-material/Logout';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import React, { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useIntl } from 'react-intl';
-import { useTheme } from '@mui/material/styles';
-import { isMobileOnly } from 'react-device-detect';
 import PropTypes from 'prop-types';
 import { pathOr } from 'ramda';
 
 import Translate from '../Translate';
 import { useUserProperties } from '../../../hooks';
+import UserAvatar from './UserAvatar';
+
+// Constants
+const MENU_MIN_WIDTH = 250;
 
 const UserMenu = ({
   authTokenExpirationDate,
@@ -19,58 +32,58 @@ const UserMenu = ({
   onLogoutClick
 }) => {
   const { formatDate, formatMessage, formatTime } = useIntl();
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
-  const theme = useTheme();
-  const userId = pathOr(null, ['id'], useUserProperties());
+  const [anchorEl, setAnchorEl] = useState(null);
   const navigate = useNavigate();
+  const userProperties = useUserProperties();
 
-  const handleMenu = event => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  // Before using onLogoutClick(), we need to handle the menu closing
-  // to detach the popover menu before the account icon/button changes.
-  const handleLogoutClick = () => {
-    handleClose();
-    onLogoutClick();
-  };
-
-  // directs to the person page to see and modify the personnal data
-  const handleMyAccountClick = () => {
-    navigate(`/ui/persons/${userId}`);
-  };
+  const userId = pathOr(null, ['id'], userProperties);
+  const open = Boolean(anchorEl);
 
   const isSessionExpired = authTokenExpirationDate < Date.now();
 
+  const handleMenu = useCallback(event => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  // Before using onLogoutClick(), we need to handle the menu closing
+  // to detach the popover menu before the account icon/button changes.
+  const handleLogoutClick = useCallback(() => {
+    handleClose();
+    onLogoutClick();
+  }, [handleClose, onLogoutClick]);
+
+  // Directs to the person page to see and modify the personal data
+  const handleMyAccountClick = useCallback(() => {
+    if (!userId) return;
+    handleClose();
+    navigate(`/ui/persons/${userId}`);
+  }, [handleClose, navigate, userId]);
+
   return !isAuth ? (
-    <Button
-      color="inherit"
-      onClick={onLoginClick}
-      startIcon={<AccountCircle />}
-      variant="text">
-      {!isMobileOnly && <Translate>Log in</Translate>}
+    <Button color="inherit" onClick={onLoginClick} variant="outlined">
+      <Translate>Log in</Translate>
     </Button>
   ) : (
     <>
       <IconButton
         aria-label={formatMessage({ id: 'account of current user' })}
         aria-controls="menu-appbar"
-        aria-haspopup="true"
+        aria-haspopup="menu"
+        aria-expanded={open}
         onClick={handleMenu}
         color="inherit"
         size="large">
-        <AccountCircle />
+        <UserAvatar username={userNickname} />
       </IconButton>
       <Menu
         id="menu-appbar"
         anchorEl={anchorEl}
         anchorOrigin={{
-          vertical: 'top',
+          vertical: 'bottom',
           horizontal: 'right'
         }}
         keepMounted
@@ -79,64 +92,75 @@ const UserMenu = ({
           horizontal: 'right'
         }}
         open={open}
-        onClose={handleClose}>
-        <MenuItem disabled>
-          {formatMessage(
-            {
-              id: 'Logged as {userNickname}',
-              defaultMessage: 'Logged as {userNickname}'
-            },
-            {
-              userNickname: (
-                <span key="nickname">
-                  &nbsp;
-                  <b>{userNickname}</b>
-                </span>
-              )
+        onClose={handleClose}
+        slotProps={{
+          list: { disablePadding: true },
+          paper: {
+            sx: {
+              minWidth: MENU_MIN_WIDTH,
+              maxWidth: '90vw',
+              mt: '4px'
             }
-          )}
+          }
+        }}>
+        {/* Primary content: User info */}
+        <Box
+          sx={{
+            px: 2,
+            py: 2,
+            bgcolor: 'action.hover',
+            display: 'flex',
+            flexDirection: 'column'
+          }}>
+          <Typography variant="body2" color="text.primary">
+            <Translate
+              id="Logged as {userNickname}"
+              values={{ userNickname: <strong>{userNickname}</strong> }}
+            />
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatMessage(
+              {
+                id: 'Expiration Date: {expirationDate} at {expirationHourAndMinutes}',
+                defaultMessage:
+                  'Expiration Date: {expirationDate} at {expirationHourAndMinutes}'
+              },
+              {
+                expirationDate: formatDate(authTokenExpirationDate),
+                expirationHourAndMinutes: formatTime(authTokenExpirationDate)
+              }
+            )}
+          </Typography>
+        </Box>
+
+        <Divider />
+
+        {/* Primary actions */}
+        <MenuItem disabled={!userId} onClick={handleMyAccountClick}>
+          <ListItemIcon>
+            <AccountCircleIcon />
+          </ListItemIcon>
+          <Translate>My Account</Translate>
         </MenuItem>
-        <MenuItem
-          divider
-          disabled
-          style={isSessionExpired ? { opacity: 1 } : {}}>
-          {isSessionExpired ? (
-            <span style={{ color: theme.palette.errorColor }}>
+
+        {/* Session expired warning */}
+        {isSessionExpired && (
+          <Box sx={{ px: 2, py: '12px' }}>
+            <Alert severity="error">
               {formatMessage({
                 id: 'Your session has expired: please log in again.'
               })}
-            </span>
-          ) : (
-            <>
-              {formatMessage(
-                {
-                  id: 'Expiration Date: {expirationDate} at {expirationHourAndMinutes}',
-                  defaultMessage:
-                    'Expiration Date: {expirationDate} at {expirationHourAndMinutes}'
-                },
-                {
-                  expirationDate: (
-                    <span key="date">
-                      &nbsp;
-                      {formatDate(authTokenExpirationDate)}
-                      &nbsp;
-                    </span>
-                  ),
-                  expirationHourAndMinutes: (
-                    <span key="time">
-                      &nbsp;
-                      {formatTime(authTokenExpirationDate)}
-                    </span>
-                  )
-                }
-              )}
-            </>
-          )}
-        </MenuItem>
-        <MenuItem onClick={handleMyAccountClick}>
-          <Translate>My Account</Translate>
-        </MenuItem>
+            </Alert>
+          </Box>
+        )}
+
+        <Divider />
+
+        {/* Secondary actions */}
         <MenuItem onClick={handleLogoutClick}>
+          <ListItemIcon>
+            <LogoutIcon />
+          </ListItemIcon>
           <Translate>Log out</Translate>
         </MenuItem>
       </Menu>

--- a/packages/web-app/src/components/common/AppBar/UserAvatar.jsx
+++ b/packages/web-app/src/components/common/AppBar/UserAvatar.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Avatar } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import PropTypes from 'prop-types';
+
+// Generate initials from username
+const getInitials = username => {
+  if (!username) return '?';
+
+  const cleaned = username.trim().toUpperCase();
+
+  // If username contains space, take first letter of first and last word
+  const words = cleaned.split(/\s+/);
+  if (words.length >= 2) {
+    return `${words[0][0]}${words[words.length - 1][0]}`;
+  }
+
+  // Otherwise, take first two letters
+  return cleaned.substring(0, 2);
+};
+
+const StyledAvatar = styled(Avatar)(({ theme }) => ({
+  width: 32,
+  height: 32,
+  cursor: 'pointer',
+  backgroundColor: theme.palette.secondary.main,
+  color: '#fff',
+  fontSize: '1.5rem',
+  fontWeight: 500
+}));
+
+const UserAvatar = ({ username, sx, ...props }) => {
+  const initials = getInitials(username);
+
+  return (
+    <StyledAvatar {...props} sx={sx}>
+      {initials}
+    </StyledAvatar>
+  );
+};
+
+UserAvatar.propTypes = {
+  username: PropTypes.string,
+  sx: PropTypes.object
+};
+
+export default UserAvatar;

--- a/packages/web-app/src/components/common/AppBar/index.jsx
+++ b/packages/web-app/src/components/common/AppBar/index.jsx
@@ -26,42 +26,42 @@ import QuickSearch from '../../appli/QuickSearch';
 
 import UserMenu from './User';
 
-const StyledMuiAppBar = styled(MuiAppBar)`
-  flex-grow: 1;
-`;
+const StyledMuiAppBar = styled(MuiAppBar)({
+  flexGrow: 1
+});
 
-const FadeWrapper = styled('div')`
-  margin-left: auto;
-  height: 56px;
-  padding: ${props => props.theme.spacing(2)};
-  ${props => props.theme.breakpoints.down('sm')} {
-    display: none;
+const NavigationGroup = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  marginRight: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    marginRight: theme.spacing(1)
   }
-  display: flex;
-  gap: 12px;
-`;
+}));
 
-const TitleWrapper = styled('div')`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: baseline;
-`;
+const Spacer = styled('div')({
+  flexGrow: 1
+});
 
-const LogoWrapper = styled('div')`
-  display: flex;
-  align-items: baseline;
-`;
-
-const LogoImage = styled('img')(
-  ({ theme }) => `
-  padding-right: ${theme.spacing(2)};
-  height: 30px;
-  ${theme.breakpoints.down('sm')} {
-    height: 25px;
+const ToolsGroup = styled('div')(({ theme }) => ({
+  height: 56,
+  display: 'flex',
+  gap: 12,
+  alignItems: 'center',
+  padding: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    display: 'none'
   }
-`
-);
+}));
+
+const LogoImage = styled('img')(({ theme }) => ({
+  height: 34,
+  marginRight: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    height: 32
+  }
+}));
 
 const GrottoTxt = styled('div')(
   ({ theme }) => `
@@ -77,6 +77,15 @@ export const StyledLink = styled(Link)`
   cursor: pointer;
   display: flex;
 `;
+
+const ActionsGroup = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1),
+  marginLeft: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    marginLeft: theme.spacing(1)
+  }
+}));
 
 const AppBar = () => {
   const dispatch = useDispatch();
@@ -97,42 +106,43 @@ const AppBar = () => {
     <>
       <StyledMuiAppBar>
         <Toolbar variant="dense">
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            edge="start"
-            onClick={() => dispatch(toggleSideMenu())}
-            size="large">
-            <MenuIcon />
-          </IconButton>
-          <TitleWrapper>
-            <LogoWrapper>
-              <Typography variant="h4">
-                <StyledLink to="">
-                  <LogoImage
-                    id="grottocenter-logo"
-                    src={logoGC}
-                    alt="Grottocenter"
-                  />
-                  <GrottoTxt>Grottocenter</GrottoTxt>
-                </StyledLink>
-              </Typography>
-            </LogoWrapper>
-          </TitleWrapper>
+          <NavigationGroup>
+            <IconButton
+              color="inherit"
+              aria-label="open drawer"
+              edge="start"
+              onClick={() => dispatch(toggleSideMenu())}
+              size="large">
+              <MenuIcon sx={{ fontSize: 32 }} />
+            </IconButton>
+            <Typography variant="h4">
+              <StyledLink to="">
+                <LogoImage
+                  id="grottocenter-logo"
+                  src={logoGC}
+                  alt="Grottocenter"
+                />
+                <GrottoTxt>Grottocenter</GrottoTxt>
+              </StyledLink>
+            </Typography>
+          </NavigationGroup>
+          <Spacer />
           <Fade in={!isSideMenuOpen}>
-            <FadeWrapper>
+            <ToolsGroup>
               <QuickSearch hasFixWidth={false} />
               <LanguageSelector />
-            </FadeWrapper>
+            </ToolsGroup>
           </Fade>
-          <NotificationMenu />
-          <UserMenu
-            authTokenExpirationDate={authTokenExpirationDate}
-            isAuth={permissions.isAuth}
-            onLoginClick={onLoginClick}
-            onLogoutClick={() => dispatch(postLogout())}
-            userNickname={authState?.authTokenDecoded?.nickname ?? null}
-          />
+          <ActionsGroup>
+            <NotificationMenu />
+            <UserMenu
+              authTokenExpirationDate={authTokenExpirationDate}
+              isAuth={permissions.isAuth}
+              onLoginClick={onLoginClick}
+              onLogoutClick={() => dispatch(postLogout())}
+              userNickname={authState?.authTokenDecoded?.nickname ?? null}
+            />
+          </ActionsGroup>
         </Toolbar>
       </StyledMuiAppBar>
       <Toolbar variant="dense" />


### PR DESCRIPTION
# Modernize header bar

## 🤔 What

This update refreshes the application header with a cleaner, more polished look and feel.

What changed for users:

- The user menu now displays an avatar with your initials instead of a generic account icon, making it easier to identify your session at a glance
- The user menu now shows your session expiration time directly in the header area, and displays a clear error alert if your session has expired
- The mobile UX is improved with correct aligment of icons, similar to the desktop experience
- The notification bell now opens a structured dropdown with a header showing the unread count, a list of notifications, and a "See all" link at the bottom
- Menu dropdowns now open below their trigger button, which feels more natural
- Fixed some minor icons dimensions / alignment

## 🤷‍♂️ Why

See #1205 

## 🔍 How

- All header layout components have been modernized and reorganized for clarity and maintainability
- Replaced deprecated MUI styling patterns with the current recommended API
- Improved accessibility attributes on interactive elements

## 🧪 Testing

- Tested visually on desktop + mobile

## 📸 Previews

<img width="1644" height="108" alt="image" src="https://github.com/user-attachments/assets/834891d5-42af-40d6-afa1-12053b97ca1a" />

<img width="1642" height="154" alt="image" src="https://github.com/user-attachments/assets/780ab96b-9c17-474c-a281-dfedf2c34618" />

<img width="428" height="320" alt="image" src="https://github.com/user-attachments/assets/2b9038f1-d3d6-430b-959c-be7943647307" />

<img width="598" height="338" alt="image" src="https://github.com/user-attachments/assets/ae0fe9e4-5ee3-495d-8cfc-4b1e6af0be86" />

<img width="319" height="203" alt="Example notification" src="https://github.com/user-attachments/assets/22e77d92-04b0-45e5-b5e2-d8a1a51aadb8" />
