### PR TITLE
feat(map): create entrance from map right-click with coords pre-filled

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "الكارستولوجيا والجيولوجيا الكهفية",
   "2": "علم الكهوف الإقليمي والكارستولوجيا",
   "3": "علم الأحياء الكهفي",
@@ -628,6 +628,7 @@
   "Create a new document": "إنشاء وثيقة جديدة",
   "Create a new entity in Grottocenter": "إنشاء كيان جديد في Grottocenter",
   "Create a new Entrance": "إنشاء مدخل جديد",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "إنشاء كيان جديد",
   "created": "تم الإنشاء",
   "Created": "أُنشئ",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -628,6 +628,7 @@
   "Create a new document": "Създаване на нов документ",
   "Create a new entity in Grottocenter": "Създайте нов обект в Grottocenter",
   "Create a new Entrance": "Създайте нов вход",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Създайте нов вход",
   "created": "създаден",
   "Created": "Създадено",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -628,6 +628,7 @@
   "Create a new document": "Crear un nou document",
   "Create a new entity in Grottocenter": "Crea una entitat nova al Grottocenter",
   "Create a new Entrance": "Crea una entrada nova",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Crea una entitat nova",
   "created": "creat",
   "Created": "Creat",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -628,6 +628,7 @@
   "Create a new document": "Neues Dokument erstellen",
   "Create a new entity in Grottocenter": "Eine neue Entität in Grottocenter erstellen",
   "Create a new Entrance": "Einen neuen Eingang erstellen",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Neue Entität erstellen",
   "created": "erstellt",
   "Created": "Erstellt",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "ΚΑΡΣΤΟΛΟΓΙΑ ΚΑΙ ΓΕΟΣΠΗΛΑΙΟΛΟΓΙΑ",
   "2": "ΠΕΡΙΦΕΡΕΙΑΚΗ ΣΠΗΛΑΙΟΛΟΓΙΑ ΚΑΙ ΚΑΡΣΤΟΛΟΓΙΑ",
   "3": "ΒΙΟΣΠΗΛΑΙΟΛΟΓΙΑ",
@@ -628,6 +628,7 @@
   "Create a new document": "Δημιουργία νέου εγγράφου",
   "Create a new entity in Grottocenter": "Δημιουργία νέας οντότητας στο Grottocenter",
   "Create a new Entrance": "Δημιουργία νέας εισόδου",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Δημιουργία νέας οντότητας",
   "created": "δημιουργήθηκε",
   "Created": "Δημιουργήθηκε",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -628,6 +628,7 @@
   "Create a new document": "Create a new document",
   "Create a new entity in Grottocenter": "Create a new entity in Grottocenter",
   "Create a new Entrance": "Create a new Entrance",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Create new entity",
   "created": "created",
   "Created": "Created",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "KARSTOLOGÍA Y GEOSPELEOLOGÍA",
   "2": "ESPELEOLOGÍA REGIONAL Y KARSTOLOGÍA",
   "3": "BIOESPELEOLOGÍA",
@@ -628,6 +628,7 @@
   "Create a new document": "Crear un nuevo documento",
   "Create a new entity in Grottocenter": "Crear una nueva entidad en Grottocenter",
   "Create a new Entrance": "Crear una nueva entrada",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Crear una nueva entidad",
   "created": "creó",
   "Created": "Creado",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -628,6 +628,7 @@
   "Create a new document": "Créer un nouveau document",
   "Create a new entity in Grottocenter": "Créer une nouvelle entité sur Grottocenter",
   "Create a new Entrance": "Créer une nouvelle Entrée",
