### PR TITLE
fix(entrance): allow non-admin users to edit sensitive entrance properties

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx
@@ -9,6 +9,7 @@ import {
   postCaveAndEntrance,
   updateCaveAndEntrance
 } from '../../../../actions/CaveAndEntrance';
+import { usePermissions } from '../../../../hooks';
 
 import { FormContainer, FormActionRow } from '../utils/FormContainers';
 import { normelizeCoordinate } from '../utils/InputCoordinate';
@@ -60,6 +61,7 @@ export const EntranceForm = ({
   onCancel
 }) => {
   const isNewEntrance = entranceValues === null || caveValues === null;
+  const permissions = usePermissions();
 
   const { locale, AVAILABLE_LANGUAGES } = useSelector(state => state.intl);
 
@@ -111,9 +113,11 @@ export const EntranceForm = ({
       'entrance.language'
     ]);
 
+  const coordsRequired =
+    !entranceValues?.isSensitive || permissions.isAdmin;
+
   const isSubmitDisabled =
-    isCoordEmpty(lat) ||
-    isCoordEmpty(lng) ||
+    (coordsRequired ? isCoordEmpty(lat) || isCoordEmpty(lng) : false) ||
     (entityType === ENTRANCE_AND_CAVE
       ? !caveName || !caveLanguage
       : !entranceName || !entranceLanguage);
@@ -216,6 +220,7 @@ export const EntranceForm = ({
 
 EntranceForm.propTypes = {
   entranceValues: PropTypes.shape({
+    id: PropTypes.number,
     name: PropTypes.string,
     description: PropTypes.string,
     descriptionTitle: PropTypes.string,

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js
@@ -1,32 +1,46 @@
 import { ENTRANCE_ONLY } from './caveType';
 
-export const makeEntranceData = (data, entityType) => ({
-  // When creating a cave with a single entrance, the name of the entrance is the same as the cave one, in data.cave
-  name: {
-    language:
-      entityType === ENTRANCE_ONLY
-        ? data.entrance.language
-        : data.cave.language,
-    text: entityType === ENTRANCE_ONLY ? data.entrance.name : data.cave.name
-  },
-  cave: data.cave.id,
-  isSensitive: data.entrance.isSensitive,
-  hasBat: data.entrance.hasBat,
-  dangerFlooding: data.entrance.dangerFlooding,
-  dangerCo2: data.entrance.dangerCo2,
-  dangerRockfall: data.entrance.dangerRockfall,
-  dangerPollution: data.entrance.dangerPollution,
-  needCleanGear: data.entrance.needCleanGear,
-  needStayOnTrail: data.entrance.needStayOnTrail,
-  hasRules: data.entrance.hasRules,
-  isTouristic: data.entrance.isTouristic,
-  longitude: data.entrance.longitude,
-  latitude: data.entrance.latitude,
-  altitude: data.entrance.altitude ? Number(data.entrance.altitude) : null,
-  yearDiscovery: data.entrance.yearDiscovery
-    ? Number(data.entrance.yearDiscovery)
-    : null
-});
+export const makeEntranceData = (data, entityType) => {
+  const entranceData = {
+    // When creating a cave with a single entrance, the name of the entrance is the same as the cave one, in data.cave
+    name: {
+      language:
+        entityType === ENTRANCE_ONLY
+          ? data.entrance.language
+          : data.cave.language,
+      text: entityType === ENTRANCE_ONLY ? data.entrance.name : data.cave.name
+    },
+    cave: data.cave.id,
+    isSensitive: data.entrance.isSensitive,
+    hasBat: data.entrance.hasBat,
+    dangerFlooding: data.entrance.dangerFlooding,
+    dangerCo2: data.entrance.dangerCo2,
+    dangerRockfall: data.entrance.dangerRockfall,
+    dangerPollution: data.entrance.dangerPollution,
+    needCleanGear: data.entrance.needCleanGear,
+    needStayOnTrail: data.entrance.needStayOnTrail,
+    hasRules: data.entrance.hasRules,
+    isTouristic: data.entrance.isTouristic,
+    altitude: data.entrance.altitude ? Number(data.entrance.altitude) : null,
+    yearDiscovery: data.entrance.yearDiscovery
+      ? Number(data.entrance.yearDiscovery)
+      : null
+  };
+
+  // Only include coordinates when they are available (they are hidden from
+  // non-admin users on sensitive entrances).
+  if (
+    data.entrance.longitude != null &&
+    data.entrance.longitude !== '' &&
+    data.entrance.latitude != null &&
+    data.entrance.latitude !== ''
+  ) {
+    entranceData.longitude = data.entrance.longitude;
+    entranceData.latitude = data.entrance.latitude;
+  }
+
+  return entranceData;
+};
 
 export const makeCaveData = data => ({
   name: {


### PR DESCRIPTION
## 🤔 What

- Fix: non-admin users can now edit properties (name, hazards, altitude, etc.) of sensitive entrances
- The submit button is no longer permanently disabled when coordinates are hidden
- Coordinates are omitted from the PUT payload when unavailable (prevents sending null values)
- Added missing `id` PropType on `entranceValues`

Closes #1340

## 🤷‍♂️ Why

When a non-admin user opened the edit form for a sensitive entrance, the API returned `null` coordinates (by design — to protect the location). The coordinate fields were correctly hidden, but the form's submit validation required non-empty coordinates, making the submit button permanently disabled. No PUT request ever reached the API.

## 🔍 How

**`packages/web-app/src/components/appli/EntitiesForm/Entrance/index.jsx`:**
- Added `usePermissions` hook
- Extracted a `coordsRequired` boolean: coordinates are only required when the entrance is not sensitive OR the user is admin
- Added `id: PropTypes.number` to `entranceValues` shape (pre-existing omission)

**`packages/web-app/src/components/appli/EntitiesForm/Entrance/transformers.js`:**
- `makeEntranceData` now conditionally includes `latitude`/`longitude` only when they have actual values, preventing null coordinates from being sent in the PUT body

## 🔗 Related API PR

None — the API already handles the case where coordinates are absent from the PUT body (it simply doesn't update them).

## 🧪 Testing

1. Log in as a non-admin user (User role only)
2. Navigate to a sensitive entrance (e.g., `/ui/entrances/138163`)
3. Click "Edit properties"
4. Change the name or any hazard toggle
5. Verify the submit button is enabled and the update succeeds
6. Verify that an admin can still edit coordinates of sensitive entrances as before
