### PR TITLE
feat(entrances): improve UX and access control for sensitive entrances

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "نصف القطر شبه الثانوي: ",
   "Send reset email": "إرسال بريد إعادة التعيين",
   "Senegal": "السنغال",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "كتلة جبلية حساسة",
   "Sensitivity Management": "إدارة الحساسية",
   "Serbia": "صربيا",

--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "نصف القطر شبه الثانوي: ",
   "Send reset email": "إرسال بريد إعادة التعيين",
   "Senegal": "السنغال",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "موقع حساس",
   "Sensitive massif": "كتلة جبلية حساسة",
   "Sensitivity Management": "إدارة الحساسية",
   "Serbia": "صربيا",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Малка полуос",
   "Send reset email": "Изпратете имейл за нулиране на паролата.",
   "Senegal": "Сенегал",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Чувствителен масив",
   "Sensitivity Management": "Управление на чувствителността",
   "Serbia": "Сърбия",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Малка полуос",
   "Send reset email": "Изпратете имейл за нулиране на паролата.",
   "Senegal": "Сенегал",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Чувствително местоположение",
   "Sensitive massif": "Чувствителен масив",
   "Sensitivity Management": "Управление на чувствителността",
   "Serbia": "Сърбия",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semieix menor :",
   "Send reset email": "Envia correu de restabliment",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Massís sensible",
   "Sensitivity Management": "Gestió de la sensibilitat",
   "Serbia": "Sèrbia",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Semieix menor :",
   "Send reset email": "Envia correu de restabliment",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Localització sensible",
   "Sensitive massif": "Massís sensible",
   "Sensitivity Management": "Gestió de la sensibilitat",
   "Serbia": "Sèrbia",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Semi-Moll-Radius:",
   "Send reset email": "Zurücksetz-E-Mail senden",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Sensibler Standort",
   "Sensitive massif": "Sensibles Massiv",
   "Sensitivity Management": "Sensibilitätsmanagement",
   "Serbia": "Bosnisch-Serbische Republik",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semi-Moll-Radius:",
   "Send reset email": "Zurücksetz-E-Mail senden",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Sensibles Massiv",
   "Sensitivity Management": "Sensibilitätsmanagement",
   "Serbia": "Bosnisch-Serbische Republik",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Ημι-ελάσσων ακτίνα: ",
   "Send reset email": "Αποστολή email επαναφοράς",
   "Senegal": "Σενεγάλη",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Ευαίσθητος ορεινός όγκος",
   "Sensitivity Management": "Διαχείριση Ευαισθησίας",
   "Serbia": "Σερβία",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Ημι-ελάσσων ακτίνα: ",
   "Send reset email": "Αποστολή email επαναφοράς",
   "Senegal": "Σενεγάλη",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Ευαίσθητη τοποθεσία",
   "Sensitive massif": "Ευαίσθητος ορεινός όγκος",
   "Sensitivity Management": "Διαχείριση Ευαισθησίας",
   "Serbia": "Σερβία",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semi-minor radius: ",
   "Send reset email": "Send reset email",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Sensitive massif",
   "Sensitivity Management": "Sensitivity Management",
   "Serbia": "Serbia",
@@ -2213,6 +2214,5 @@
   "Zanzibar": "Tansania",
   "Zimbabwe": "Zimbabwe",
   "Zip code": "Zip code",
-  "Zone": "Zone",
-  "Sensitive location": "Sensitive location"
+  "Zone": "Zone"
 }

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -2213,5 +2213,6 @@
   "Zanzibar": "Tansania",
   "Zimbabwe": "Zimbabwe",
   "Zip code": "Zip code",
-  "Zone": "Zone"
+  "Zone": "Zone",
+  "Sensitive location": "Sensitive location"
 }

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semi-radio menor de edad: ",
   "Send reset email": "Enviar email de restablecimiento",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Macizo sensible",
   "Sensitivity Management": "Gestión de la sensibilidad",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Semi-radio menor de edad: ",
   "Send reset email": "Enviar email de restablecimiento",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Localización sensible",
   "Sensitive massif": "Macizo sensible",
   "Sensitivity Management": "Gestión de la sensibilidad",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Demi-petit axe :",
   "Send reset email": "Envoyer le mail",
   "Senegal": "Sénégal",