+  "Create an entrance here": "Créer une entrée ici",
   "Create new entity": "Créer une nouvelle entité",
   "created": "a créé",
   "Created": "Créé",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -628,6 +628,7 @@
   "Create a new document": "יצירת מסמך חדש",
   "Create a new entity in Grottocenter": "צור ישות חדשה ב-Grottocenter",
   "Create a new Entrance": "צור כניסה חדשה",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "צור ישות חדשה",
   "created": "נוצר",
   "Created": "נוצר",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -628,6 +628,7 @@
   "Create a new document": "Buat dokumen baru",
   "Create a new entity in Grottocenter": "Buat entitas baru di Grottocenter",
   "Create a new Entrance": "Buat Pintu Masuk baru",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Buat entitas baru",
   "created": "dibuat",
   "Created": "Dibuat",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "CARSOLOGIA E GEOSPELEOLOGIA",
   "2": "SPELEOLOGIA REGIONALE E CARSOLOGIA",
   "3": "BIOSPELEOLOGIA",
@@ -628,6 +628,7 @@
   "Create a new document": "Crea un nuovo documento",
   "Create a new entity in Grottocenter": "Crea una nuova entità in Grottocenter",
   "Create a new Entrance": "Crea una nuova entrata",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Crea nuova entità",
   "created": "creato",
   "Created": "Creato",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "カルスト学と地学洞窟学",
   "2": "地域洞窟学とカルスト学",
   "3": "生物洞窟学",
@@ -628,6 +628,7 @@
   "Create a new document": "新しいドキュメントを作成",
   "Create a new entity in Grottocenter": "Grottocenterで新しいエンティティを作成",
   "Create a new Entrance": "新しい入口を作成",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "新しいエンティティを作成",
   "created": "作成済み",
   "Created": "作成済み",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "KARSTOLOGIE EN GEOSPELEOLOGIE",
   "2": "REGIONALE SPELEOLOGIE EN KARSTOLOGIE",
   "3": "BIOSPELEOLOGIE",
@@ -628,6 +628,7 @@
   "Create a new document": "Nieuw document aanmaken",
   "Create a new entity in Grottocenter": "Een nieuwe entiteit aanmaken in Grottocenter",
   "Create a new Entrance": "Een nieuwe ingang aanmaken",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Nieuwe entiteit aanmaken",
   "created": "aangemaakt",
   "Created": "Aangemaakt",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "CARSTOLOGIA E GEOESOELEOLOGIA",
   "2": "ESPELEOLOGIA REGIONAL E CARSTOLOGIA",
   "3": "BIOESPELEOLOGIA",
@@ -628,6 +628,7 @@
   "Create a new document": "Criar um novo documento",
   "Create a new entity in Grottocenter": "Criar uma nova entidade no Grottocenter",
   "Create a new Entrance": "Criar uma nova entrada",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Criar nova entidade",
   "created": "criado",
   "Created": "Criado",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "1": "KARSTOLOGIE ȘI GEOSPEOLOGIE",
   "2": "SPEOLOGIE REGIONALĂ ȘI KARSTOLOGIE",
   "3": "BIOSPEOLOGIE",
@@ -628,6 +628,7 @@
   "Create a new document": "Creează un document nou",
   "Create a new entity in Grottocenter": "Creați o nouă entitate în Grottocenter",
   "Create a new Entrance": "Creați o nouă intrare",
