### PR TITLE
ci(workflows): fix deprecation warnings and add cache headers

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build And Deploy
@@ -28,7 +28,7 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "." # App source code path
-          api_location: "/api" # Api source code path - optional
+          api_location: "" # No Azure Functions API in this repo
           output_location: "packages/web-app/build" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,9 +25,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -2,5 +2,22 @@
   "navigationFallback": {
     "rewrite": "index.html",
     "exclude": ["/images/*", "/static/*"]
-  }
+  },
+  "globalHeaders": {
+    "X-Content-Type-Options": "nosniff"
+  },
+  "routes": [
+    {
+      "route": "/index.html",
+      "headers": {
+        "Cache-Control": "no-cache"
+      }
+    },
+    {
+      "route": "/static/*",
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# ci(workflows): fix deprecation warnings and add cache headers

## 🤔 What

- Upgrade `actions/checkout` from v2 to v4 across all workflows
- Upgrade `actions/setup-node` from v3 to v4 in lint workflow
- Upgrade `github/codeql-action/*` from v1 to v3 in CodeQL workflow
- Set `api_location` to empty string in Azure SWA workflow
- Add cache control headers in `staticwebapp.config.json` to prevent stale file errors after deployments

## 🤷‍♂️ Why

- `actions/checkout@v2` and `actions/setup-node@v3` run on Node.js 20 which is deprecated and will be forced to Node.js 24 starting June 2nd, 2026
- `actions/checkout@v2` also causes a permission error during post-job cleanup when removing the git extraheader
- `github/codeql-action@v1` has been deprecated for a long time
- `api_location: "/api"` causes a warning since this repo has no Azure Functions API directory
- Without cache headers, `index.html` can be cached by browsers, causing users to load stale references to JS/CSS chunks that no longer exist after a new deployment

## 🔍 How

- Bumped action versions to their latest major releases (checkout v4, setup-node v4, codeql-action v3)
- Set `api_location: ""` to explicitly tell Azure SWA there's no API
- Added `no-cache` on `/index.html` so browsers always revalidate
- Added `immutable` caching on `/static/*` since CRA hashes these filenames on every build
- Added `X-Content-Type-Options: nosniff` as a global security header

## 🔗 Related API PR

None.

## 🧪 Testing

- Verify all three workflows (Azure SWA, Lint, CodeQL) run without deprecation warnings
- Verify no `[WARNING] Api Directory Location` message in Azure SWA deploy logs
- Verify no `Failed to remove extraheader` error in post-job cleanup
- After deploy, verify `index.html` response has `Cache-Control: no-cache` header
- After deploy, verify static assets have `Cache-Control: public, max-age=31536000, immutable`

## 📸 Previews

N/A — infrastructure changes only.
