### PR TITLE
fix(Search): rename entrance.name and massif.name to plural in document advanced search

### DIFF
--- a/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
@@ -47,8 +47,8 @@ const initialFilterState = {
   issue: '',
   'parent.title': '',
   'cave.name': '',
-  'entrance.name': '',
-  'massif.name': ''
+  'entrances.name': '',
+  'massifs.name': ''
 };
 
 const SubjectEntry = ({ subject }) => {
@@ -281,14 +281,14 @@ const DocumentSearch = () => {
 
           <SearchText
             label="Entrance"
-            onChange={e => updateFilter('entrance.name', e)}
-            value={filterState['entrance.name']}
+            onChange={e => updateFilter('entrances.name', e)}
+            value={filterState['entrances.name']}
           />
 
           <SearchText
             label="Massif"
-            onChange={e => updateFilter('massif.name', e)}
-            value={filterState['massif.name']}
+            onChange={e => updateFilter('massifs.name', e)}
+            value={filterState['massifs.name']}
           />
         </SearchFormContainer>
       </SearchFieldset>

--- a/packages/web-app/src/components/common/EntityTable/entitiesConfig.jsx
+++ b/packages/web-app/src/components/common/EntityTable/entitiesConfig.jsx
@@ -149,7 +149,7 @@ const documents = {
     [false, 'importSource', 'Import source', false],
     [false, 'importId', 'Import Id', false],
     [false, 'cave.name', 'Cave', true],
-    [false, 'entrance.name', 'Entrance', true],
+    [false, 'entrances', 'Entrances', false, cellsRender.keyArray('name')],
     [false, 'massifs', 'Massifs', false, cellsRender.keyArray('name')]
   ],
   link: doc => `/ui/documents/${doc.id}`


### PR DESCRIPTION
# fix(Search): rename entrance.name and massif.name to plural in document advanced search

## 🤔 What

- Rename `entrance.name` → `entrances.name` in the document advanced search filter state and JSX
- Rename `massif.name` → `massifs.name` in the document advanced search filter state and JSX
- Fix the documents entity table `entrance` column: rename to `Entrances`, use `entrances` array field with `keyArray('name')` renderer, mark as not sortable (array fields can't be sorted in Typesense)
- Close issue #1235

## 🤷♂️ Why

The Typesense collection schema for `documents` defines `entrances.name` and `massifs.name` as plural fields (arrays). The front-end was sending the singular variants in two places:
1. The advanced search filter — causing a 500 error (`RequestMalformed: Could not find a filter field named entrance.name in the schema`) whenever a user filtered documents by entrance or massif name.
2. The entity table column config — the `entrance.name` field didn't match the actual API response shape (`entrances[].name`), so the entrance name never rendered; and since `entrances` is an array field, sorting on it is not supported by Typesense.

## 🔍 How

4 occurrences updated in `DocumentSearch.jsx`:
- `initialFilterState` keys renamed from singular to plural
- `onChange` / `value` props on the Entrance and Massif `SearchText` fields updated accordingly

1 occurrence updated in `entitiesConfig.jsx`:
- `entrance.name` column replaced with `entrances` using `keyArray('name')` renderer to correctly display the array, labeled `Entrances`, and marked as not sortable (consistent with the `massifs` column)

## 🔗 Related API PR

N/A — the schema is already correct on the back-end side.

## 🧪 Testing

1. Go to the advanced search page and select **Documents**
2. Enter any value in the **Entrance** or **Massif** name fields
3. Submit — should return results instead of a 500 error
4. The **Entrances** column in the results table should now display the entrance name(s)
