### PR TITLE
fix(auth): logout user on 401 response

### DIFF
--- a/packages/web-app/src/actions/Notifications/CountUnreadNotifications.js
+++ b/packages/web-app/src/actions/Notifications/CountUnreadNotifications.js
@@ -2,7 +2,6 @@ import fetch from 'isomorphic-fetch';
 import { countUnreadNotificationsUrl } from '../../conf/apiRoutes';
 import makeErrorMessage from '../../helpers/makeErrorMessage';
 import { checkAndGetStatus } from '../utils';
-import { logout } from '../Login';
 
 export const COUNT_UNREAD_NOTIFICATIONS = 'COUNT_UNREAD_NOTIFICATIONS';
 export const COUNT_UNREAD_NOTIFICATIONS_SUCCESS =
@@ -40,14 +39,6 @@ export function countUnreadNotifications() {
         dispatch(countUnreadNotificationsActionSuccess(data.count));
       })
       .catch(error => {
-        // When logged, countUnreadNotifications() is the first authenticated request made to the API
-        // So it is the first request that test if the JWT is really valid
-        // In case of invalid token we logout the user
-        if (error.message === '401') {
-          dispatch(logout());
-          return;
-        }
-
         dispatch(
           countUnreadNotificationsActionFailure(
             makeErrorMessage(error.message, `Counting unread notifications`),

--- a/packages/web-app/src/actions/Notifications/GetMenuNotifications.js
+++ b/packages/web-app/src/actions/Notifications/GetMenuNotifications.js
@@ -37,7 +37,7 @@ export function fetchMenuNotifications(criterias) {
     };
 
     try {
-      const response = checkAndGetStatus(
+      const response = await checkAndGetStatus(
         await fetch(makeUrl(fetchNotificationsUrl, criterias), requestOptions)
       );
 

--- a/packages/web-app/src/actions/Notifications/GetNotifications.js
+++ b/packages/web-app/src/actions/Notifications/GetNotifications.js
@@ -32,7 +32,7 @@ export function fetchNotifications(criterias) {
     };
 
     try {
-      const response = checkAndGetStatus(
+      const response = await checkAndGetStatus(
         await fetch(makeUrl(fetchNotificationsUrl, criterias), requestOptions)
       );
 

--- a/packages/web-app/src/actions/utils.js
+++ b/packages/web-app/src/actions/utils.js
@@ -8,6 +8,7 @@ import {
   defaultTo,
   equals
 } from 'ramda';
+import { logout } from './Login';
 
 // Remove the next line when other exports are created.
 export const makeUrl = (url, criterias) => {
@@ -19,19 +20,26 @@ export const makeUrl = (url, criterias) => {
   return url;
 };
 
-export const checkAndGetStatus = response => {
-  if (response.status >= 200 && response.status <= 300) {
+export const checkAndGetStatus = async response => {
+  if (response.status >= 200 && response.status < 300) {
     return response;
   }
-  return response.json().then(body => {
-    const errorMessage = new Error(body.message || response.status);
-    errorMessage.body = body;
-    throw errorMessage;
-  }).catch(err => {
-    if (err.body) throw err;
-    const errorMessage = new Error(response.status);
-    throw errorMessage;
-  });
+  if (response.status === 401) {
+    // eslint-disable-next-line global-require
+    const gcStore = require('../store').default;
+    gcStore.dispatch(logout());
+    return response;
+  }
+  const errorMessage = new Error(response.status);
+  try {
+    errorMessage.body = await response.json();
+    if (errorMessage.body?.message) {
+      errorMessage.message = errorMessage.body.message;
+    }
+  } catch (_) {
+    // ignore if body is not JSON
+  }
+  throw errorMessage;
 };
 
 const makeNumber = ifElse(identity, Number, always(1));

--- a/packages/web-app/src/pages/ApplicationShell.jsx
+++ b/packages/web-app/src/pages/ApplicationShell.jsx
@@ -2,15 +2,12 @@ import React, { useRef, useEffect } from 'react';
 import { Provider, useSelector, useDispatch } from 'react-redux';
 import { Outlet } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
-import createDebounce from 'redux-debounced';
 import { isMobileOnly } from 'react-device-detect';
 import { SnackbarProvider } from 'notistack';
-import { createStore, applyMiddleware, compose } from 'redux';
-import { thunk } from 'redux-thunk';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 
-import GCReducer from '../reducers/GCReducer';
+import gcStore from '../store';
 import { bootstrapIntl } from '../actions/Intl';
 import { toggleSideMenu } from '../actions/SideMenu';
 import ErrorHandler from '../components/appli/ErrorHandler';
@@ -32,10 +29,6 @@ async function transitionToReact() {
     loaderEl.remove();
   }, 410);
 }
-
-const middlewares = applyMiddleware(createDebounce(), thunk);
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const gcStore = createStore(GCReducer, composeEnhancers(middlewares));
 
 const customOnIntlError = err => {
   // Custom handler for missing translation.

--- a/packages/web-app/src/store.js
+++ b/packages/web-app/src/store.js
@@ -1,0 +1,14 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import { thunk } from 'redux-thunk';
+import createDebounce from 'redux-debounced';
+import GCReducer from './reducers/GCReducer';
+
+const middlewares = applyMiddleware(createDebounce(), thunk);
+const composeEnhancers =
+  (typeof window !== 'undefined' &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+  compose;
+
+const gcStore = createStore(GCReducer, composeEnhancers(middlewares));
+
+export default gcStore;


### PR DESCRIPTION
# fix(auth): logout user on 401 response

Closes #778

## 🤔 What

- Automatically log out the user when any API request returns a 401 response
- Extract Redux store creation into a dedicated `store.js` file
- Make `checkAndGetStatus` async for consistent promise handling

## 🤷♂️ Why

When a user's JWT token expires or is revoked, the API returns a 401. The app was not logging the user out in this case because:

1. The 401 check in `CountUnreadNotifications` compared `error.message === '401'`, but `checkAndGetStatus` was throwing with `body.message` (e.g. `"Unauthorized"`) instead of the status code
2. Even after fixing that, CORS policy blocks the response entirely for cross-origin 401s, so `fetch` throws `TypeError: Failed to fetch` before `checkAndGetStatus` even runs — meaning the status code was never readable from the catch block

## 🔍 How

- Moved the logout logic into `checkAndGetStatus` in `utils.js`, where the raw `response.status` is directly accessible before any CORS/fetch error can obscure it
- The store is accessed via a lazy `require('../store')` to avoid pulling in the full reducer tree at module load time (which broke Jest tests due to `intlBootstrap` not being defined in the test environment)
- Extracted store creation from `ApplicationShell.jsx` into `src/store.js` so it can be required lazily
- Made `checkAndGetStatus` `async` for consistent promise handling — two callers (`GetNotifications`, `GetMenuNotifications`) were missing `await`, causing unhandled promise rejections
- Removed the now-redundant logout logic from `CountUnreadNotifications`

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Log in
2. Revoke or expire the JWT token on the backend
3. Navigate to a page that triggers an authenticated API call
4. Verify the user is automatically logged out

## 📸 Previews

N/A