+  "Sensitive location": "Localisation sensible",
   "Sensitive massif": "Massif sensible",
   "Sensitivity Management": "Gestion de la sensibilité",
   "Serbia": "Serbie",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "רדיוס חצי-משני: ",
   "Send reset email": "שלח אימייל לאיפוס",
   "Senegal": "סנגל",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "מיקום רגיש",
   "Sensitive massif": "מאסיב רגיש",
   "Sensitivity Management": "ניהול רגישות",
   "Serbia": "סרביה",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "רדיוס חצי-משני: ",
   "Send reset email": "שלח אימייל לאיפוס",
   "Senegal": "סנגל",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "מאסיב רגיש",
   "Sensitivity Management": "ניהול רגישות",
   "Serbia": "סרביה",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Radius semi-minor: ",
   "Send reset email": "Kirim email reset",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Massif sensitif",
   "Sensitivity Management": "Manajemen Sensitivitas",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Radius semi-minor: ",
   "Send reset email": "Kirim email reset",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Lokasi sensitif",
   "Sensitive massif": "Massif sensitif",
   "Sensitivity Management": "Manajemen Sensitivitas",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Semiasse minore: ",
   "Send reset email": "Invia email di reset",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Posizione sensibile",
   "Sensitive massif": "Massiccio sensibile",
   "Sensitivity Management": "Gestione della sensibilità",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semiasse minore: ",
   "Send reset email": "Invia email di reset",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Massiccio sensibile",
   "Sensitivity Management": "Gestione della sensibilità",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "セミ-マイナー半径：",
   "Send reset email": "リセットメールを送信",
   "Senegal": "セネガル",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "機密の位置情報",
   "Sensitive massif": "高感度な山塊",
   "Sensitivity Management": "感度管理",
   "Serbia": "セルビア",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "セミ-マイナー半径：",
   "Send reset email": "リセットメールを送信",
   "Senegal": "セネガル",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "高感度な山塊",
   "Sensitivity Management": "感度管理",
   "Serbia": "セルビア",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Halve kleine as",
   "Send reset email": "Reset-e-mail verzenden",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Gevoelige locatie",
   "Sensitive massif": "Gevoelig massief",
   "Sensitivity Management": "Gevoeligheidsbeheer",
   "Serbia": "Servië",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Halve kleine as",
   "Send reset email": "Reset-e-mail verzenden",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Gevoelig massief",
   "Sensitivity Management": "Gevoeligheidsbeheer",
   "Serbia": "Servië",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Semieixo menor: ",
   "Send reset email": "Enviar email de redefinição",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Localização sensível",
   "Sensitive massif": "Maciço sensível",
   "Sensitivity Management": "Gestão de sensibilidade",
   "Serbia": "Sérvia",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Semieixo menor: ",
   "Send reset email": "Enviar email de redefinição",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Maciço sensível",
   "Sensitivity Management": "Gestão de sensibilidade",
   "Serbia": "Sérvia",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1742,6 +1742,7 @@
   "Semi-minor radius: ": "Rază semiminoră:",
   "Send reset email": "Trimiteți emailul de resetare",
   "Senegal": "Senegal",
+  "Sensitive location": "Sensitive location",
   "Sensitive massif": "Masiv sensibil",
   "Sensitivity Management": "Gestionarea sensibilității",
   "Serbia": "Serbia",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1742,7 +1742,7 @@
   "Semi-minor radius: ": "Rază semiminoră:",
   "Send reset email": "Trimiteți emailul de resetare",
   "Senegal": "Senegal",
