### PR TITLE
fix: loader size

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/utils/FormProgressInfo.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/FormProgressInfo.jsx
@@ -52,7 +52,11 @@ const FormProgressInfo = ({
     );
   }
 
-  return <CircularProgress />;
+  return (
+    <Box display="flex" justifyContent="center">
+      <CircularProgress />
+    </Box>
+  );
 };
 
 FormProgressInfo.propTypes = {

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 import Skeleton from '@mui/material/Skeleton';
-import { Box, Card } from '@mui/material';
+import { Card } from '@mui/material';
 
 import FixedLayout from '../../common/Layouts/Fixed';
 import FixedContent from '../../common/Layouts/Fixed/FixedContent';
@@ -234,9 +234,7 @@ export const Entry = ({ isLoading, error, entrance }) => {
         )}
         {isLoading && (
           <Card sx={{ padding: 3 }}>
-            <Box style={{ display: 'flex', justifyContent: 'center' }}>
-              <Skeleton height={300} width={800} /> {/* Map Skeleton */}
-            </Box>
+            <Skeleton height={300} width="100%" /> {/* Map Skeleton */}
             <Skeleton height={80} />
             <Skeleton height={100} />
             <Skeleton height={150} />

--- a/packages/web-app/src/components/appli/Massif/Massif.jsx
+++ b/packages/web-app/src/components/appli/Massif/Massif.jsx
@@ -5,10 +5,14 @@ import { useParams, useNavigate } from 'react-router-dom';
 
 import { useDispatch, useSelector } from 'react-redux';
 import Skeleton from '@mui/material/Skeleton';
-import { Box, Card } from '@mui/material';
+import { Card } from '@mui/material';
 import { useIntl } from 'react-intl';
 
-import { usePermissions, useSubscriptions, useScrollToHashOnLoad } from '../../../hooks';
+import {
+  usePermissions,
+  useSubscriptions,
+  useScrollToHashOnLoad
+} from '../../../hooks';
 import { subscribeToMassif } from '../../../actions/Subscriptions/SubscribeToMassif';
 import { unsubscribeFromMassif } from '../../../actions/Subscriptions/UnsubscribeFromMassif';
 import { deleteMassif } from '../../../actions/Massif/DeleteMassif';
@@ -154,9 +158,7 @@ const Massif = ({ isLoading, error, massif }) => {
       )}
       {isLoading && (
         <Card sx={{ padding: 3 }}>
-          <Box style={{ display: 'flex', justifyContent: 'center' }}>
-            <Skeleton height={300} width={800} />
-          </Box>
+          <Skeleton height={300} width="100%" />
           <Skeleton height={100} />
           <Skeleton height={100} />
           <Skeleton height={100} />
@@ -185,26 +187,15 @@ const Massif = ({ isLoading, error, massif }) => {
             anchorId="statistics"
             title={formatMessage({ id: 'More information' })}
             content={
-              <StatisticsDataDashboard
-                massifId={massifIdInt}
-                hideTitle
-              />
+              <StatisticsDataDashboard massifId={massifIdInt} hideTitle />
             }
           />
-          <Documents
-            documents={massif?.documents ?? []}
-            massifId={massifId}
-          />
+          <Documents documents={massif?.documents ?? []} massifId={massifId} />
           {massif?.networks?.length > 0 && (
             <ScrollableContent
               anchorId="networks"
               title={formatMessage({ id: 'Networks list' })}
-              content={
-                <EntitiesList
-                  type="cave"
-                  entites={massif.networks}
-                />
-              }
+              content={<EntitiesList type="cave" entites={massif.networks} />}
             />
           )}
         </>

--- a/packages/web-app/src/components/appli/Network/index.jsx
+++ b/packages/web-app/src/components/appli/Network/index.jsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Skeleton from '@mui/material/Skeleton';
-import { Box, Card } from '@mui/material';
+import { Card } from '@mui/material';
 
 import { usePermissions, useUserProperties } from '../../../hooks';
 import { linkCave } from '../../../actions/Cave/LinkCave';
@@ -200,9 +200,7 @@ export const Network = ({ isLoading, error, cave }) => {
         }>
         {isLoading && (
           <Card sx={{ padding: 3 }}>
-            <Box style={{ display: 'flex', justifyContent: 'center' }}>
-              <Skeleton height={300} width={800} /> {/* Map Skeleton */}
-            </Box>
+            <Skeleton height={300} width="100%" /> {/* Map Skeleton */}
             <Skeleton height={100} /> {/* EntranceList Skeleton */}
             <Skeleton height={100} /> {/* Description Skeleton */}
           </Card>

--- a/packages/web-app/src/components/appli/Organization/index.jsx
+++ b/packages/web-app/src/components/appli/Organization/index.jsx
@@ -6,7 +6,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
-import { Box, Card } from '@mui/material';
+import { Card } from '@mui/material';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import PersonRemoveIcon from '@mui/icons-material/PersonRemove';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
@@ -54,8 +54,7 @@ const Organization = ({ error, isLoading, organization }) => {
 
   const isMember = useMemo(
     () =>
-      isAuth &&
-      organization?.cavers?.some(caver => caver.id === currentUserId),
+      isAuth && organization?.cavers?.some(caver => caver.id === currentUserId),
     [isAuth, organization?.cavers, currentUserId]
   );
   const canManageCaves = isAdmin || isModerator || isMember;
@@ -135,7 +134,9 @@ const Organization = ({ error, isLoading, organization }) => {
           avatar={
             <BadgesSection
               nbCavers={(organization.cavers ?? []).length}
-              nbExploredEntrances={(organization.exploredEntrances ?? []).length}
+              nbExploredEntrances={
+                (organization.exploredEntrances ?? []).length
+              }
               nbExploredNetworks={(organization.exploredNetworks ?? []).length}
             />
           }
@@ -183,9 +184,7 @@ const Organization = ({ error, isLoading, organization }) => {
       )}
       {isLoading && (
         <Card sx={{ padding: 3 }}>
-          <Box style={{ display: 'flex', justifyContent: 'center' }}>
-            <Skeleton height={150} width={800} />
-          </Box>
+          <Skeleton height={150} width="100%" />
           <Skeleton height={100} />
           <Skeleton height={100} />
           <Skeleton height={100} />
@@ -233,7 +232,9 @@ const Organization = ({ error, isLoading, organization }) => {
                   type="person"
                   entites={organization.cavers}
                   onItemRemove={isAdmin ? handleRemoveMember : null}
-                  toolTipTitle={formatMessage({ id: 'Remove from organization' })}
+                  toolTipTitle={formatMessage({
+                    id: 'Remove from organization'
+                  })}
                 />
                 {joinLeaveError && (
                   <Alert severity="error" title={joinLeaveError} />
@@ -265,14 +266,20 @@ const Organization = ({ error, isLoading, organization }) => {
               canManageCaves && (
                 <Tooltip
                   title={formatMessage({
-                    id: isCaveSearchVisible ? 'Cancel this search' : 'Add a cave'
+                    id: isCaveSearchVisible
+                      ? 'Cancel this search'
+                      : 'Add a cave'
                   })}>
                   <Button
                     color={isCaveSearchVisible ? 'inherit' : 'secondary'}
                     variant="outlined"
                     onClick={() => setIsCaveSearchVisible(v => !v)}
-                    startIcon={isCaveSearchVisible ? <CancelIcon /> : <AddCircleIcon />}>
-                    {formatMessage({ id: isCaveSearchVisible ? 'Cancel' : 'Add' })}
+                    startIcon={
+                      isCaveSearchVisible ? <CancelIcon /> : <AddCircleIcon />
+                    }>
+                    {formatMessage({
+                      id: isCaveSearchVisible ? 'Cancel' : 'Add'
+                    })}
                   </Button>
                 </Tooltip>
               )

--- a/packages/web-app/src/components/appli/Person/Person.jsx
+++ b/packages/web-app/src/components/appli/Person/Person.jsx
@@ -124,7 +124,7 @@ const Person = ({
       )}
       {isLoading && (
         <Card sx={{ padding: 3 }}>
-          <Skeleton width={600} />
+          <Skeleton width="100%" />
           <Skeleton height={200} width="100%" />
           <Skeleton height={100} />
           <Skeleton height={100} />

--- a/packages/web-app/src/components/common/PageLoader.jsx
+++ b/packages/web-app/src/components/common/PageLoader.jsx
@@ -4,10 +4,10 @@ import { styled } from '@mui/material/styles';
 
 const Container = styled('div')`
   width: 100%;
-  height: 200px;
+  min-height: 200px;
   display: flex;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
 `;
 
 const PageLoader = () => (

--- a/packages/web-app/src/components/common/Subscriptions/SubscriptionsList.jsx
+++ b/packages/web-app/src/components/common/Subscriptions/SubscriptionsList.jsx
@@ -38,7 +38,11 @@ const SubscriptionsList = ({
   const { countries, massifs, regions } = subscriptions ?? {};
 
   if (subscriptionsStatus === REDUCER_STATUS.LOADING)
-    return <CircularProgress />;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
 
   if (subscriptionsStatus === REDUCER_STATUS.SUCCEEDED)
     return (

--- a/packages/web-app/src/components/common/card/RandomEntryCard.jsx
+++ b/packages/web-app/src/components/common/card/RandomEntryCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import FullStarIcon from '@mui/icons-material/Star';
 import EmptyStarIcon from '@mui/icons-material/StarBorder';
 import HalfStarIcon from '@mui/icons-material/StarHalf';
+import { Box } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import { styled } from '@mui/material/styles';
 import withStyles from '@mui/styles/withStyles';
@@ -357,7 +358,11 @@ const RandomEntryCard = ({ entry, isFetching, fetch }) => {
   }, [fetch]);
 
   if (isFetching) {
-    return <CircularProgress />;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
   }
 
   if (entry && entry.id) {

--- a/packages/web-app/src/components/common/card/RecentChangesCard.jsx
+++ b/packages/web-app/src/components/common/card/RecentChangesCard.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import CircularProgress from '@mui/material/CircularProgress';
 import PropTypes from 'prop-types';
-import { Chip } from '@mui/material';
+import { Box, Chip } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import GCLink from '../GCLink';
 
@@ -169,7 +169,12 @@ const RecentChangesCard = ({ changes, isFetching, fetch }) => {
     fetch();
   }, [fetch]);
 
-  if (isFetching || !changes) return <CircularProgress />;
+  if (isFetching || !changes)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
   return (
     <ChangeTable>
       {changes.map((e, index) => (

--- a/packages/web-app/src/pages/EntrancesList/index.jsx
+++ b/packages/web-app/src/pages/EntrancesList/index.jsx
@@ -198,7 +198,7 @@ const EntrancesListPage = () => {
             !error && (
               <StyledList>
                 {skeletons.map((_, index) => (
-                  <Skeleton key={index} height={90} width={350} />
+                  <Skeleton key={index} height={90} width="100%" />
                 ))}
               </StyledList>
             )}

--- a/packages/web-app/src/pages/homepage/PartnersCarousel.jsx
+++ b/packages/web-app/src/pages/homepage/PartnersCarousel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import { styled } from '@mui/material/styles';
 import AliceCarousel from 'react-alice-carousel';
@@ -91,7 +92,11 @@ const PartnersCarousel = ({ fetch, partners, isFetching }) => {
   }, []);
 
   if (isFetching) {
-    return <CircularProgress />;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
   }
   if (rows.length > 0) {
     return (


### PR DESCRIPTION
# Loader sizing fixes — mobile overflow

## Context

Several loading states (skeletons and spinners) had fixed pixel widths or incorrect sizing that caused horizontal overflow and misaligned rendering on small screens.

---

## Changes

### 1. Skeleton width overflow (6 files)

Skeletons used as loading placeholders had hard-coded pixel widths that exceeded the viewport on mobile.

| File | Before | After |
|---|---|---|
| `components/appli/Entry/index.jsx` | `width={800}` | `width="100%"` |
| `components/appli/Network/index.jsx` | `width={800}` | `width="100%"` |
| `components/appli/Massif/Massif.jsx` | `width={800}` | `width="100%"` |
| `components/appli/Organization/index.jsx` | `width={800}` | `width="100%"` |
| `components/appli/Person/Person.jsx` | `width={600}` | `width="100%"` |
| `pages/EntrancesList/index.jsx` | `width={350}` | `width="100%"` |

---

### 2. Dead `Box` wrappers removed (4 files)

The map skeletons in Entry, Network, Massif, and Organization were wrapped in a `Box` with `justifyContent: 'center'` — originally there to center the fixed-width skeleton. After switching to `width="100%"`, that wrapper served no purpose and was removed along with the now-unused `Box` import.

Affected files: `Entry/index.jsx`, `Network/index.jsx`, `Massif/Massif.jsx`, `Organization/index.jsx`.

---

### 3. Uncentered `CircularProgress` spinners (4 files)

Several components returned a bare `<CircularProgress />` with no wrapper, causing the spinner to appear top-left aligned inside its container.

Each spinner is now wrapped in a centered `Box`:

```jsx
<Box sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}>
  <CircularProgress />
</Box>
```

Affected files:
- `components/common/card/RandomEntryCard.jsx`
- `components/common/card/RecentChangesCard.jsx`
- `pages/homepage/PartnersCarousel.jsx`
- `components/common/Subscriptions/SubscriptionsList.jsx`

---

### 4. `PageLoader` sizing and alignment

**File:** `components/common/PageLoader.jsx`

- `height: 200px` → `min-height: 200px`: prevents the loader from being clipped inside constrained containers while still providing a minimum visual area.
- `align-items: flex-end` → `align-items: center`: spinner was rendered at the bottom of the 200px zone; it is now vertically centered.
