### PR TITLE
feat(notification): support REJECT notification type

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "الكهف الإقليمي",
   "regions": "المناطق",
   "Regions": "مناطق",
+  "rejected": "مرفوض",
   "Related to": "مرتبط بـ",
   "Reload": "إعادة تحميل",
   "remove": "إزالة",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Регионална спелеология",
   "regions": "региони",
   "Regions": "Региони",
+  "rejected": "отхвърлен",
   "Related to": "Свързано с",
   "Reload": "Презареди",
   "remove": "премахни",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Espeleologia regional",
   "regions": "regions",
   "Regions": "Regions",
+  "rejected": "rebutjat",
   "Related to": "Relacionat amb",
   "Reload": "Recarregar",
   "remove": "eliminar",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -1543,6 +1543,7 @@
   "Regional speleology": "Regionale Speläologie",
   "regions": "Regionen",
   "Regions": "Regionen",
+  "rejected": "abgelehnt",
   "Related to": "Bezogen auf",
   "Reload": "Neu laden",
   "remove": "entfernen",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Περιφερειακή σπηλαιολογία",
   "regions": "περιοχές",
   "Regions": "Περιοχές",
+  "rejected": "απορρίφθηκε",
   "Related to": "Σχετικό με",
   "Reload": "Επαναφόρτωση",
   "remove": "αφαίρεση",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1544,6 +1544,7 @@
   "Regional speleology": "Regional speleology",
   "regions": "regions",
   "Regions": "Regions",
+  "rejected": "rejected",
   "Related to": "Related to",
   "Reload": "Reload",
   "remove": "remove",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Espeleología regional",
   "regions": "regiones",
   "Regions": "Regiones",
+  "rejected": "rechazado",
   "Related to": "Relacionado con",
   "Reload": "Recargar",
   "remove": "eliminar",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1543,6 +1543,7 @@
   "Regional speleology": "Spéléologie régionale",
   "regions": "Régions",
   "Regions": "Régions",
+  "rejected": "rejeté",
   "Related to": "Lié à",
   "Reload": "Recharger",
   "remove": "supprimer",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "ספלאולוגיה אזורית",
   "regions": "אזורים",
   "Regions": "אזורים",
+  "rejected": "נדחה",
   "Related to": "קשור ל-",
   "Reload": "טען מחדש",
   "remove": "הסר",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Speleologi regional",
   "regions": "wilayah-wilayah",
   "Regions": "Wilayah",
+  "rejected": "ditolak",
   "Related to": "Terkait dengan",
   "Reload": "Muat ulang",
   "remove": "hapus",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Speleologia regionale",
   "regions": "regioni",
   "Regions": "Regioni",
+  "rejected": "rifiutato",
   "Related to": "Correlato a",
   "Reload": "Ricaricare",
   "remove": "rimuovi",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "地域洞窟学",
   "regions": "地域一覧",
   "Regions": "地域",
+  "rejected": "却下済み",
   "Related to": "関連する",
   "Reload": "再読み込み",
   "remove": "削除",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Regionale speleologie",
   "regions": "regio's",
   "Regions": "Regio's",
+  "rejected": "afgewezen",
   "Related to": "Gerelateerd aan",
   "Reload": "Herladen",
   "remove": "verwijderen",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Espeleologia regional",
   "regions": "regiões",
   "Regions": "Regiões",
+  "rejected": "rejeitado",
   "Related to": "Relacionado com",
   "Reload": "Recarregar",
   "remove": "remover",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1614,6 +1614,7 @@
   "Regional speleology": "Speologie regională",
   "regions": "regiuni",
   "Regions": "Regiuni",
+  "rejected": "respins",
   "Related to": "Legat de",
   "Reload": "Reîncărcați",
   "remove": "elimina",

--- a/packages/web-app/src/types/notification.type.js
+++ b/packages/web-app/src/types/notification.type.js
@@ -1,7 +1,7 @@
 import { number, string, shape, oneOf, arrayOf } from 'prop-types';
 import idNameType from './idName.type';
 
-const notificationype = shape({
+const notificationType = shape({
   id: number.isRequired,
   dateInscription: string.isRequired,
   notifier: shape({
@@ -10,7 +10,7 @@ const notificationype = shape({
   }),
   notificationType: shape({
     id: number.isRequired,
-    name: oneOf(['CREATE', 'DELETE', 'UPDATE'])
+    name: oneOf(['CREATE', 'DELETE', 'REJECT', 'UPDATE', 'VALIDATE'])
   }),
   cave: idNameType,
   description: shape({
@@ -58,4 +58,4 @@ const notificationype = shape({
   massif: idNameType
 });
 
-export default notificationype;
+export default notificationType;

--- a/packages/web-app/src/util/formatNotification.js
+++ b/packages/web-app/src/util/formatNotification.js
@@ -111,6 +111,9 @@ const formatNotification = notification => {
     case 'UPDATE':
       verb = 'updated';
       break;
+    case 'REJECT':
+      verb = 'rejected';
+      break;
     case 'VALIDATE':
       verb = 'validated';
       break;


### PR DESCRIPTION
# feat(notification): support REJECT notification type in UI

## 🤔 What

Add frontend support for the new `REJECT` notification type introduced in the API.

- Add `REJECT` case to `formatNotification` switch → verb `"rejected"`
- Add `REJECT` and `VALIDATE` to the PropTypes `oneOf` in `notification.type.js` (was stale, only had `CREATE`, `DELETE`, `UPDATE`)
- Add `"rejected"` translation key to all 15 language files

Closes #1243
Related to #988

## 🤷‍♂️ Why

The API now notifies document authors when a moderator rejects their submission (GrottoCenter/grottocenter-api#1558). Without this change, `REJECT` notifications would render with an empty verb in the notification center.

## 🔍 How

The notification rendering pipeline is generic — `formatNotification()` maps `notificationType.name` to a display verb, which is then passed through `formatMessage` for i18n. Adding a new type only requires:

1. A new `case` in the switch statement (`REJECT` → `'rejected'`)
2. The corresponding translation key in each language file
3. Updating the PropTypes definition to include the missing types

No changes to Redux, API routes, or notification components — they handle any type transparently.

## 🔗 Related API PR

- GrottoCenter/grottocenter-api#1558

The Azure Static Web Apps stage site won't fully demonstrate rejection notifications until the API PR is merged and deployed.

## 🧪 Testing

1. With the API PR deployed, submit a document and have a moderator reject it
2. Check the notification bell — the rejection should appear as `"[Document title] (document) rejected"` in the user's language
3. Verify the notification links to the document page

## 📸 Previews

No visual changes beyond the new verb appearing in notification items.