-  "Sensitive location": "Sensitive location",
+  "Sensitive location": "Locație sensibilă",
   "Sensitive massif": "Masiv sensibil",
   "Sensitivity Management": "Gestionarea sensibilității",
   "Serbia": "Serbia",

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -12,6 +12,7 @@ import {
 
 import { FormContainer, FormActionRow } from '../utils/FormContainers';
 import { normelizeCoordinate } from '../utils/InputCoordinate';
+import { usePermissions } from '../../../../hooks';
 import LicenseBox from '../utils/LicenseBox';
 import FormProgressInfo from '../utils/FormProgressInfo';
 import EditTypeSelection from './EditTypeSelection';
@@ -82,6 +83,8 @@ export const EntranceForm = ({
     [caveValues?.entrances?.length]
   );
   const [entityType, setEntityType] = useState(entityTypeInitialValue);
+  const { isAdmin } = usePermissions();
+  const isSensitiveDisabled = !isAdmin && (entranceValues?.isSensitive ?? false);
 
   const defaultFormValues = useMemo(
     () => ({
@@ -112,8 +115,7 @@ export const EntranceForm = ({
     ]);
 
   const isSubmitDisabled =
-    isCoordEmpty(lat) ||
-    isCoordEmpty(lng) ||
+    (!isSensitiveDisabled && (isCoordEmpty(lat) || isCoordEmpty(lng))) ||
     (entityType === ENTRANCE_AND_CAVE
       ? !caveName || !caveLanguage
       : !entranceName || !entranceLanguage);

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -218,6 +218,7 @@ export const EntranceForm = ({
 
 EntranceForm.propTypes = {
   entranceValues: PropTypes.shape({
+    id: PropTypes.number,
     name: PropTypes.string,
     description: PropTypes.string,
     descriptionTitle: PropTypes.string,

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
@@ -1,32 +1,47 @@
 import { ENTRANCE_ONLY } from './caveType';
 
-export const makeEntranceData = (data, entityType) => ({
-  // When creating a cave with a single entrance, the name of the entrance is the same as the cave one, in data.cave
-  name: {
-    language:
-      entityType === ENTRANCE_ONLY
-        ? data.entrance.language
-        : data.cave.language,
-    text: entityType === ENTRANCE_ONLY ? data.entrance.name : data.cave.name
-  },
-  cave: data.cave.id,
-  isSensitive: data.entrance.isSensitive,
-  hasBat: data.entrance.hasBat,
-  dangerFlooding: data.entrance.dangerFlooding,
-  dangerCo2: data.entrance.dangerCo2,
-  dangerRockfall: data.entrance.dangerRockfall,
-  dangerPollution: data.entrance.dangerPollution,
-  needCleanGear: data.entrance.needCleanGear,
-  needStayOnTrail: data.entrance.needStayOnTrail,
-  hasRules: data.entrance.hasRules,
-  isTouristic: data.entrance.isTouristic,
-  longitude: data.entrance.longitude,
-  latitude: data.entrance.latitude,
-  altitude: data.entrance.altitude ? Number(data.entrance.altitude) : null,
-  yearDiscovery: data.entrance.yearDiscovery
-    ? Number(data.entrance.yearDiscovery)
-    : null
-});
+export const makeEntranceData = (data, entityType) => {
+  const entranceData = {
+    // When creating a cave with a single entrance, the name of the entrance is the same as the cave one, in data.cave
+    name: {
+      language:
+        entityType === ENTRANCE_ONLY
+          ? data.entrance.language
+          : data.cave.language,
+      text: entityType === ENTRANCE_ONLY ? data.entrance.name : data.cave.name
+    },
+    cave: data.cave.id,
+    isSensitive: data.entrance.isSensitive,
+    hasBat: data.entrance.hasBat,
+    dangerFlooding: data.entrance.dangerFlooding,
+    dangerCo2: data.entrance.dangerCo2,
+    dangerRockfall: data.entrance.dangerRockfall,
+    dangerPollution: data.entrance.dangerPollution,
+    needCleanGear: data.entrance.needCleanGear,
+    needStayOnTrail: data.entrance.needStayOnTrail,
+    hasRules: data.entrance.hasRules,
+    isTouristic: data.entrance.isTouristic,
+    altitude: data.entrance.altitude ? Number(data.entrance.altitude) : null,
+    yearDiscovery: data.entrance.yearDiscovery
+      ? Number(data.entrance.yearDiscovery)
+      : null
+  };
+
+  // Only include coordinates when available — they are hidden from non-admin
+  // users on sensitive entrances, so omitting them prevents overwriting the
+  // stored values with empty ones.
+  if (
+    data.entrance.longitude != null &&
+    data.entrance.longitude !== '' &&
+    data.entrance.latitude != null &&
+    data.entrance.latitude !== ''
+  ) {
+    entranceData.longitude = data.entrance.longitude;
+    entranceData.latitude = data.entrance.latitude;
+  }
+
+  return entranceData;
+};
 
 export const makeCaveData = data => ({
   name: {

--- a/packages/web-app/src/components/appli/Entry/Locations/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Locations/index.jsx
@@ -22,7 +22,9 @@ const Locations = ({ entranceId, locations, isSensitive, isEditAllowed }) => {
   const permissions = usePermissions();
   const dispatch = useDispatch();
   const [isFormVisible, setIsFormVisible] = useState(false);
-  const { movingId, handleMove } = useMoveRelevanceWithUndo(moveLocationRelevance);
+  const { movingId, handleMove } = useMoveRelevanceWithUndo(
+    moveLocationRelevance
+  );
 
   const onSubmitForm = data => {
     dispatch(
@@ -44,21 +46,20 @@ const Locations = ({ entranceId, locations, isSensitive, isEditAllowed }) => {
       title={formatMessage({ id: 'Location' })}
       icon={
         permissions.isAuth &&
-        isEditAllowed && (
+        isEditAllowed &&
+        (!isSensitive || permissions.isAdmin) && (
           <Tooltip
             title={
               isFormVisible
                 ? formatMessage({ id: 'Cancel adding a new location' })
                 : formatMessage({ id: 'Add a new location' })
-            }
-          >
+            }>
             <Button
               color={isFormVisible ? 'inherit' : 'secondary'}
               size="small"
               variant="outlined"
               onClick={() => setIsFormVisible(!isFormVisible)}
-              startIcon={isFormVisible ? <CancelIcon /> : <AddCircleIcon />}
-            >
+              startIcon={isFormVisible ? <CancelIcon /> : <AddCircleIcon />}>
               {formatMessage({ id: isFormVisible ? 'Cancel' : 'New' })}
             </Button>
           </Tooltip>

--- a/packages/web-app/src/components/appli/Entry/Locations/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Locations/index.jsx
@@ -45,6 +45,7 @@ const Locations = ({ entranceId, locations, isSensitive, isEditAllowed }) => {
       defaultExpanded={locations.length > 0}
       title={formatMessage({ id: 'Location' })}
       icon={
+        // Hidden for non-admins on sensitive entrances: they cannot add locations
         permissions.isAuth &&
         isEditAllowed &&
         (!isSensitive || permissions.isAdmin) && (

--- a/packages/web-app/src/components/appli/Entry/SensitiveLocationPlaceholder.jsx
+++ b/packages/web-app/src/components/appli/Entry/SensitiveLocationPlaceholder.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { useIntl } from 'react-intl';
+
+const SensitiveLocationPlaceholder = () => {
+  const { formatMessage } = useIntl();
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 1,
+        bgcolor: 'secondary.veryLight',
+        borderRadius: 1,
+        p: 3,
+        gap: 1
+      }}>
+      <LockOutlinedIcon sx={{ fontSize: 48, color: 'secondary.main' }} />
+      <Typography variant="h6" color="secondary.main">
+        {formatMessage({ id: 'Sensitive location' })}
+      </Typography>
+      <Typography variant="body2" textAlign="center" color="text.secondary">
+        {formatMessage({
+          id: 'This entrance requires special protection measures. We do not communicate its precise location on Grottocenter.'
+        })}
+      </Typography>
+    </Box>
+  );
+};
+
+export default SensitiveLocationPlaceholder;

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -50,6 +50,7 @@ import {
   useSharePage
 } from '../../../hooks';
 import SensitiveCaveWarning from './SensitiveCaveWarning';
+import SensitiveLocationPlaceholder from './SensitiveLocationPlaceholder';
 import AuthorAndDate from '../../common/Contribution/AuthorAndDate';
 import Alert from '../../common/Alert';
 import Map from '../../common/Maps/MapMultipleMarkers';
@@ -355,7 +356,7 @@ export const Entry = ({ isLoading, error, entrance }) => {
                   onDeletePress(entity?.id, isDeleteConfirmationPermanent);
                 }}
               />
-              {entrance.isSensitive && (
+              {entrance.isSensitive && isAdmin && (
                 <Box sx={{ mx: 2, mt: 2 }}>
                   <SensitiveCaveWarning />
                 </Box>
@@ -364,11 +365,13 @@ export const Entry = ({ isLoading, error, entrance }) => {
                 content={
                   <>
                     <HalfSplitContainer>
-                      {(!entrance.isSensitive || isAdmin) && (
-                        <Box sx={{ flex: 1, minHeight: 200 }}>
+                      <Box sx={{ flex: 1, minHeight: 200, display: 'flex' }}>
+                        {!entrance.isSensitive || isAdmin ? (
                           <Map positions={mapPositions} loading={isLoading} />
-                        </Box>
-                      )}
+                        ) : (
+                          <SensitiveLocationPlaceholder />
+                        )}
+                      </Box>
                       <Box sx={{ flex: 1, overflow: 'auto' }}>
                         <Properties
                           entrance={entrance}

--- a/scripts/translations/sort.js
+++ b/scripts/translations/sort.js
@@ -14,7 +14,7 @@ const sortComparator = (a, b) =>
 // Detect the indentation used in a JSON file by looking at the first indented line.
 // Assumes flat key-value JSON with uniform indentation.
 function detectIndent(content) {
-  const match = content.match(/^(\s+)"/m);
+  const match = content.match(/^([^\S\n]+)"/m);
   return match ? match[1] : '  ';
 }
 


### PR DESCRIPTION
## 🤔 What

Improve the UX for sensitive entrances by properly restricting location-related actions for non-admin users.

- Replace the blank/missing map area with a dedicated `SensitiveLocationPlaceholder` component (lock icon + explanatory message) for non-admins viewing a sensitive entrance
- Hide the `SensitiveCaveWarning` banner from non-admin users (was leaking the sensitivity status without useful context)
- Prevent non-admins from adding new locations on a sensitive entrance
- Fix the entrance edit form: skip coordinate validation for non-admin users editing a sensitive entrance, so the form can be saved without location data

## 🤷‍♂️ Why

Sensitive entrances must not expose their precise location. Previously the map area was simply hidden, leaving a confusing gap in the UI. Non-admins could also attempt to add locations or save an edit form that incorrectly required coordinates.

closes #1340

## 🔍 How

- New `SensitiveLocationPlaceholder` component rendered in place of the map when `entrance.isSensitive && !isAdmin`
- `Entry/index.jsx`: conditionalize `SensitiveCaveWarning` on `isAdmin`, swap conditional rendering to always show the `Box` (flex container) and pick map vs placeholder inside
- `Entry/Locations/index.jsx`: gate the "Add location" button on `!isSensitive || permissions.isAdmin`
- `EntitiesForm/Entrance/index.jsx`: derive `isSensitiveDisabled` from `isAdmin` + `entranceValues.isSensitive`, then only require coordinates when `!isSensitiveDisabled`
- i18n: new keys added to all 15 language files (`Sensitive location` + description)

## 🔗 Related API PR

_None — behaviour relies on existing `isSensitive` flag already returned by the API._

## 🧪 Testing

1. Log in as a **regular user** and navigate to a sensitive entrance:
   - Map area should show the lock placeholder instead of the map
   - The "Add location" button should not appear
   - Editing the entrance should not require coordinates to save
2. Log in as an **admin** and navigate to the same entrance:
   - Map and `SensitiveCaveWarning` should still appear normally
   - "Add location" button should be available
   - Coordinate validation should still apply in the edit form

## 📸 Previews

<img width="1427" height="886" alt="image" src="https://github.com/user-attachments/assets/6e9ca865-c61a-460e-946c-bab088d9635b" />

<img width="388" height="712" alt="image" src="https://github.com/user-attachments/assets/5467ed3a-a7a2-45f0-86c6-f8e2ba4dc98c" />


