### PR TITLE
fix(entrances): error management to move sections by relevance

### DIFF
--- a/packages/web-app/src/actions/createMoveRelevanceAction.js
+++ b/packages/web-app/src/actions/createMoveRelevanceAction.js
@@ -29,18 +29,15 @@ const createMoveRelevanceAction = (entityName, urlBuilder, label) => {
       .then(checkAuthStatus(dispatch))
       .then(response => response.json())
       .then(data =>
-        dispatch({
-          type: SUCCESS,
-          moved: data.moved,
-          swapped: data.swapped
-        })
+        dispatch({ type: SUCCESS, moved: data.moved, swapped: data.swapped })
       )
       .catch(error => {
-        if (error.isAuthError) return;
+        if (error.isAuthError) return { error: true };
         dispatch({
           type: FAILURE,
           error: makeErrorMessage(error.message, `Moving ${label} relevance`)
         });
+        return { error: error.message };
       });
   };
 

--- a/packages/web-app/src/hooks/useMoveRelevanceWithUndo.js
+++ b/packages/web-app/src/hooks/useMoveRelevanceWithUndo.js
@@ -15,7 +15,15 @@ export const useMoveRelevanceWithUndo = moveThunk => {
       setMovingId(entityId);
       dispatch(moveThunk(entityId, direction))
         .then(result => {
-          if (result?.error) return;
+          if (result?.error) {
+            if (typeof result.error === 'string') {
+              enqueueSnackbar(result.error, {
+                variant: 'error',
+                autoHideDuration: 6000
+              });
+            }
+            return;
+          }
           enqueueSnackbar(formatMessage({ id: 'Order updated' }), {
             variant: 'success',
             autoHideDuration: 6000,
@@ -37,8 +45,7 @@ export const useMoveRelevanceWithUndo = moveThunk => {
                       );
                     })
                     .finally(() => setMovingId(null));
-                }}
-              >
+                }}>
                 {formatMessage({ id: 'Undo' })}
               </Link>
             )

--- a/packages/web-app/src/hooks/useMoveRelevanceWithUndo.js
+++ b/packages/web-app/src/hooks/useMoveRelevanceWithUndo.js
@@ -16,12 +16,12 @@ export const useMoveRelevanceWithUndo = moveThunk => {
       dispatch(moveThunk(entityId, direction))
         .then(result => {
           if (result?.error) {
-            if (typeof result.error === 'string') {
-              enqueueSnackbar(result.error, {
-                variant: 'error',
-                autoHideDuration: 6000
-              });
-            }
+            enqueueSnackbar(
+              typeof result.error === 'string'
+                ? result.error
+                : formatMessage({ id: 'An error occurred. Please try again.' }),
+              { variant: 'error', autoHideDuration: 6000 }
+            );
             return;
           }
           enqueueSnackbar(formatMessage({ id: 'Order updated' }), {
@@ -38,7 +38,13 @@ export const useMoveRelevanceWithUndo = moveThunk => {
                   setMovingId(entityId);
                   dispatch(moveThunk(entityId, direction * -1))
                     .then(undoResult => {
-                      if (undoResult?.error) return;
+                      if (undoResult?.error) {
+                        enqueueSnackbar(
+                          formatMessage({ id: 'An error occurred. Please try again.' }),
+                          { variant: 'error', autoHideDuration: 6000 }
+                        );
+                        return;
+                      }
                       enqueueSnackbar(
                         formatMessage({ id: 'Undo successful' }),
                         { variant: 'success', autoHideDuration: 3000 }

--- a/packages/web-app/src/hooks/useMoveRelevanceWithUndo.unit.test.js
+++ b/packages/web-app/src/hooks/useMoveRelevanceWithUndo.unit.test.js
@@ -177,7 +177,7 @@ describe('useMoveRelevanceWithUndo', () => {
     );
   });
 
-  it('does not show success snackbar when move fails', async () => {
+  it('shows error snackbar and no success snackbar when move fails', async () => {
     const mockThunk = createMockThunk(failureResult);
     const { result } = renderHook(() =>
       useMoveRelevanceWithUndo(mockThunk)
@@ -187,10 +187,14 @@ describe('useMoveRelevanceWithUndo', () => {
       result.current.handleMove(1, -1);
     });
 
-    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+    expect(mockEnqueueSnackbar).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ variant: 'error' })
+    );
   });
 
-  it('does not show undo-success snackbar when undo fails', async () => {
+  it('shows error snackbar and no undo-success snackbar when undo fails', async () => {
     const mockThunk = createMockThunk();
     const { result } = renderHook(() =>
       useMoveRelevanceWithUndo(mockThunk)
@@ -204,7 +208,6 @@ describe('useMoveRelevanceWithUndo', () => {
     const actionElement = actionFn('snackbar-1');
 
     mockEnqueueSnackbar.mockClear();
-    // Make the undo dispatch return a failure result
     mockDispatch.mockImplementation(() =>
       Promise.resolve(failureResult)
     );
@@ -213,7 +216,10 @@ describe('useMoveRelevanceWithUndo', () => {
       actionElement.props.onClick();
     });
 
-    // No success snackbar should appear — ErrorHandler handles the failure
-    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+    expect(mockEnqueueSnackbar).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ variant: 'error' })
+    );
   });
 });


### PR DESCRIPTION
## 🤔 What

- Fix error propagation in `createMoveRelevanceAction` so the `.catch` handler returns `{ error: true }` on auth errors and `{ error: error.message }` on other failures
- In `useMoveRelevanceWithUndo`, display the error message via a snackbar when moving a section's relevance fails (instead of silently swallowing the error)

## 🤷‍♂️ Why

When moving an entrance section by relevance failed (e.g. due to a network or API error), the user received no feedback — the error was caught but never surfaced in the UI. The fix ensures the error message is shown to the user via a snackbar notification.

## 🔍 How

- `createMoveRelevanceAction.js`: the `.catch` block now returns `{ error: true }` for auth errors (to keep the early-return guard working) and `{ error: error.message }` for other errors so the hook can read the message.
- `useMoveRelevanceWithUndo.js`: when `result?.error` is a string, it is displayed as an error snackbar with a 6-second duration before the function returns early.

## 🔗 Related API PR

See also https://github.com/GrottoCenter/grottocenter-api/pull/1605

## 🧪 Testing

1. Trigger a relevance move on an entrance section while the API returns an error (e.g. temporarily break the network or mock a 500 response).
2. Verify that an error snackbar appears with the error message.
3. Verify that the undo snackbar does **not** appear on failure.
4. Verify that a successful move still shows the "Order updated" success snackbar with the Undo action.

## 📸 Previews

<img width="1632" height="384" alt="image" src="https://github.com/user-attachments/assets/2ba13787-078c-4b26-9959-789e939d05ec" />