+  "Create an entrance here": "Create an entrance here",
   "Create new entity": "Creați o nouă entitate",
   "created": "creat",
   "Created": "Creat",

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -89,7 +89,7 @@ export const EntranceForm = ({
     formState: { errors, isSubmitting, isSubmitSuccessful }
   } = useForm({
     defaultValues: {
-      entrance: entranceValues || defaultEntranceValues,
+      entrance: { ...defaultEntranceValues, ...(entranceValues ?? {}) },
       cave: caveValues || defaultCaveValues
     }
   });

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -86,6 +86,7 @@ export const EntranceForm = ({
     reset,
     control,
     getValues,
+    watch,
     formState: { errors, isSubmitting, isSubmitSuccessful }
   } = useForm({
     defaultValues: {
@@ -94,7 +95,22 @@ export const EntranceForm = ({
     }
   });
 
-  // TODO set latitude & longitude from the selected Entry
+  const [lat, lng, caveName, caveLanguage, entranceName, entranceLanguage] =
+    watch([
+      'entrance.latitude',
+      'entrance.longitude',
+      'cave.name',
+      'cave.language',
+      'entrance.name',
+      'entrance.language'
+    ]);
+
+  const isSubmitDisabled =
+    !lat ||
+    !lng ||
+    (entityType === ENTRANCE_AND_CAVE
+      ? !caveName || !caveLanguage
+      : !entranceName || !entranceLanguage);
 
   const handleUpdateEntityType = type => {
     setEntityType(type);
@@ -182,6 +198,7 @@ export const EntranceForm = ({
         <FormActionRow
           isNew={isNewEntrance}
           isSubmitting={isSubmitting}
+          disabled={isSubmitDisabled}
           onCancel={onCancel}
         />
       </form>

--- a/packages/web-app/src/components/appli/Entry/Documents/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Documents/index.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Box, Button, Divider, Tooltip } from '@mui/material';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
+import { EntityIcon } from '../../../../pages/EntityCreation/entityConfig';
 import AddLinkIcon from '@mui/icons-material/AddLink';
 import { useDispatch } from 'react-redux';
 import CancelIcon from '@mui/icons-material/Cancel';
@@ -56,7 +56,7 @@ const Documents = ({ documents, entranceId, isEditAllowed }) => {
                   size="small"
                   variant="outlined"
                   onClick={navigateToNewDocument}
-                  startIcon={<AddCircleIcon />}>
+                  startIcon={<EntityIcon iconType="bibliography" size={20} />}>
                   {formatMessage({ id: 'New' })}
                 </Button>
               </Tooltip>

--- a/packages/web-app/src/components/appli/Massif/Documents.jsx
+++ b/packages/web-app/src/components/appli/Massif/Documents.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Button, Divider, Tooltip } from '@mui/material';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
+import AddLinkIcon from '@mui/icons-material/AddLink';
 import { useDispatch } from 'react-redux';
 import CancelIcon from '@mui/icons-material/Cancel';
 import { linkDocumentToMassif } from '../../../actions/LinkDocumentToMassif';
@@ -46,10 +46,10 @@ const Documents = ({ documents, massifId }) => {
               variant="outlined"
               onClick={() => setIsDocumentSearchVisible(v => !v)}
               startIcon={
-                isDocumentSearchVisible ? <CancelIcon /> : <AddCircleIcon />
+                isDocumentSearchVisible ? <CancelIcon /> : <AddLinkIcon />
               }>
               {formatMessage({
-                id: isDocumentSearchVisible ? 'Cancel' : 'Add'
+                id: isDocumentSearchVisible ? 'Cancel' : 'Associate'
               })}
             </Button>
           </Tooltip>

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -37,9 +37,9 @@ import copyToClipboard from '../../../../helpers/clipboard';
 import {
   useNotification,
   useCoordinatePreference,
+  usePermissions,
   getCRSLabel
 } from '../../../../hooks';
-import { usePermissions } from '../../../../hooks/usePermissions';
 import { displayLoginDialog } from '../../../../actions/Login';
 import { EntityIcon } from '../../../../pages/EntityCreation/entityConfig';
 import CRSMenu from '../../CRSMenu';

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { useMap, useMapEvent } from 'react-leaflet';
+import { useNavigate } from 'react-router-dom';
 import { uniq } from 'ramda';
 
 import DataControl, { heatmapTypes, markerTypes } from './DataControl';
@@ -14,15 +15,19 @@ import MapTour from './MapTour';
 import GeocodingControl from '../common/GeocodingControl';
 import {
   Box,
+  Divider,
   IconButton,
+  ListItemIcon,
+  ListItemText,
   ListSubheader,
   Menu,
+  MenuItem,
   Tooltip,
   Typography,
   useMediaQuery
 } from '@mui/material';
 import { ContentCopy, Tune } from '@mui/icons-material';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
 import {
   formatCoordinatesForCopy,
@@ -34,6 +39,9 @@ import {
   useCoordinatePreference,
   getCRSLabel
 } from '../../../../hooks';
+import { usePermissions } from '../../../../hooks/usePermissions';
+import { displayLoginDialog } from '../../../../actions/Login';
+import { EntityIcon } from '../../../../pages/EntityCreation/entityConfig';
 import CRSMenu from '../../CRSMenu';
 import MeasureControl from '../common/MeasureControl';
 import useHeatLayer, { HexGlobalCss } from './useHeatLayer';
@@ -68,11 +76,15 @@ const HydratedMap = ({
   const map = useMap();
   const { formatMessage } = useIntl();
   const { onSuccess } = useNotification();
+  const { isAuth } = usePermissions();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
   const projections = useSelector(
     state => state.projections?.projections ?? []
   );
   const [contextCoords, setContextCoords] = useState(null);
   const [contextMenuAnchor, setContextMenuAnchor] = useState(null);
+  const [pendingEntranceUrl, setPendingEntranceUrl] = useState(null);
   const [formatMenuAnchor, setFormatMenuAnchor] = useState(null);
   const [preferred, setPref] = useCoordinatePreference();
   const isTouch = useMediaQuery('(pointer: coarse)');
@@ -253,6 +265,24 @@ const HydratedMap = ({
     [setPref]
   );
 
+  useEffect(() => {
+    if (isAuth && pendingEntranceUrl) {
+      navigate(pendingEntranceUrl);
+      setPendingEntranceUrl(null);
+    }
+  }, [isAuth, pendingEntranceUrl, navigate]);
+
+  const handleCreateEntrance = useCallback(() => {
+    const url = `/ui/entity/add/entrance?lat=${contextCoords.lat}&lng=${contextCoords.lng}`;
+    setContextCoords(null);
+    if (isAuth) {
+      navigate(url);
+    } else {
+      setPendingEntranceUrl(url);
+      dispatch(displayLoginDialog());
+    }
+  }, [contextCoords, isAuth, navigate, dispatch]);
+
   useMapEvent('contextmenu', e => {
     e.originalEvent.preventDefault();
     setContextCoords({ lat: e.latlng.lat, lng: e.latlng.lng });
@@ -360,6 +390,15 @@ const HydratedMap = ({
             </IconButton>
           </Tooltip>
         </Box>
+        <Divider />
+        <MenuItem onClick={handleCreateEntrance}>
+          <ListItemIcon>
+            <EntityIcon iconType="entrance" size={20} />
+          </ListItemIcon>
+          <ListItemText>
+            {formatMessage({ id: 'Create an entrance here' })}
+          </ListItemText>
+        </MenuItem>
       </Menu>
       <CRSMenu
         anchorEl={formatMenuAnchor}

--- a/packages/web-app/src/components/common/NewEntityButton.jsx
+++ b/packages/web-app/src/components/common/NewEntityButton.jsx
@@ -5,7 +5,7 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { useIntl } from 'react-intl';
 import { useAuthNavigate } from '../../hooks';
 
-const NewEntityButton = ({ to }) => {
+const NewEntityButton = ({ to, icon = <AddCircleIcon /> }) => {
   const { formatMessage } = useIntl();
   const handleClick = useAuthNavigate(to);
 
@@ -13,7 +13,7 @@ const NewEntityButton = ({ to }) => {
     <Button
       color="secondary"
       variant="outlined"
-      startIcon={<AddCircleIcon />}
+      startIcon={icon}
       onClick={handleClick}>
       {formatMessage({ id: 'New' })}
     </Button>
@@ -21,7 +21,8 @@ const NewEntityButton = ({ to }) => {
 };
 
 NewEntityButton.propTypes = {
-  to: PropTypes.string.isRequired
+  to: PropTypes.string.isRequired,
+  icon: PropTypes.node
 };
 
 export default NewEntityButton;

--- a/packages/web-app/src/pages/Documents.jsx
+++ b/packages/web-app/src/pages/Documents.jsx
@@ -6,6 +6,7 @@ import DocumentSearch from '../components/appli/AdvancedSearch/DocumentSearch';
 import InternationalizedLink from '../components/common/InternationalizedLink';
 import { wikiBBSLinks } from '../conf/externalLinks';
 import NewEntityButton from '../components/common/NewEntityButton';
+import { EntityIcon } from './EntityCreation/entityConfig';
 
 const DocumentsSearchPage = () => {
   const { formatMessage } = useIntl();
@@ -13,7 +14,12 @@ const DocumentsSearchPage = () => {
     <EntitySearchPage
       title="Documents"
       entityType="documents"
-      actions={<NewEntityButton to="/ui/entity/add/document" />}
+      actions={
+        <NewEntityButton
+          to="/ui/entity/add/document"
+          icon={<EntityIcon iconType="bibliography" size={20} />}
+        />
+      }
       subheader={
         <Typography variant="subtitle2" color="text.secondary">
           {formatMessage({ id: 'The BBS ("Bulletin Bibliographique Spéléologique" in french) is an annual review of the worldwide speleological literature.' })}{' '}

--- a/packages/web-app/src/pages/EntityCreation/AddEntrance.jsx
+++ b/packages/web-app/src/pages/EntityCreation/AddEntrance.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import Layout from '../../components/common/Layouts/Fixed/FixedContent';
 import { EntranceForm } from '../../components/appli/EntitiesForm';
@@ -8,12 +8,20 @@ import { EntityIcon } from './entityConfig';
 const AddEntrance = () => {
   const navigate = useNavigate();
   const { formatMessage } = useIntl();
+  const [searchParams] = useSearchParams();
+  const lat = searchParams.get('lat');
+  const lng = searchParams.get('lng');
+
+  const entranceValues =
+    lat && lng
+      ? { latitude: parseFloat(lat), longitude: parseFloat(lng) }
+      : null;
 
   return (
     <Layout
       icon={<EntityIcon iconType="entrance" />}
       title={formatMessage({ id: 'Add an entrance' })}
-      content={<EntranceForm onCancel={() => navigate(-1)} />}
+      content={<EntranceForm entranceValues={entranceValues} onCancel={() => navigate(-1)} />}
     />
   );
 };

--- a/packages/web-app/src/pages/Entrances.jsx
+++ b/packages/web-app/src/pages/Entrances.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import EntitySearchPage from '../components/appli/AdvancedSearch/EntitySearchPage';
 import EntrancesSearch from '../components/appli/AdvancedSearch/EntrancesSearch';
 import NewEntityButton from '../components/common/NewEntityButton';
+import { EntityIcon } from './EntityCreation/entityConfig';
 
 const EntrancesSearchPage = () => (
   <EntitySearchPage
     title="Entrances"
     entityType="entrances"
-    actions={<NewEntityButton to="/ui/entity/add/entrance" />}>
+    actions={
+      <NewEntityButton
+        to="/ui/entity/add/entrance"
+        icon={<EntityIcon iconType="entrance" size={20} />}
+      />
+    }>
     <EntrancesSearch />
   </EntitySearchPage>
 );

--- a/packages/web-app/src/pages/Massifs.jsx
+++ b/packages/web-app/src/pages/Massifs.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import EntitySearchPage from '../components/appli/AdvancedSearch/EntitySearchPage';
 import MassifsSearch from '../components/appli/AdvancedSearch/MassifsSearch';
 import NewEntityButton from '../components/common/NewEntityButton';
+import { EntityIcon } from './EntityCreation/entityConfig';
 
 const MassifsSearchPage = () => (
   <EntitySearchPage
     title="Massifs"
     entityType="massifs"
-    actions={<NewEntityButton to="/ui/entity/add/massif" />}>
+    actions={
+      <NewEntityButton
+        to="/ui/entity/add/massif"
+        icon={<EntityIcon iconType="massif" size={20} />}
+      />
+    }>
     <MassifsSearch />
   </EntitySearchPage>
 );

--- a/packages/web-app/src/pages/Organizations.jsx
+++ b/packages/web-app/src/pages/Organizations.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import EntitySearchPage from '../components/appli/AdvancedSearch/EntitySearchPage';
 import OrganizationsSearch from '../components/appli/AdvancedSearch/OrganizationsSearch';
 import NewEntityButton from '../components/common/NewEntityButton';
+import { EntityIcon } from './EntityCreation/entityConfig';
 
 const OrganizationsSearchPage = () => (
   <EntitySearchPage
     title="Organizations"
     entityType="organizations"
-    actions={<NewEntityButton to="/ui/entity/add/organization" />}>
+    actions={
+      <NewEntityButton
+        to="/ui/entity/add/organization"
+        icon={<EntityIcon iconType="organization" size={20} />}
+      />
+    }>
     <OrganizationsSearch />
   </EntitySearchPage>
 );


### PR DESCRIPTION
## 🤔 What

- Add a "Create an entrance here" option to the map right-click context menu, with coordinates pre-filled in the creation form
- Disable the entrance creation "Create" button until all mandatory fields (name, language, latitude, longitude) are filled
- Replace generic `+` icons with entity-specific icons (entrance, massif, organization, bibliography) on "New" buttons across list pages and document tabs

Closes #1148

## 🤷‍♂️ Why

- Creating an entrance from the map is a natural workflow: the user right-clicks a location, selects "Create an entrance here", and lands on the form with coordinates already set
- The "Create" button being always clickable was misleading — users could submit an invalid form (missing required coords, name, language)
- Using entity-specific icons improves visual consistency and helps users immediately identify what they're creating

## 🔍 How

**Map → entrance creation flow (`feat(map)`):**
- Added a `MenuItem` to the existing map right-click `Menu` (MUI) with `EntityIcon iconType="entrance"`
- Handler checks auth via `usePermissions`: if authenticated → `navigate('/ui/entity/add/entrance?lat=…&lng=…')`; if not → opens login dialog and stores the pending URL in state; a `useEffect` on `isAuth` triggers navigation after successful login
- `AddEntrance.jsx` reads `?lat` and `?lng` from `useSearchParams` and passes them as `entranceValues` to `EntranceForm`
- `EntranceForm` merges partial `entranceValues` with `defaultEntranceValues` via spread (`{ ...defaultEntranceValues, ...(entranceValues ?? {}) }`) so other fields keep their defaults

**Required fields guard (`fix(entrances)`):**
- Uses a single `watch([...])` call on all 6 required fields (latitude, longitude, name, language — for both entity type modes)
- Computes `isSubmitDisabled` based on `entityType` and passes it to `FormActionRow`

**Icon consistency (`refactor(icons)`):**
- `NewEntityButton` accepts an optional `icon` prop (defaults to `AddCircleIcon` for backward compatibility)
- All entity list pages (Entrances, Massifs, Organizations, Documents) pass their respective `EntityIcon`
- Entry and Massif document tabs use `EntityIcon iconType="bibliography"` / `AddLinkIcon` consistently

## 🔗 Related API PR

None.

## 🧪 Testing

1. **Map → entrance creation (authenticated):** right-click the map → "Create an entrance here" → form opens with lat/lng pre-filled, button enabled
2. **Map → entrance creation (unauthenticated):** right-click → "Create an entrance here" → login dialog → after login, navigates to the form with coords
3. **Required fields guard:** open `/ui/entity/add/entrance` → "Create" button is disabled → fill name, language, lat, lng → button enables
4. **Icons:** check "New" buttons on `/ui/entrances`, `/ui/massifs`, `/ui/organizations`, `/ui/documents` and document tabs on entrance/massif pages

## 📸 Previews

_Screenshots welcome after review._
