### PR TITLE
fix(Person): pass entityId instead of isPermanent to deletePersonUrl

### DIFF
--- a/packages/web-app/src/actions/Person/DeletePerson.js
+++ b/packages/web-app/src/actions/Person/DeletePerson.js
@@ -12,7 +12,7 @@ const deletePersonSuccess = () => ({ type: DELETE_PERSON_PERMANENT_SUCCESS });
 const deletePersonFailure = error => ({ type: DELETE_PERSON_FAILURE, error });
 
 export const deletePerson =
-  ({ id, isPermanent }) =>
+  ({ id, entityId, isPermanent }) =>
   (dispatch, getState) => {
     dispatch(deletePersonAction());
 
@@ -21,7 +21,7 @@ export const deletePerson =
       headers: getState().login.authorizationHeader
     };
 
-    return fetch(deletePersonUrl(id, isPermanent), requestOptions)
+    return fetch(deletePersonUrl(id, entityId), requestOptions)
       .then(checkAuthStatus(dispatch))
       .then(response => response.json())
       .then(data => dispatch(deletePersonSuccess(data, isPermanent)))


### PR DESCRIPTION
## 🤔 What

- Fix the person deletion merge feature sending `entityId=true` instead of the actual destination person ID
- Closes #1271

## 🤷‍♂️ Why

When an admin deletes a person and selects a destination person to merge data into, the API receives `DELETE /api/v1/cavers/:id?entityId=true` instead of `DELETE /api/v1/cavers/:id?entityId=<selectedPersonId>`. This means the merge never works correctly.

## 🔍 How

The `deletePerson` action creator was destructuring only `{ id, isPermanent }` from its argument and passing `isPermanent` (a boolean `true`) as the second argument to `deletePersonUrl`. The URL builder interprets that second argument as `entityId`.

The fix destructures `entityId` from the payload and passes it to `deletePersonUrl` instead. The calling component was already passing `entityId` correctly — it just wasn't being picked up.

## 🔗 Related API PR

None.

## 🧪 Testing

1. Log in as an admin
2. Navigate to a person's page
3. Click delete, select a destination person for merging
4. Verify the network request is `DELETE /api/v1/cavers/:id?entityId=<selectedPersonId>` (not `entityId=true`)
