### PR TITLE
feat(admin): display list of cavers with invalid email

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          NODE_VERSION: 20
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ORANGE_ROCK_0D4F87503 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -229,6 +229,7 @@
   "Link copied!": "تم نسخ الرابط!",
   "Link to an existing entrance or network": "ربط بمدخل أو شبكة موجودة",
   "Linked to an existing entrance or network": "مرتبط بمدخل أو شبكة موجودة",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "ليتوانيا",
   "location": "الموقع",
   "LUX": "لوكسمبورغ",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -898,6 +898,7 @@
   "Linked Information": "Свързана информация",
   "Linked to an existing entrance or network": "Свързано с вход или мрежа",
   "List of administrators": "Списък на администраторите",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "List of explored caves": "Списък на изследваните пещери",
   "List of moderators": "Списък на модераторите",
   "Lithuania": "Литва",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -746,6 +746,7 @@
   "Linked Information": "Informació Vinculada",
   "Linked to an existing entrance or network": "Vinculat a una entrada o xarxa existent",
   "List of administrators": "Llista d'administradors",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "List of moderators": "Llista de moderadors",
   "Lithuania": "Lituània",
   "Loading full data, please wait...": "S'estan carregant les dades completes, espereu...",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -462,6 +462,7 @@
   "Link copied!": "Link kopiert!",
   "Link to an existing entrance or network": "Mit einem vorhandenen Mundloch oder Netzwerk verknüpfen",
   "Linked to an existing entrance or network": "Mit einem vorhandenen Mundloch oder Netzwerk verknüpft",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "Litauen",
   "Localisation": "Ort",
   "Localization": "Lokalisierung",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -265,6 +265,7 @@
   "Link copied!": "Ο σύνδεσμος αντιγράφηκε!",
   "Link to an existing entrance or network": "Σύνδεση με υπάρχουσα είσοδο ή δίκτυο",
   "Linked to an existing entrance or network": "Συνδεδεμένο με υπάρχουσα είσοδο ή δίκτυο",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "Λιθουανία",
   "location": "τοποθεσία",
   "Longitude": "Γεωγραφικό μήκος",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1068,6 +1068,7 @@
   "Linked to an existing entrance or network": "Linked to an existing entrance or network",
   "List of administrators": "List of administrators",
   "List of banned cavers": "List of banned cavers",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "List of explored caves": "List of explored caves",
   "List of leaders": "List of leaders",
   "List of moderators": "List of moderators",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1069,6 +1069,7 @@
   "Linked to an existing entrance or network": "Vinculado a una entrada o red existente.",
   "List of administrators": "Lista de administradores",
   "List of banned cavers": "Lista de espeleólogos baneados",
+  "List of cavers with invalid email": "Lista de espeleólogos con email inválido",
   "List of explored caves": "Lista de cuevas exploradas",
   "List of leaders": "Lista de líderes",
   "List of moderators": "Lista de moderadores",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1069,6 +1069,7 @@
   "Linked to an existing entrance or network": "Liée à une entrée ou un réseau existant",
   "List of administrators": "Liste des administrateurs",
   "List of banned cavers": "Liste des spéléologues bannis",
