### PR TITLE
fix(map): add referrer policy to OSM tile layers to prevent 403 errors

### DIFF
--- a/packages/web-app/src/components/common/DuplicatesHandler/EntranceComponents/MapLine.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/EntranceComponents/MapLine.jsx
@@ -42,8 +42,9 @@ const MapComponent = ({ position, updatePosition }) => (
     center={position}
     scrollWheelZoom={false}>
     <TileLayer
-      attribution='&copy; <a href="https://beta.grottocenter.org/">GrottoCenter</a> contributors'
+      attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      referrerPolicy="strict-origin-when-cross-origin"
     />
 
     {isNil(updatePosition) ? (

--- a/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
+++ b/packages/web-app/src/components/common/Maps/common/LayersControl.jsx
@@ -58,6 +58,7 @@ const createWMTSTileLayer = (layer, opacity = 1) => (
     maxNativeZoom={layer.maxNativeZoom ?? 22}
     bounds={layer.bounds ?? new L.LatLngBounds(new L.LatLng(-90, -180), new L.LatLng(90, 180))}
     opacity={opacity}
+    referrerPolicy={layer.referrerPolicy}
   />
 );
 

--- a/packages/web-app/src/components/common/Maps/common/mapLayers.js
+++ b/packages/web-app/src/components/common/Maps/common/mapLayers.js
@@ -20,6 +20,7 @@ const layers = [
     attribution:
       '« © <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap </a> contributors » under ODbL licence',
     url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    referrerPolicy: 'strict-origin-when-cross-origin',
     maxZoom: 19,
     maxNativeZoom: 19,
     base: true


### PR DESCRIPTION
# fix(map): add referrer policy to OSM tile layers to prevent 403 errors

## 🤔 What

- Added `referrerPolicy: 'strict-origin-when-cross-origin'` to all OpenStreetMap tile layer usages so the browser sends a `Referer` header with tile requests.
- Fixed incorrect attribution in `MapLine.jsx` (was crediting GrottoCenter instead of OpenStreetMap).
- Closes #1225

## 🤷‍♂️ Why

OpenStreetMap's tile servers enforce their [tile usage policy](https://operations.osmfoundation.org/policies/tiles/) which requires a valid HTTP `Referer` header. Browsers may strip or omit the `Referer` on cross-origin image requests by default, causing OSM to return 403 errors with a "blocked referrer" message.

## 🔍 How

Three files changed:

- `mapLayers.js` — added `referrerPolicy` to the OSM layer config object.
- `LayersControl.jsx` — passes the `referrerPolicy` prop through to the `<TileLayer>` component.
- `MapLine.jsx` — added `referrerPolicy` prop directly on the standalone `<TileLayer>`, and corrected the attribution to properly credit OpenStreetMap.

## 🔗 Related API PR

None.

## 🧪 Testing

1. Open any map view in the app.
2. Verify OSM tiles load without 403 errors in the Network tab.
3. Open the duplicates handler with entrance positions and verify its map also loads tiles correctly.

## 📸 Previews

N/A — no visual changes, tiles should simply load correctly now.
