### PR TITLE
fix(AuthorLink): prevent crash when verb is empty string

### DIFF
--- a/packages/web-app/src/components/common/AuthorLink/index.js
+++ b/packages/web-app/src/components/common/AuthorLink/index.js
@@ -14,7 +14,9 @@ const verbMessages = defineMessages({
 
 const AuthorLink = ({ author, verb = 'Posted' }) => {
   const { formatMessage } = useIntl();
-  const verbLabel = formatMessage(verbMessages[verb] ?? { id: verb });
+  const verbLabel = verb
+    ? formatMessage(verbMessages[verb] ?? { id: verb })
+    : '';
   if (!author?.id || !author?.nickname)
     return <span>{formatMessage({ id: 'author.unknown' }, { verb: verbLabel })}</span>;
 


### PR DESCRIPTION
# fix(AuthorLink): prevent crash when verb is empty string

## 🤔 What

- Fix a crash on history/snapshot pages (e.g. `/ui/entrances/:id/snapshots`)

## 🤷‍♂️ Why

`Contribution.jsx` passes `verb=""` (empty string) to `AuthorLink` when a reviewer exists but no author. Inside `AuthorLink`, `verbMessages[""]` is `undefined`, so the fallback `{ id: "" }` was passed to `formatMessage`. `@formatjs/intl` treats an empty string as a missing id and throws, crashing the whole page.

## 🔍 How

Guard `verb` before calling `formatMessage` in `AuthorLink`:

```js
const verbLabel = verb
  ? formatMessage(verbMessages[verb] ?? { id: verb })
  : '';
```

The existing `{verb && (...)}` check already suppresses the label display when `verb` is falsy, so behaviour is unchanged for all other cases.

## 🔗 Related API PR

N/A

## 🧪 Testing

Navigate to `/ui/entrances/156670/snapshots` — page should load without error.

## 📸 Previews

N/A

Closes #1329