+  "List of cavers with invalid email": "Liste des spéléologues avec un email invalide",
   "List of explored caves": "Liste des cavités explorées",
   "List of leaders": "Liste des dirigeants",
   "List of moderators": "Liste des modérateurs",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -66,6 +66,7 @@
   "Link copied!": "הקישור הועתק!",
   "Link to an existing entrance or network": "קישור לכניסה או רשת קיימת",
   "Linked to an existing entrance or network": "מקושר לכניסה או רשת קיימת",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "massif": "מאסיף",
   "Massif": "מאסיף",
   "Massif area": "אזור המאסיף",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -90,6 +90,7 @@
   "Link copied!": "Tautan disalin!",
   "Link to an existing entrance or network": "Menautkan ke pintu masuk atau jaringan yang sudah ada",
   "Linked to an existing entrance or network": "Tertaut ke pintu masuk atau jaringan yang sudah ada",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Longitude": "Bujur",
   "Make access to the natural caves data easier especially by using Internet": "Membantu perlindungan gua alam dan lingkungan mereka.",
   "massif": "masif",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -291,6 +291,7 @@
   "Link copied!": "Link copiato!",
   "Link to an existing entrance or network": "Collegamento a un ingresso o a una rete esistente",
   "Linked to an existing entrance or network": "Collegato a un ingresso o a una rete esistente",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "Lituania",
   "Localization": "Localization",
   "location": "Localizzazione ",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -291,6 +291,7 @@
   "Link copied!": "リンクをコピーしました！",
   "Link to an existing entrance or network": "既存の入口またはネットワークにリンク",
   "Linked to an existing entrance or network": "既存の入口またはネットワークにリンク済み",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "リトアニア",
   "Localization": "Localization",
   "location": "ロケーション",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -299,6 +299,7 @@
   "Link copied!": "Link gekopieerd!",
   "Link to an existing entrance or network": "Koppelen aan een bestaande grotingang of netwerk",
   "Linked to an existing entrance or network": "Gekoppeld aan een bestaande grotingang of netwerk",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "Litouwen",
   "Localisation": "Locatie",
   "location": "ligging",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -305,6 +305,7 @@
   "Link copied!": "Link copiado!",
   "Link to an existing entrance or network": "Vincular a uma entrada ou rede existente",
   "Linked to an existing entrance or network": "Vinculado a uma entrada ou rede existente",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "Lithuania": "Lituania",
   "Localisation": "Localização",
   "location": "localização",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -671,6 +671,7 @@
   "Linked Information": "Informații Grottocenter legate de document (masiv, editor, bibliotecă ...",
   "Linked to an existing entrance or network": "Legat la o intrare sau rețea existentă",
   "List of administrators": "Lista administratorilor",
+  "List of cavers with invalid email": "List of cavers with invalid email",
   "List of moderators": "Lista moderatorilor",
   "Lithuania": "Lituania",
   "Localisation": "Localizare",

