### PR TITLE
fix: advance search sliders for caves

### DIFF
--- a/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
@@ -194,13 +194,13 @@ const EntrancesSearch = () => {
           label="Depth"
           helperText="In meters"
           marks={depthMarks}
-          onChange={e => updateFilter('cave.depth', Math.trunc(e))}
+          onChange={e => updateFilter('cave.depth', e)}
         />
         <SearchSlider
           label="Length"
           helperText="In meters"
           marks={lengthMarks}
-          onChange={e => updateFilter('cave.length', Math.trunc(e))}
+          onChange={e => updateFilter('cave.length', e)}
         />
       </SearchFieldset>
 


### PR DESCRIPTION
## Bug: Depth and length filters ignored in advanced search for cavities

### Description

In the advanced search for entrances/cavities, the **depth** and **length** filters were silently broken: changing the slider had no effect on search results.

<img width="1484" height="748" alt="image" src="https://github.com/user-attachments/assets/60ba6f1d-596a-4c29-8d59-b407ffafd40c" />


### Root cause

In `EntrancesSearch.jsx`, the `onChange` callbacks for both sliders were wrapping the emitted value with `Math.trunc()`:

```js
// Before (broken)
onChange={e => updateFilter('cave.depth', Math.trunc(e))}
onChange={e => updateFilter('cave.length', Math.trunc(e))}
```

However, `SearchSlider` emits a **range array** `[min, max]` (e.g. `[50, 1000]`), not a single number. Calling `Math.trunc()` on an array coerces it to `NaN`:

```js
Math.trunc([50, 1000]) // → NaN
```

As a result, `filterState['cave.depth']` and `filterState['cave.length']` were always `NaN`, and the backend received invalid filter values regardless of what the user selected.

The other sliders in the same form (ratings) were not affected because they pass `e` directly without wrapping.

### Fix

Remove the `Math.trunc()` wrapper and pass the array value through unchanged:

```js
// After (fixed)
onChange={e => updateFilter('cave.depth', e)}
onChange={e => updateFilter('cave.length', e)}
```

### Affected file

`packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx`

## Screenshot of fixed feature

<img width="1475" height="744" alt="image" src="https://github.com/user-attachments/assets/7e300858-f8af-4a12-a202-1d9e671c4ed9" />
