### PR TITLE
fix: hex doesn't display when fly at hex

### DIFF
--- a/packages/web-app/src/components/common/Maps/MapClusters/useHeatLayer.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/useHeatLayer.js
@@ -142,7 +142,7 @@ const useHeatLayer = (data = [], type = heatmapTypes.ENTRANCES) => {
 
     d3.selectAll('.hexbin-tooltip').attr('opacity', 0);
     const bounds = new L.LatLngBounds(
-      hexPoints.map(point => point.o.reverse())
+      hexPoints.map(point => [point.o[1], point.o[0]])
     );
     map.flyToBounds(bounds, {
       maxZoom: MARKERS_LIMIT,


### PR DESCRIPTION
# Bugfix hex zoom

## 🤔 What

When clicking on an hex, didn't display the lower level zoom hex:

<img width="1187" height="894" alt="image" src="https://github.com/user-attachments/assets/7af8ed59-8728-45d8-89e7-d6d575df41ac" />

## 🔍 How

Le problème : Array.prototype.reverse() mute le tableau en place. point.o est une référence directe vers l'entrée originale dans le tableau entrances (e.g. [lng, lat]). Après l'appel, tous les points du hex cliqué ont leurs coordonnées inversées → [lat, lng].

Résultat : au prochain affichage de la heatmap (après zoom out, quand updateHeatData(entrances) est rappelé), les coordonnées des entrances affectées sont corrompues — les hexagones se placent aux mauvaises positions ou hors de la carte, donc ils n'apparaissent plus.
