### PR TITLE
Fix massif creation and edition form

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifFields.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifFields.jsx
@@ -10,8 +10,9 @@ import { FormRow, FormSectionLabel } from '../utils/FormContainers';
 
 const PolygonMap = React.lazy(() => import('./PolygonMap'));
 
-const MassifFields = ({ control, errors, geoJson, isNew }) => {
+const MassifFields = ({ control, errors, geoJson }) => {
   const { formatMessage } = useIntl();
+
   return (
     <>
       <FormSectionLabel label={formatMessage({ id: 'Basic Information' })} />
@@ -31,29 +32,6 @@ const MassifFields = ({ control, errors, geoJson, isNew }) => {
         />
       </FormRow>
 
-      {isNew && (
-        <>
-          <FormSectionLabel
-            label={formatMessage({ id: 'Description of the massif' })}
-          />
-          <InputText
-            formKey="massif.descriptionTitle"
-            labelName="Title"
-            control={control}
-            isError={!!errors?.massif?.descriptionTitle}
-            isRequired
-          />
-          <InputText
-            formKey="massif.descriptionBody"
-            labelName="Description"
-            control={control}
-            isError={!!errors?.massif?.description}
-            isRequired
-            minRows={6}
-          />
-        </>
-      )}
-
       <FormSectionLabel label={formatMessage({ id: 'Massif area' })} />
       <FormHelperText>
         {formatMessage({
@@ -67,8 +45,7 @@ const MassifFields = ({ control, errors, geoJson, isNew }) => {
             <Skeleton width={75} />
             <Skeleton width={100} />
           </>
-        }
-      >
+        }>
         <Controller
           name="massif.geogPolygon"
           control={control}
@@ -91,8 +68,7 @@ MassifFields.propTypes = {
       geoJson: PropTypes.shape({})
     })
   }),
-  geoJson: PropTypes.shape({}),
-  isNew: PropTypes.bool
+  geoJson: PropTypes.shape({})
 };
 
 export default MassifFields;

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonLayersList.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonLayersList.jsx
@@ -34,7 +34,7 @@ const PolygonLayersList = ({
   const hasNeedles = layers.some(l => l.isNeedle);
 
   return (
-    <Paper sx={{ width: 250, maxHeight: '70vh', overflow: 'auto' }}>
+    <Paper sx={{ width: { xs: '100%', md: 250 }, maxHeight: { xs: 300, md: '70vh' }, overflow: 'auto' }}>
       {allHoles && (
         <Alert severity="error" sx={{ py: 0 }}>
           {formatMessage({

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -4,7 +4,7 @@ import { MapContainer, FeatureGroup, ScaleControl } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import L from 'leaflet';
 import { useIntl } from 'react-intl';
-import { Box } from '@mui/material';
+import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { useNotification, useProjections } from '../../../../hooks';
 import useGeolocation from '../../../../hooks/useGeolocation';
 import LayersControl from '../../../common/Maps/common/LayersControl';
@@ -67,6 +67,8 @@ const detectHoles = layers => {
 
 const PolygonMap = ({ onChange, data }) => {
   const { formatMessage } = useIntl();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   useProjections();
   const isMounted = useRef(true);
   const displayValue = useRef(false);
@@ -169,6 +171,13 @@ const PolygonMap = ({ onChange, data }) => {
       )
     : geoLocation;
   const ZOOM_LEVEL = hasCoordinates || hasLocation ? focusZoom : defaultZoom;
+
+  useEffect(() => {
+    if (map) {
+      const t = setTimeout(() => map.invalidateSize(), 200);
+      return () => clearTimeout(t);
+    }
+  }, [map, isMobile]);
 
   useEffect(() => {
     if (map) {
@@ -504,7 +513,7 @@ const PolygonMap = ({ onChange, data }) => {
         />
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 2 }}>
+      <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', md: 'row' } }}>
         <MapContainer
           center={initialCenter}
           zoom={ZOOM_LEVEL}
@@ -513,8 +522,8 @@ const PolygonMap = ({ onChange, data }) => {
           }}
           position="topLeft"
           style={{
-            height: '70dvh',
-            flex: 1
+            height: isMobile ? '50dvh' : '70dvh',
+            ...(isMobile ? { width: '100%' } : { flex: 1 })
           }}>
           <FeatureGroup
             ref={reactFGref => {

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/index.jsx
@@ -17,8 +17,6 @@ import MassifFields from './MassifFields';
 const defaultMassifValues = {
   name: '',
   language: '',
-  descriptionTitle: '',
-  descriptionBody: '',
   geogPolygon: null
 };
 
@@ -95,8 +93,6 @@ export const MassifForm = ({ massifValues, onCancel }) => {
       dispatch(
         postMassif({
           name: data.massif.name,
-          description: data.massif.descriptionBody,
-          descriptionTitle: data.massif.descriptionTitle,
           descriptionAndNameLanguage: { id: data.massif.language },
           geogPolygon: data.massif.geogPolygon
         })
@@ -147,7 +143,6 @@ export const MassifForm = ({ massifValues, onCancel }) => {
           control={control}
           errors={errors}
           geoJson={geoJson}
-          isNew={isNewMassif}
         />
         <FormActionRow
           isNew={isNewMassif}


### PR DESCRIPTION
# Massif creation form: remove description fields

Linked to https://github.com/GrottoCenter/grottocenter-api/pull/1555

## What changed

The API no longer requires a description or title when creating a massif. The creation form has been updated accordingly:

- Removed `descriptionTitle` and `descriptionBody` fields from `MassifFields.jsx`
- Removed `descriptionTitle`, `descriptionBody` from `defaultMassifValues` in `index.jsx`
- The `postMassif` payload now only sends `name`, `descriptionAndNameLanguage`, and `geogPolygon`

## Why it makes sense

Descriptions are already handled as a separate concern in the app. On any massif page, the `Descriptions` ScrollableContent component lets authenticated users add, edit, and reorder descriptions independently — after the massif is created.

Duplicating that capability in the creation form would mean maintaining two separate code paths for the same data, with different validation logic, different UX patterns, and different API calls. It also creates an asymmetry: description editing is never part of the massif edit form, only creation — which is confusing.

The right flow is:
1. Create the massif (name + language + area)
2. Add descriptions from the massif page, using the existing `Descriptions` component

This keeps the creation form minimal and focused, and reuses the existing description infrastructure for everything description-related.

---

## Responsive layout

Made the massif creation/edit form responsive, with a focus on the map area (`PolygonMap.jsx`, `PolygonLayersList.jsx`).