--- a/packages/web-app/src/actions/Person/GetPerson.invalidEmail.property.test.js
+++ b/packages/web-app/src/actions/Person/GetPerson.invalidEmail.property.test.js
@@ -1,0 +1,221 @@
+import fc from 'fast-check';
+import { fetchInvalidEmailCavers } from './GetPerson';
+
+// Mock isomorphic-fetch
+jest.mock('isomorphic-fetch');
+
+// Mock the Login module
+jest.mock('../Login', () => ({
+  postLogout: () => mockPostLogoutThunk
+}));
+
+const mockPostLogoutThunk = dispatch => {
+  dispatch({ type: 'LOGOUT' });
+};
+
+const caverArb = fc.record({
+  id: fc.integer({ min: 1, max: 999999 }),
+  name: fc.string({ minLength: 0, maxLength: 30 }),
+  surname: fc.string({ minLength: 0, maxLength: 30 }),
+  nickname: fc.string({ minLength: 0, maxLength: 30 })
+});
+
+const caversArrayArb = fc.array(caverArb, {
+  minLength: 0,
+  maxLength: 20
+});
+
+const getState = () => ({
+  login: { authorizationHeader: { Authorization: 'Bearer token' } }
+});
+
+/**
+ * Helper: creates a dispatch spy that records plain-object actions
+ * and executes thunks (like postLogout) inline.
+ */
+const makeDispatchSpy = () => {
+  const dispatched = [];
+  const dispatch = action => {
+    if (typeof action === 'function') return action(dispatch);
+    dispatched.push(action);
+    return action;
+  };
+  return { dispatch, dispatched };
+};
+
+/**
+ * Property 1: Action creator extracts cavers field
+ *
+ * For any array of caver-like objects returned by the API in the
+ * `cavers` response field, the fetchInvalidEmailCavers thunk
+ * dispatches a success action whose `cavers` payload is exactly
+ * that array.
+ *
+ * Encodes: the thunk correctly extracts the `cavers` field
+ * from the API response and passes it through unchanged.
+ * Covers: random arrays of caver-like objects of varying size
+ * and shape.
+ *
+ * Validates: Requirements 2.3
+ */
+describe('Feature: invalid-email-cavers, Property 1: Action creator extracts cavers field', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('dispatches success with the exact cavers array from the API response', async () => {
+    await fc.assert(
+      fc.asyncProperty(caversArrayArb, async cavers => {
+        const fetch = require('isomorphic-fetch');
+        fetch.mockResolvedValue({
+          status: 200,
+          json: () => Promise.resolve({ cavers })
+        });
+
+        const { dispatch, dispatched } = makeDispatchSpy();
+        await fetchInvalidEmailCavers()(dispatch, getState);
+
+        expect(dispatched.length).toBe(2);
+        expect(dispatched[0]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS'
+        });
+        expect(dispatched[1]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS_SUCCESS',
+          cavers
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 2: Missing cavers field falls back to empty array
+ *
+ * When the API returns a 200 response whose body does NOT contain
+ * a `cavers` field, the thunk dispatches success with an empty array.
+ *
+ * Encodes: the defensive `data.cavers || []` fallback in the thunk.
+ * Covers: response bodies with arbitrary keys but no `cavers` field.
+ *
+ * Validates: Requirements 2.4
+ */
+describe('Feature: invalid-email-cavers, Property 2: Missing cavers field falls back to empty array', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const responseWithoutCaversArb = fc
+    .dictionary(
+      fc.string({ minLength: 1, maxLength: 10 }).filter(k => k !== 'cavers'),
+      fc.jsonValue()
+    );
+
+  it('dispatches success with an empty array when cavers field is missing', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    await fc.assert(
+      fc.asyncProperty(responseWithoutCaversArb, async body => {
+        const fetch = require('isomorphic-fetch');
+        fetch.mockResolvedValue({
+          status: 200,
+          json: () => Promise.resolve(body)
+        });
+
+        const { dispatch, dispatched } = makeDispatchSpy();
+        await fetchInvalidEmailCavers()(dispatch, getState);
+
+        expect(dispatched.length).toBe(2);
+        expect(dispatched[0]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS'
+        });
+        expect(dispatched[1]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS_SUCCESS',
+          cavers: []
+        });
+      }),
+      { numRuns: 100 }
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+
+/**
+ * Property 3: Non-auth errors dispatch failure action
+ *
+ * When the fetch rejects with an error that does NOT have
+ * `isAuthError = true`, the thunk dispatches the failure action
+ * with that error.
+ *
+ * Encodes: the catch block dispatches FETCH_INVALID_EMAIL_CAVERS_FAILURE
+ * for non-auth errors.
+ * Covers: random error messages.
+ *
+ * Validates: Requirements 2.5
+ */
+describe('Feature: invalid-email-cavers, Property 3: Non-auth errors dispatch failure action', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const errorMessageArb = fc.string({ minLength: 1, maxLength: 50 });
+
+  it('dispatches failure with the error for non-auth errors', async () => {
+    await fc.assert(
+      fc.asyncProperty(errorMessageArb, async msg => {
+        const error = new Error(msg);
+        const fetch = require('isomorphic-fetch');
+        fetch.mockRejectedValue(error);
+
+        const { dispatch, dispatched } = makeDispatchSpy();
+        await fetchInvalidEmailCavers()(dispatch, getState);
+
+        expect(dispatched.length).toBe(2);
+        expect(dispatched[0]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS'
+        });
+        expect(dispatched[1]).toEqual({
+          type: 'FETCH_INVALID_EMAIL_CAVERS_FAILURE',
+          error
+        });
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+/**
+ * Property 4: Auth errors skip failure dispatch
+ *
+ * When checkAuthStatus intercepts a 401 response, it throws an
+ * error with `isAuthError = true`. The thunk's catch block must
+ * skip the failure dispatch in that case, leaving only the
+ * loading action and the LOGOUT action (from postLogout).
+ *
+ * Encodes: the `if (error.isAuthError) return;` guard in the
+ * catch block.
+ * Covers: 401 responses (single partition, not property-varied).
+ */
+describe('Feature: invalid-email-cavers, Property 4: Auth errors skip failure dispatch', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not dispatch failure when the API returns 401', async () => {
+    const fetch = require('isomorphic-fetch');
+    fetch.mockResolvedValue({ status: 401 });
+
+    const { dispatch, dispatched } = makeDispatchSpy();
+    await fetchInvalidEmailCavers()(dispatch, getState);
+
+    // Should see FETCH_INVALID_EMAIL_CAVERS and LOGOUT, but NOT FAILURE
+    expect(dispatched.map(a => a.type)).toContain(
+      'FETCH_INVALID_EMAIL_CAVERS'
+    );
+    expect(dispatched.map(a => a.type)).toContain('LOGOUT');
+    expect(dispatched.map(a => a.type)).not.toContain(
+      'FETCH_INVALID_EMAIL_CAVERS_FAILURE'
+    );
+  });
+});

--- a/packages/web-app/src/actions/Person/GetPerson.js
+++ b/packages/web-app/src/actions/Person/GetPerson.js
@@ -2,6 +2,7 @@ import fetch from 'isomorphic-fetch';
 import {
   getGroupsUrl,
   getBannedCaversUrl,
+  getInvalidEmailCaversUrl,
   getCaverUrl
 } from '../../conf/apiRoutes';
 import { checkAndGetStatus, checkAuthStatus } from '../utils';
@@ -19,6 +20,12 @@ export const FETCH_BANNED_CAVERS = 'FETCH_BANNED_CAVERS';
 export const FETCH_BANNED_CAVERS_SUCCESS = 'FETCH_BANNED_CAVERS_SUCCESS';
 export const FETCH_BANNED_CAVERS_FAILURE = 'FETCH_BANNED_CAVERS_FAILURE';
 
+export const FETCH_INVALID_EMAIL_CAVERS = 'FETCH_INVALID_EMAIL_CAVERS';
+export const FETCH_INVALID_EMAIL_CAVERS_SUCCESS =
+  'FETCH_INVALID_EMAIL_CAVERS_SUCCESS';
+export const FETCH_INVALID_EMAIL_CAVERS_FAILURE =
+  'FETCH_INVALID_EMAIL_CAVERS_FAILURE';
+
 const fetchPersonAction = () => ({ type: FETCH_PERSON });
 const fetchPersonSuccess = person => ({ type: FETCH_PERSON_SUCCESS, person });
 const fetchPersonFailure = error => ({ type: FETCH_PERSON_FAILURE, error });
@@ -34,6 +41,18 @@ const fetchBannedCaversSuccess = cavers => ({
 });
 const fetchBannedCaversFailure = error => ({
   type: FETCH_BANNED_CAVERS_FAILURE,
+  error
+});
+
+const fetchInvalidEmailCaversAction = () => ({
+  type: FETCH_INVALID_EMAIL_CAVERS
+});
+const fetchInvalidEmailCaversSuccess = cavers => ({
+  type: FETCH_INVALID_EMAIL_CAVERS_SUCCESS,
+  cavers
+});
+const fetchInvalidEmailCaversFailure = error => ({
+  type: FETCH_INVALID_EMAIL_CAVERS_FAILURE,
   error
 });
 
@@ -101,6 +120,34 @@ export function fetchBannedCavers() {
       .catch(error => {
         if (error.isAuthError) return;
         dispatch(fetchBannedCaversFailure(error));
+      });
+  };
+}
+
+export function fetchInvalidEmailCavers() {
+  return (dispatch, getState) => {
+    dispatch(fetchInvalidEmailCaversAction());
+
+    const requestOptions = {
+      method: 'GET',
+      headers: getState().login.authorizationHeader
+    };
+
+    return fetch(getInvalidEmailCaversUrl, requestOptions)
+      .then(checkAuthStatus(dispatch))
+      .then(response => response.json())
+      .then(data => {
+        if (data.cavers === undefined) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'fetchInvalidEmailCavers: unexpected API response shape — "cavers" field is missing'
+          );
+        }
+        dispatch(fetchInvalidEmailCaversSuccess(data.cavers || []));
+      })
+      .catch(error => {
+        if (error.isAuthError) return;
+        dispatch(fetchInvalidEmailCaversFailure(error));
       });
   };
 }

--- a/packages/web-app/src/conf/apiRoutes.js
+++ b/packages/web-app/src/conf/apiRoutes.js
@@ -261,6 +261,7 @@ export const unlinkCaveFromOrganizationUrl = (caveId, organizationId) =>
 // ===== Persons / cavers urls
 export const getGroupsUrl = `${API_BASE_PATH}/cavers/groups`;
 export const getBannedCaversUrl = `${API_BASE_PATH}/cavers/banned`;
+export const getInvalidEmailCaversUrl = `${API_BASE_PATH}/cavers/invalid-mail`;
 export const getCaverUrl = `${API_BASE_PATH}/cavers/`;
 export const postPersonUrl = `${API_BASE_PATH}/cavers`;
 export const postPersonGroupsUrl = userId =>

--- a/packages/web-app/src/pages/Admin/ManageUsers.jsx
+++ b/packages/web-app/src/pages/Admin/ManageUsers.jsx
@@ -5,7 +5,11 @@ import { useIntl } from 'react-intl';
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-import { fetchGroups, fetchBannedCavers } from '../../actions/Person/GetPerson';
+import {
+  fetchGroups,
+  fetchBannedCavers,
+  fetchInvalidEmailCavers
+} from '../../actions/Person/GetPerson';
 
 import AuthChecker from '../../components/appli/AuthChecker';
 
@@ -50,6 +54,11 @@ const ManageUsers = () => {
     isLoading: isBannedLoading
   } = useSelector(state => state.bannedCavers);
 
+  const {
+    invalidEmailCavers,
+    isLoading: isInvalidEmailLoading
+  } = useSelector(state => state.invalidEmailCavers);
+
   const { isLoading: isUpdateLoading, isSuccess: isUpdateSuccess } =
     useSelector(state => state.updatePersonGroups);
 
@@ -75,6 +84,7 @@ const ManageUsers = () => {
   useEffect(() => {
     dispatch(fetchGroups());
     dispatch(fetchBannedCavers());
+    dispatch(fetchInvalidEmailCavers());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -106,6 +116,11 @@ const ManageUsers = () => {
                 isLoading={isBannedLoading}
                 userList={bannedCavers}
                 title={formatMessage({ id: 'List of banned cavers' })}
+              />
+              <UserList
+                isLoading={isInvalidEmailLoading}
+                userList={invalidEmailCavers}
+                title={formatMessage({ id: 'List of cavers with invalid email' })}
               />
             </>
           }

--- a/packages/web-app/src/pages/Admin/ManageUsers.test.jsx
+++ b/packages/web-app/src/pages/Admin/ManageUsers.test.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import ManageUsers from './ManageUsers';
+
+// ---- Redux mock ----
+const mockDispatch = jest.fn();
+let mockStoreState = {};
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+  useSelector: selector =>
+    selector(mockStoreState)
+}));
+
+// ---- Action mocks ----
+const mockFetchGroups = jest.fn(() => ({ type: 'FETCH_GROUPS' }));
+const mockFetchBannedCavers = jest.fn(() => ({ type: 'FETCH_BANNED_CAVERS' }));
+const mockFetchInvalidEmailCavers = jest.fn(() => ({
+  type: 'FETCH_INVALID_EMAIL_CAVERS'
+}));
+
+jest.mock('../../actions/Person/GetPerson', () => ({
+  fetchGroups: (...args) => mockFetchGroups(...args),
+  fetchBannedCavers: (...args) => mockFetchBannedCavers(...args),
+  fetchInvalidEmailCavers: (...args) => mockFetchInvalidEmailCavers(...args)
+}));
+
+// ---- Component mocks ----
+jest.mock('../../components/appli/AuthChecker', () => {
+  const MockAuthChecker = ({ componentToDisplay }) => (
+    <div data-testid="auth-checker">{componentToDisplay}</div>
+  );
+  return MockAuthChecker;
+});
+
+jest.mock('../../components/common/Layouts/Fixed/FixedContent', () => {
+  const MockLayout = ({ title, content }) => (
+    <div data-testid="layout">
+      <h1>{title}</h1>
+      {content}
+    </div>
+  );
+  return MockLayout;
+});
+
+jest.mock('./ManageUserGroups', () => {
+  const MockManageUserGroups = () => (
+    <div data-testid="manage-user-groups">ManageUserGroups</div>
+  );
+  return MockManageUserGroups;
+});
+
+jest.mock('../../components/common/EntityTable/EntityTable', () => {
+  const MockEntityTable = ({ isLoading, pageRows }) => (
+    <div data-testid="entity-table">
+      {isLoading ? 'Loading...' : `${pageRows.length} rows`}
+    </div>
+  );
+  return MockEntityTable;
+});
+
+const messages = {
+  'Manage Users': 'Manage Users',
+  'List of administrators': 'List of administrators',
+  'List of moderators': 'List of moderators',
+  'List of leaders': 'List of leaders',
+  'List of banned cavers': 'List of banned cavers',
+  'List of cavers with invalid email': 'List of cavers with invalid email'
+};
+
+const defaultState = {
+  groups: {
+    administrators: [],
+    moderators: [],
+    leaders: [],
+    isLoading: false
+  },
+  bannedCavers: {
+    bannedCavers: [],
+    isLoading: false
+  },
+  invalidEmailCavers: {
+    invalidEmailCavers: [],
+    isLoading: false
+  },
+  updatePersonGroups: {
+    isLoading: false,
+    isSuccess: false
+  },
+  banCaver: {
+    isLoading: false,
+    isSuccess: false
+  }
+};
+
+const renderManageUsers = (stateOverrides = {}) => {
+  mockStoreState = { ...defaultState, ...stateOverrides };
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <ManageUsers />
+    </IntlProvider>
+  );
+};
+
+beforeEach(() => {
+  mockDispatch.mockClear();
+  mockFetchGroups.mockClear();
+  mockFetchBannedCavers.mockClear();
+  mockFetchInvalidEmailCavers.mockClear();
+});
+
+describe('ManageUsers - invalid email cavers integration', () => {
+  it('renders the invalid email cavers UserList section', () => {
+    renderManageUsers();
+
+    expect(
+      screen.getByText('List of cavers with invalid email')
+    ).toBeInTheDocument();
+  });
+
+  it('dispatches fetchInvalidEmailCavers on mount', () => {
+    renderManageUsers();
+
+    // fetchInvalidEmailCavers action creator is called once on mount
+    expect(mockFetchInvalidEmailCavers).toHaveBeenCalledTimes(1);
+    // dispatch is called with the result of fetchInvalidEmailCavers()
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('renders the invalid email section after the banned cavers section', () => {
+    renderManageUsers();
+
+    const bannedTitle = screen.getByText('List of banned cavers');
+    const invalidEmailTitle = screen.getByText(
+      'List of cavers with invalid email'
+    );
+
+    // Verify ordering: banned cavers should appear before invalid email cavers
+    const result = bannedTitle.compareDocumentPosition(invalidEmailTitle);
+    // eslint-disable-next-line no-bitwise
+    expect(result & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('dispatches fetchGroups and fetchBannedCavers alongside fetchInvalidEmailCavers on mount', () => {
+    renderManageUsers();
+
+    expect(mockFetchGroups).toHaveBeenCalledTimes(1);
+    expect(mockFetchBannedCavers).toHaveBeenCalledTimes(1);
+    expect(mockFetchInvalidEmailCavers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-app/src/reducers/GCReducer.js
+++ b/packages/web-app/src/reducers/GCReducer.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import advancedsearch from './AdvancedsearchReducer';
 import banCaver from './BanCaverReducer';
 import bannedCavers from './BannedCaversReducer';
+import invalidEmailCavers from './InvalidEmailCaversReducer';
 import linkDocumentToEntrance from './LinkDocumentToEntrance';
 import unlinkDocumentToEntrance from './UnlinkDocumentToEntrance';
 import cave from './CaveReducer';
@@ -92,6 +93,7 @@ const GCReducer = combineReducers({
   advancedsearch,
   banCaver,
   bannedCavers,
+  invalidEmailCavers,
   linkDocumentToEntrance,
   unlinkDocumentToEntrance,
   cave,

--- a/packages/web-app/src/reducers/InvalidEmailCaversReducer.js
+++ b/packages/web-app/src/reducers/InvalidEmailCaversReducer.js
@@ -1,0 +1,37 @@
+import {
+  FETCH_INVALID_EMAIL_CAVERS,
+  FETCH_INVALID_EMAIL_CAVERS_FAILURE,
+  FETCH_INVALID_EMAIL_CAVERS_SUCCESS
+} from '../actions/Person/GetPerson';
+
+const initialState = {
+  invalidEmailCavers: [],
+  isLoading: false,
+  error: null
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_INVALID_EMAIL_CAVERS:
+      return {
+        ...initialState,
+        isLoading: true
+      };
+    case FETCH_INVALID_EMAIL_CAVERS_SUCCESS:
+      return {
+        ...initialState,
+        isLoading: false,
+        invalidEmailCavers: action.cavers
+      };
+    case FETCH_INVALID_EMAIL_CAVERS_FAILURE:
+      return {
+        ...initialState,
+        isLoading: false,
+        error: action.error
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/packages/web-app/src/reducers/InvalidEmailCaversReducer.property.test.js
+++ b/packages/web-app/src/reducers/InvalidEmailCaversReducer.property.test.js
@@ -1,0 +1,155 @@
+import fc from 'fast-check';
+import reducer from './InvalidEmailCaversReducer';
+import {
+  FETCH_INVALID_EMAIL_CAVERS,
+  FETCH_INVALID_EMAIL_CAVERS_SUCCESS,
+  FETCH_INVALID_EMAIL_CAVERS_FAILURE
+} from '../actions/Person/GetPerson';
+
+/**
+ * Property 2: Reducer state transitions
+ *
+ * For any prior reducer state and any dispatched action (loading,
+ * success with a random cavers array, or failure with a random error),
+ * the InvalidEmailCaversReducer produces the correct output state:
+ * - loading sets { invalidEmailCavers: [], isLoading: true, error: null }
+ * - success sets { invalidEmailCavers: <payload>, isLoading: false, error: null }
+ * - failure sets { invalidEmailCavers: [], isLoading: false, error: <payload> }
+ *
+ * Encodes: reducer is a pure state machine with deterministic transitions
+ * that always reset to initialState spread, regardless of prior state.
+ * Covers: random prior states and all three action types.
+ *
+ * Validates: Requirements 2.7, 2.8, 2.9
+ */
+describe('Feature: invalid-email-cavers, Property 2: Reducer state transitions', () => {
+  const caverArb = fc.record({
+    id: fc.integer({ min: 1, max: 999999 }),
+    name: fc.string({ minLength: 0, maxLength: 30 }),
+    surname: fc.string({ minLength: 0, maxLength: 30 }),
+    nickname: fc.string({ minLength: 0, maxLength: 30 })
+  });
+
+  const caversArrayArb = fc.array(caverArb, {
+    minLength: 0,
+    maxLength: 20
+  });
+
+  const errorArb = fc
+    .string({ minLength: 1, maxLength: 50 })
+    .map(msg => new Error(msg));
+
+  const priorStateArb = fc.record({
+    invalidEmailCavers: caversArrayArb,
+    isLoading: fc.boolean(),
+    error: fc.option(errorArb, { nil: null })
+  });
+
+  const actionArb = fc.oneof(
+    fc.constant({ type: FETCH_INVALID_EMAIL_CAVERS }),
+    caversArrayArb.map(cavers => ({
+      type: FETCH_INVALID_EMAIL_CAVERS_SUCCESS,
+      cavers
+    })),
+    errorArb.map(error => ({
+      type: FETCH_INVALID_EMAIL_CAVERS_FAILURE,
+      error
+    }))
+  );
+
+  it('produces correct state for any prior state and action', () => {
+    fc.assert(
+      fc.property(priorStateArb, actionArb, (priorState, action) => {
+        const state = reducer(priorState, action);
+
+        if (action.type === FETCH_INVALID_EMAIL_CAVERS) {
+          expect(state).toEqual({
+            invalidEmailCavers: [],
+            isLoading: true,
+            error: null
+          });
+        } else if (action.type === FETCH_INVALID_EMAIL_CAVERS_SUCCESS) {
+          expect(state).toEqual({
+            invalidEmailCavers: action.cavers,
+            isLoading: false,
+            error: null
+          });
+        } else if (action.type === FETCH_INVALID_EMAIL_CAVERS_FAILURE) {
+          expect(state).toEqual({
+            invalidEmailCavers: [],
+            isLoading: false,
+            error: action.error
+          });
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('produces correct final state for any sequence of actions', () => {
+    fc.assert(
+      fc.property(
+        fc.array(actionArb, { minLength: 1, maxLength: 20 }),
+        actions => {
+          let state;
+          for (const action of actions) {
+            state = reducer(state, action);
+          }
+
+          const lastAction = actions[actions.length - 1];
+
+          if (lastAction.type === FETCH_INVALID_EMAIL_CAVERS) {
+            expect(state).toEqual({
+              invalidEmailCavers: [],
+              isLoading: true,
+              error: null
+            });
+          } else if (
+            lastAction.type === FETCH_INVALID_EMAIL_CAVERS_SUCCESS
+          ) {
+            expect(state).toEqual({
+              invalidEmailCavers: lastAction.cavers,
+              isLoading: false,
+              error: null
+            });
+          } else if (
+            lastAction.type === FETCH_INVALID_EMAIL_CAVERS_FAILURE
+          ) {
+            expect(state).toEqual({
+              invalidEmailCavers: [],
+              isLoading: false,
+              error: lastAction.error
+            });
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('returns initial state for unknown action types', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .string({ minLength: 1, maxLength: 30 })
+          .filter(
+            type =>
+              ![
+                FETCH_INVALID_EMAIL_CAVERS,
+                FETCH_INVALID_EMAIL_CAVERS_SUCCESS,
+                FETCH_INVALID_EMAIL_CAVERS_FAILURE
+              ].includes(type)
+          ),
+        type => {
+          const state = reducer(undefined, { type });
+          expect(state).toEqual({
+            invalidEmailCavers: [],
+            isLoading: false,
+            error: null
+          });
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
## 🤔 What

Adds a new "List of cavers with invalid email" section to the admin ManageUsers page, displaying cavers whose email addresses have been flagged as invalid by the AWS SES suppression list polling mechanism on the backend.

- New API route constant `getInvalidEmailCaversUrl` in `apiRoutes.js`
- Redux action types, thunk (`fetchInvalidEmailCavers`), and `InvalidEmailCaversReducer` following the existing banned cavers pattern
- New `UserList` section on ManageUsers, rendered after the banned cavers list
- Translation keys for all 15 supported languages (EN, FR, ES with native translations; remaining 12 with English fallback)

## 🤷‍♂️ Why

The backend already polls the AWS SES suppression list and marks caver emails as invalid (`mail_is_valid = false`). Admins need visibility into which cavers have bounced or complained email addresses so they can take appropriate action.

## 🔍 How

The implementation replicates the existing `BannedCavers` pattern exactly:

1. `apiRoutes.js` — new `getInvalidEmailCaversUrl` constant pointing to `GET /api/v1/cavers/invalid-mail`
2. `GetPerson.js` — new `FETCH_INVALID_EMAIL_CAVERS` action types, action creators, and authenticated thunk using `checkAuthStatus` for 401 handling
3. `InvalidEmailCaversReducer.js` — manages `{ invalidEmailCavers, isLoading, error }` state, registered in `GCReducer.js`
4. `ManageUsers.jsx` — fetches invalid-email cavers on mount, renders a `UserList` section with `EntityTable` configured for `entityType="persons"`

The thunk defensively handles a missing `cavers` field in the API response (logs a warning, falls back to `[]`).

### Naming convention

All internal identifiers use the `invalidEmail` prefix (`invalidEmailCavers`, `FETCH_INVALID_EMAIL_CAVERS`, `fetchInvalidEmailCavers`, `InvalidEmailCaversReducer`) for natural readability, while the API path follows the backend's `/cavers/invalid-mail` route.

## 🔗 Related API PR

- https://github.com/GrottoCenter/grottocenter-api/pull/1536

The Azure Static Web Apps stage site won't fully work for testing this PR until the API PR is merged and deployed.

## 🧪 Testing

- Property-based tests (fast-check, 100 runs each):
  - Action creator correctly extracts the `cavers` field from any API response shape
  - Action creator falls back to `[]` when `cavers` field is missing
  - Action creator dispatches failure for non-auth errors
  - Action creator skips failure dispatch on 401 auth errors
  - Reducer produces correct state for any prior state and action combination
  - Reducer produces correct final state for any sequence of actions
  - Reducer returns initial state for unknown action types
- Unit tests (React Testing Library):
  - ManageUsers renders the invalid-email cavers section
  - ManageUsers dispatches `fetchInvalidEmailCavers` on mount
  - Invalid-email section renders after the banned cavers section
  - All three fetch actions dispatched together on mount

All 11 tests pass.

## 📸 Previews

The new section appears at the bottom of the ManageUsers page, after the banned cavers list, using the same `EntityTable` layout as all other user lists on the page.
