### PR TITLE
feat(observations): CSV import wizard POC

### DIFF
--- a/packages/web-app/src/App.jsx
+++ b/packages/web-app/src/App.jsx
@@ -35,6 +35,7 @@ import AddMassif from './pages/EntityCreation/AddMassif';
 import AddOrganization from './pages/EntityCreation/AddOrganization';
 import EntryPage from './pages/Entry';
 import ImportContainer from './pages/ImportCSV';
+import ImportObservationsCsv from './components/appli/ImportObservationsCsv';
 import ManageUsers from './pages/Admin/ManageUsers';
 import Map from './pages/Map';
 import MassifPage from './pages/Massif';
@@ -127,6 +128,7 @@ const router = createBrowserRouter(
       <Route path="/ui/documents/validation" element={<DocumentValidation />} />
       <Route path="/ui/documents/:documentId" element={<DocumentDetails />} />
       <Route path="/ui/import-csv" element={<ImportContainer />} />
+      <Route path="/ui/import-observations" element={<ImportObservationsCsv />} />
       <Route path="/ui/duplicates" element={<DuplicateImportHandle />} />
 
       {/* Routes requiring authentication */}

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/StepDownload.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/StepDownload.jsx
@@ -1,0 +1,210 @@
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import generateSql from './generateSql';
+import { normalizeNumber } from './numberUtils';
+import { COLUMN_ROLES } from './constants';
+import { buildTimestamp } from './timestampUtils';
+import resolveRow from './resolveRow';
+
+// We use a synthetic index to store the computed timestamp in processed rows
+const TS_SLOT = '__timestamp__';
+
+const StepDownload = ({ state, dispatch, onExportProfile }) => {
+  const {
+    rawData,
+    headerRow,
+    skipLastRows,
+    columnMappings,
+    dateFormat,
+    dateOnlyFormat,
+    timeOnlyFormat,
+    numberLocale,
+    timezone,
+    caveId,
+    pointLabel,
+    authorId,
+    fileName
+  } = state;
+
+  const processedData = useMemo(() => {
+    const hasHeader = headerRow != null;
+    const startIdx = hasHeader ? headerRow + 1 : 0;
+    const endIdx = skipLastRows > 0 ? rawData.length - skipLastRows : rawData.length;
+    const dataRows = rawData.slice(startIdx, Math.max(startIdx, endIdx));
+
+    const measurementCols = Object.entries(columnMappings)
+      .filter(([_, m]) => m.role === COLUMN_ROLES.MEASUREMENT && m.quantityKind && m.unit)
+      .map(([idx, m]) => ({ index: Number(idx), ...m }));
+
+    // Process rows: build timestamps and normalize numbers
+    const rows = [];
+    dataRows.forEach(rawRow => {
+      const row = resolveRow(rawRow, columnMappings);
+      const ts = buildTimestamp(row, columnMappings, { dateFormat, dateOnlyFormat, timeOnlyFormat, timezone });
+      if (!ts) return;
+
+      const processedRow = { [TS_SLOT]: ts };
+
+      let hasValue = false;
+      measurementCols.forEach(col => {
+        const num = normalizeNumber(row[col.index], numberLocale);
+        processedRow[col.index] = num;
+        if (num != null) hasValue = true;
+      });
+
+      if (hasValue) rows.push(processedRow);
+    });
+
+    return { rows, measurementCols };
+  }, [rawData, headerRow, skipLastRows, columnMappings, dateFormat, dateOnlyFormat, timeOnlyFormat, numberLocale, timezone]);
+
+  const sql = useMemo(() => {
+    const { rows, measurementCols } = processedData;
+
+    const columns = measurementCols.map(col => ({
+      ...col,
+      role: 'measurement'
+    }));
+    // Add a virtual timestamp column that uses the TS_SLOT key
+    columns.push({
+      index: TS_SLOT,
+      role: 'timestamp'
+    });
+
+    return generateSql({
+      caveId: caveId || '0',
+      pointLabel: pointLabel || 'Imported Point',
+      authorId: authorId || 1,
+      timezone: timezone || null,
+      columns,
+      rows
+    });
+  }, [processedData, caveId, pointLabel, authorId, timezone]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([sql], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const baseName = (fileName || 'import').replace(/\.[^.]+$/, '');
+    a.href = url;
+    a.download = `import-${baseName}.sql`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [sql, fileName]);
+
+  const handleCaveIdChange = useCallback(
+    e => dispatch({ type: 'SET_CAVE_ID', payload: e.target.value }),
+    [dispatch]
+  );
+
+  const handlePointLabelChange = useCallback(
+    e => dispatch({ type: 'SET_POINT_LABEL', payload: e.target.value }),
+    [dispatch]
+  );
+
+  const handleAuthorIdChange = useCallback(
+    e => dispatch({ type: 'SET_AUTHOR_ID', payload: e.target.value }),
+    [dispatch]
+  );
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Typography variant="h6">Generate SQL Import Script</Typography>
+
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <TextField
+          size="small"
+          label="Cave ID"
+          value={caveId}
+          onChange={handleCaveIdChange}
+          placeholder="e.g., 74138"
+          sx={{ width: 140 }}
+        />
+        <TextField
+          size="small"
+          label="Point label"
+          value={pointLabel}
+          onChange={handlePointLabelChange}
+          placeholder="e.g., Clim B 1"
+          sx={{ width: 200 }}
+        />
+        <TextField
+          size="small"
+          label="Author ID (caver)"
+          value={authorId}
+          onChange={handleAuthorIdChange}
+          placeholder="e.g., 460"
+          sx={{ width: 160 }}
+        />
+      </Box>
+
+      <Alert severity="info">
+        <Typography variant="subtitle2" gutterBottom>
+          The SQL script will create:
+        </Typography>
+        <Box component="ul" sx={{ m: 0, pl: 2 }}>
+          <li>1 device</li>
+          <li>{processedData.measurementCols.length} sensor configuration(s)</li>
+          <li>1 point</li>
+          <li>1 observation</li>
+          <li>{processedData.measurementCols.length} time series</li>
+          <li>{processedData.rows.length * processedData.measurementCols.length} measurement inserts</li>
+        </Box>
+      </Alert>
+
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<DownloadIcon />}
+          onClick={handleDownload}>
+          Download SQL File
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<FileDownloadIcon />}
+          onClick={onExportProfile}>
+          Export profile
+        </Button>
+      </Box>
+
+      <Box
+        component="pre"
+        sx={{
+          maxHeight: 400,
+          overflow: 'auto',
+          p: 2,
+          bgcolor: 'grey.100',
+          borderRadius: 1,
+          fontSize: '0.75rem',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all'
+        }}>
+        {sql.slice(0, 5000)}
+        {sql.length > 5000 && '\n\n... (truncated preview) ...'}
+      </Box>
+    </Box>
+  );
+};
+
+StepDownload.propTypes = {
+  state: PropTypes.shape({
+    rawData: PropTypes.arrayOf(PropTypes.array).isRequired,
+    headerRow: PropTypes.number,
+    columnMappings: PropTypes.object.isRequired,
+    dateFormat: PropTypes.string.isRequired,
+    numberLocale: PropTypes.string.isRequired,
+    timezone: PropTypes.string.isRequired,
+    caveId: PropTypes.string.isRequired,
+    pointLabel: PropTypes.string.isRequired,
+    authorId: PropTypes.string.isRequired,
+    fileName: PropTypes.string
+  }).isRequired,
+  dispatch: PropTypes.func.isRequired,
+  onExportProfile: PropTypes.func.isRequired
+};
+
+export default StepDownload;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/StepMapping.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/StepMapping.jsx
@@ -1,0 +1,458 @@
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Autocomplete,
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import { blue, orange } from '@mui/material/colors';
+import {
+  COLUMN_ROLES,
+  DATE_FORMATS,
+  DATE_ONLY_FORMATS,
+  MEDIA,
+  QUANTITY_KINDS,
+  QUANTITY_MEDIUM_MAP,
+  QUANTITY_UNIT_MAP,
+  TIME_ONLY_FORMATS,
+  TIMESTAMP_TYPES,
+  TIMEZONES,
+  UNITS
+} from './constants';
+
+const ROLE_OPTIONS = [
+  { value: COLUMN_ROLES.TIMESTAMP, label: 'Timestamp' },
+  { value: COLUMN_ROLES.MEASUREMENT, label: 'Measurement' },
+  { value: COLUMN_ROLES.DECIMAL_PART, label: 'Decimals of prev.' },
+  { value: COLUMN_ROLES.EXCLUDED, label: 'Excluded' }
+];
+
+const StepMapping = ({ state, dispatch }) => {
+  const { rawData, headerRow, skipLastRows, columnMappings, dateFormat, dateOnlyFormat, timeOnlyFormat, timezone } = state;
+  const hasHeader = headerRow != null;
+  const maxCols = rawData.reduce((max, row) => Math.max(max, row.length), 0);
+  const headerRowData = hasHeader && rawData.length > headerRow
+    ? rawData[headerRow]
+    : null;
+  const headers = headerRowData && headerRowData.length >= maxCols
+    ? headerRowData
+    : (maxCols > 0 ? Array.from({ length: maxCols }, (_, i) => `Col ${i + 1}`) : []);
+
+  // Find the next timestamp type to auto-assign on new timestamp columns
+  const nextTimestampType = useMemo(() => {
+    const tsCols = Object.entries(columnMappings)
+      .filter(([_, m]) => m.role === COLUMN_ROLES.TIMESTAMP && m.timestampType)
+      .map(([idx, m]) => ({ index: Number(idx), type: m.timestampType }))
+      .sort((a, b) => a.index - b.index);
+    if (tsCols.length === 0) return null;
+    const last = tsCols[tsCols.length - 1];
+
+    // If the last one is already elapsed_seconds, keep suggesting it (it stacks)
+    if (last.type === 'elapsed_seconds') return 'elapsed_seconds';
+
+    // Otherwise find what comes next in the sequence
+    const typeValues = TIMESTAMP_TYPES.map(t => t.value);
+    const lastIdx = typeValues.indexOf(last.type);
+    if (lastIdx >= 0 && lastIdx < typeValues.length - 1) {
+      return typeValues[lastIdx + 1];
+    }
+    // Past the end of the list → default to elapsed_seconds
+    return 'elapsed_seconds';
+  }, [columnMappings]);
+
+  const handleRoleChange = useCallback(
+    (colIndex, role) => {
+      dispatch({ type: 'SET_COLUMN_ROLE', payload: { colIndex, role } });
+      // Auto-assign next timestamp type
+      if (role === COLUMN_ROLES.TIMESTAMP && nextTimestampType) {
+        dispatch({
+          type: 'SET_COLUMN_TIMESTAMP_TYPE',
+          payload: { colIndex, timestampType: nextTimestampType }
+        });
+      }
+    },
+    [dispatch, nextTimestampType]
+  );
+
+  const handleTimestampTypeChange = useCallback(
+    (colIndex, timestampType) => {
+      dispatch({
+        type: 'SET_COLUMN_TIMESTAMP_TYPE',
+        payload: { colIndex, timestampType }
+      });
+    },
+    [dispatch]
+  );
+
+  const handleQuantityKindChange = useCallback(
+    (colIndex, quantityKind) => {
+      dispatch({
+        type: 'SET_COLUMN_QUANTITY_KIND',
+        payload: { colIndex, quantityKind }
+      });
+
+      if (quantityKind) {
+        // Auto-select first compatible unit
+        const unitIds = QUANTITY_UNIT_MAP[quantityKind.id] || [];
+        const firstUnit = unitIds.length > 0
+          ? UNITS.find(u => u.id === unitIds[0])
+          : null;
+        dispatch({
+          type: 'SET_COLUMN_UNIT',
+          payload: { colIndex, unit: firstUnit }
+        });
+
+        // Auto-select default medium
+        const mediumId = QUANTITY_MEDIUM_MAP[quantityKind.id];
+        const medium = mediumId ? MEDIA.find(m => m.id === mediumId) : null;
+        dispatch({
+          type: 'SET_COLUMN_MEDIUM',
+          payload: { colIndex, medium }
+        });
+      } else {
+        dispatch({ type: 'SET_COLUMN_UNIT', payload: { colIndex, unit: null } });
+        dispatch({ type: 'SET_COLUMN_MEDIUM', payload: { colIndex, medium: null } });
+      }
+    },
+    [dispatch]
+  );
+
+  const handleUnitChange = useCallback(
+    (colIndex, unit) => {
+      dispatch({ type: 'SET_COLUMN_UNIT', payload: { colIndex, unit } });
+    },
+    [dispatch]
+  );
+
+  const handleMediumChange = useCallback(
+    (colIndex, medium) => {
+      dispatch({ type: 'SET_COLUMN_MEDIUM', payload: { colIndex, medium } });
+    },
+    [dispatch]
+  );
+
+  const handleDateFormatChange = useCallback(
+    e => {
+      dispatch({ type: 'SET_DATE_FORMAT', payload: e.target.value });
+    },
+    [dispatch]
+  );
+
+  const handleDateOnlyFormatChange = useCallback(
+    e => {
+      dispatch({ type: 'SET_DATE_ONLY_FORMAT', payload: e.target.value });
+    },
+    [dispatch]
+  );
+
+  const handleTimeOnlyFormatChange = useCallback(
+    e => {
+      dispatch({ type: 'SET_TIME_ONLY_FORMAT', payload: e.target.value });
+    },
+    [dispatch]
+  );
+
+  const handleTimezoneChange = useCallback(
+    (_, val) => {
+      dispatch({ type: 'SET_TIMEZONE', payload: val ? val.value : 'UTC' });
+    },
+    [dispatch]
+  );
+
+  // Get units available for a given quantity kind
+  const getUnitsForQuantityKind = quantityKind => {
+    if (!quantityKind) return [];
+    const unitIds = QUANTITY_UNIT_MAP[quantityKind.id] || [];
+    return UNITS.filter(u => unitIds.includes(u.id));
+  };
+
+  // Sample values from the first 3 and last 3 data rows for each column
+  const startIdx = hasHeader ? headerRow + 1 : 0;
+  const endIdx = skipLastRows > 0 ? rawData.length - skipLastRows : rawData.length;
+  const dataRows = rawData.slice(startIdx, Math.max(startIdx, endIdx));
+  const sampleFirst = dataRows.slice(0, 10);
+  const sampleLast = dataRows.length > 20 ? dataRows.slice(-10) : [];
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Typography variant="body1">
+        Assign a role to each column. Timestamp columns need a type. Measurement
+        columns need a quantity kind and unit.
+        {' '}({dataRows.length} data rows to process)
+      </Typography>
+
+      {/* Contextual config fields */}
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Autocomplete
+          size="small"
+          options={TIMEZONES}
+          getOptionLabel={opt => opt.label}
+          value={TIMEZONES.find(tz => tz.value === timezone) || null}
+          onChange={handleTimezoneChange}
+          renderInput={params => (
+            <TextField {...params} label="Timezone" />
+          )}
+          sx={{ minWidth: 300 }}
+          isOptionEqualToValue={(opt, val) => opt.value === val.value}
+        />
+      </Box>
+
+      {/* Column mapping table */}
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 'bold' }}>Column</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Sample</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Role</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Type / Quantity</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Unit</TableCell>
+              <TableCell sx={{ fontWeight: 'bold' }}>Medium</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {headers.map((header, colIdx) => {
+              const mapping = columnMappings[colIdx] || {};
+              const isTimestamp = mapping.role === COLUMN_ROLES.TIMESTAMP;
+              const isMeasurement = mapping.role === COLUMN_ROLES.MEASUREMENT;
+              const isDecimalPart = mapping.role === COLUMN_ROLES.DECIMAL_PART;
+              const isExcluded = mapping.role === COLUMN_ROLES.EXCLUDED;
+              const excludedSx = isExcluded
+                ? { textDecoration: 'line-through', opacity: 0.5 }
+                : {};
+
+              let rowBgColor;
+              if (isTimestamp) rowBgColor = blue[50];
+              else if (isMeasurement || isDecimalPart) rowBgColor = orange[50];
+
+              const firstSamples = sampleFirst.map(r => r[colIdx] || '');
+              const lastSamples = sampleLast.map(r => r[colIdx] || '');
+              const allSamples = sampleLast.length > 0
+                ? [...firstSamples, '...', ...lastSamples]
+                : firstSamples;
+              const sampleText = allSamples.join(', ');
+              const displayText = sampleText.length > 40
+                ? `${sampleText.slice(0, 40)}…`
+                : sampleText;
+
+              const availableUnits = getUnitsForQuantityKind(mapping.quantityKind);
+
+              return (
+                <TableRow
+                  key={colIdx}
+                  sx={{
+                    ...excludedSx,
+                    ...(rowBgColor && { bgcolor: rowBgColor })
+                  }}>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight="bold" sx={excludedSx}>
+                      {header || `Col ${colIdx + 1}`}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Tooltip title={sampleText} arrow placement="top">
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          maxWidth: 200,
+                          display: 'block',
+                          cursor: 'default',
+                          ...excludedSx
+                        }}>
+                        {displayText}
+                      </Typography>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      value={mapping.role || ''}
+                      onChange={e => handleRoleChange(colIdx, e.target.value)}
+                      displayEmpty
+                      sx={{ minWidth: 120 }}>
+                      <MenuItem value="" disabled>
+                        <em>Select...</em>
+                      </MenuItem>
+                      {ROLE_OPTIONS.map(opt => (
+                        <MenuItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    {isTimestamp && (
+                      <Select
+                        size="small"
+                        value={mapping.timestampType || ''}
+                        onChange={e =>
+                          handleTimestampTypeChange(colIdx, e.target.value)
+                        }
+                        displayEmpty
+                        sx={{ minWidth: 180 }}>
+                        <MenuItem value="" disabled>
+                          <em>Select type...</em>
+                        </MenuItem>
+                        {TIMESTAMP_TYPES.map(t => (
+                          <MenuItem key={t.value} value={t.value}>
+                            {t.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                    {isMeasurement && (
+                      <Select
+                        size="small"
+                        value={mapping.quantityKind?.id ?? ''}
+                        onChange={e => {
+                          const qk = QUANTITY_KINDS.find(
+                            q => q.id === e.target.value
+                          );
+                          handleQuantityKindChange(colIdx, qk || null);
+                        }}
+                        displayEmpty
+                        sx={{ minWidth: 150 }}>
+                        <MenuItem value="" disabled>
+                          <em>Quantity...</em>
+                        </MenuItem>
+                        {QUANTITY_KINDS.map(qk => (
+                          <MenuItem key={qk.id} value={qk.id}>
+                            {qk.code}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isTimestamp && mapping.timestampType === 'datetime' && (
+                      <FormControl size="small" sx={{ minWidth: 180 }}>
+                        <InputLabel>Datetime format</InputLabel>
+                        <Select
+                          value={dateFormat}
+                          label="Datetime format"
+                          onChange={handleDateFormatChange}>
+                          {DATE_FORMATS.map(fmt => (
+                            <MenuItem key={fmt.value} value={fmt.value}>
+                              {fmt.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    )}
+                    {isTimestamp && mapping.timestampType === 'date' && (
+                      <FormControl size="small" sx={{ minWidth: 160 }}>
+                        <InputLabel>Date format</InputLabel>
+                        <Select
+                          value={dateOnlyFormat}
+                          label="Date format"
+                          onChange={handleDateOnlyFormatChange}>
+                          {DATE_ONLY_FORMATS.map(fmt => (
+                            <MenuItem key={fmt.value} value={fmt.value}>
+                              {fmt.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    )}
+                    {isTimestamp && mapping.timestampType === 'time' && (
+                      <FormControl size="small" sx={{ minWidth: 140 }}>
+                        <InputLabel>Time format</InputLabel>
+                        <Select
+                          value={timeOnlyFormat}
+                          label="Time format"
+                          onChange={handleTimeOnlyFormatChange}>
+                          {TIME_ONLY_FORMATS.map(fmt => (
+                            <MenuItem key={fmt.value} value={fmt.value}>
+                              {fmt.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    )}
+                    {isMeasurement && (
+                      <Select
+                        size="small"
+                        value={mapping.unit?.id ?? ''}
+                        onChange={e => {
+                          const u = UNITS.find(
+                            unit => unit.id === e.target.value
+                          );
+                          handleUnitChange(colIdx, u || null);
+                        }}
+                        displayEmpty
+                        disabled={!mapping.quantityKind}
+                        sx={{ minWidth: 120 }}>
+                        <MenuItem value="" disabled>
+                          <em>Unit...</em>
+                        </MenuItem>
+                        {availableUnits.map(u => (
+                          <MenuItem key={u.id} value={u.id}>
+                            {u.symbol}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isMeasurement && (
+                      <Select
+                        size="small"
+                        value={mapping.medium?.id ?? ''}
+                        onChange={e => {
+                          const med = MEDIA.find(
+                            m => m.id === e.target.value
+                          );
+                          handleMediumChange(colIdx, med || null);
+                        }}
+                        displayEmpty
+                        sx={{ minWidth: 100 }}>
+                        <MenuItem value="">
+                          <em>None</em>
+                        </MenuItem>
+                        {MEDIA.map(m => (
+                          <MenuItem key={m.id} value={m.id}>
+                            {m.code}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+StepMapping.propTypes = {
+  state: PropTypes.shape({
+    rawData: PropTypes.arrayOf(PropTypes.array).isRequired,
+    headerRow: PropTypes.number,
+    columnMappings: PropTypes.object.isRequired,
+    dateFormat: PropTypes.string.isRequired,
+    timezone: PropTypes.string.isRequired
+  }).isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export default StepMapping;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/StepUpload.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/StepUpload.jsx
@@ -1,0 +1,348 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import { usePapaParse } from 'react-papaparse';
+import { ENCODINGS, NUMBER_LOCALES } from './constants';
+import detectEncoding from './detectEncoding';
+
+const MAX_PREVIEW_ROWS = 10;
+
+const StepUpload = ({ state, dispatch }) => {
+  const { readString } = usePapaParse();
+  const fileRef = useRef(null);
+  const csvInputRef = useRef(null);
+
+  const parseFile = useCallback(
+    (file, encoding) => {
+      const reader = new FileReader();
+      reader.onload = event => {
+        const text = event.target.result;
+        readString(text, {
+          header: false,
+          skipEmptyLines: true,
+          complete: results => {
+            dispatch({ type: 'SET_RAW_DATA', payload: results.data });
+          }
+        });
+      };
+      reader.readAsText(file, encoding);
+    },
+    [dispatch, readString]
+  );
+
+  const handleFileChange = useCallback(
+    async e => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      fileRef.current = file;
+      dispatch({ type: 'SET_FILE_NAME', payload: file.name });
+
+      // Auto-detect encoding
+      const detected = await detectEncoding(file);
+      dispatch({ type: 'SET_ENCODING', payload: detected });
+      parseFile(file, detected);
+    },
+    [dispatch, parseFile]
+  );
+
+  const handleEncodingChange = useCallback(
+    e => {
+      dispatch({ type: 'SET_ENCODING', payload: e.target.value });
+    },
+    [dispatch]
+  );
+
+  // Re-parse when encoding changes
+  useEffect(() => {
+    if (fileRef.current) {
+      parseFile(fileRef.current, state.encoding);
+    }
+  }, [state.encoding, parseFile]);
+
+  // Clear file refs on reset (when rawData becomes empty)
+  useEffect(() => {
+    if (state.rawData.length === 0) {
+      fileRef.current = null;
+      if (csvInputRef.current) {
+        csvInputRef.current.value = '';
+      }
+      if (profileInputRef.current) {
+        profileInputRef.current.value = '';
+      }
+    }
+  }, [state.rawData]);
+
+  const handleHeaderRowChange = useCallback(
+    e => {
+      dispatch({
+        type: 'SET_HEADER_ROW',
+        payload: e.target.value === '' ? null : Number(e.target.value)
+      });
+    },
+    [dispatch]
+  );
+
+  const handleSkipLastRowsChange = useCallback(
+    e => {
+      dispatch({
+        type: 'SET_SKIP_LAST_ROWS',
+        payload: Number(e.target.value) || 0
+      });
+    },
+    [dispatch]
+  );
+
+  const profileInputRef = useRef(null);
+
+  const handleImportProfile = useCallback(
+    e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      dispatch({ type: 'SET_PROFILE_NAME', payload: file.name });
+      const reader = new FileReader();
+      reader.onload = event => {
+        try {
+          const profile = JSON.parse(event.target.result);
+          if (profile.columnMappings) {
+            dispatch({ type: 'SET_PROFILE', payload: profile });
+          }
+        } catch (err) {
+          // Invalid JSON — ignore silently
+        }
+      };
+      reader.readAsText(file);
+      if (profileInputRef.current) {
+        profileInputRef.current.value = '';
+      }
+    },
+    [dispatch]
+  );
+
+  const handleLocaleChange = useCallback(
+    e => {
+      dispatch({ type: 'SET_NUMBER_LOCALE', payload: e.target.value });
+    },
+    [dispatch]
+  );
+
+  const { rawData, headerRow, skipLastRows, numberLocale, fileName, encoding } = state;
+  const hasHeader = headerRow != null;
+  const maxCols = rawData.reduce((max, row) => Math.max(max, row.length), 0);
+  const headerRowData = hasHeader && rawData.length > headerRow
+    ? rawData[headerRow]
+    : null;
+  // Use header row for column names only if it has the expected column count
+  const headers = headerRowData && headerRowData.length >= maxCols
+    ? headerRowData
+    : (maxCols > 0 ? Array.from({ length: maxCols }, (_, i) => `Col ${i + 1}`) : []);
+  const startIdx = hasHeader ? headerRow + 1 : 0;
+  const endIdx = skipLastRows > 0 ? rawData.length - skipLastRows : rawData.length;
+  const dataRows = rawData.slice(startIdx, Math.max(startIdx, endIdx));
+  const previewFirst = dataRows.slice(0, MAX_PREVIEW_ROWS);
+  const previewLast =
+    dataRows.length > MAX_PREVIEW_ROWS * 2
+      ? dataRows.slice(-MAX_PREVIEW_ROWS)
+      : [];
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+        <Button
+          component="label"
+          variant="contained"
+          startIcon={<CloudUploadIcon />}>
+          Upload CSV
+          <input
+            type="file"
+            accept=".csv,.tsv,.txt"
+            hidden
+            ref={csvInputRef}
+            onChange={handleFileChange}
+          />
+        </Button>
+        {fileName && (
+          <Typography variant="body2" color="text.secondary">
+            {fileName} ({dataRows.length} data rows)
+          </Typography>
+        )}
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+        <Button
+          component="label"
+          variant="outlined"
+          size="small"
+          disabled={rawData.length === 0}
+          startIcon={<FileUploadIcon />}>
+          Import profile
+          <input
+            type="file"
+            accept=".json"
+            hidden
+            ref={profileInputRef}
+            onChange={handleImportProfile}
+          />
+        </Button>
+        {state.profileName && (
+          <Typography variant="body2" color="text.secondary">
+            {state.profileName}
+          </Typography>
+        )}
+      </Box>
+
+      {rawData.length > 0 && (
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel>Encoding</InputLabel>
+            <Select
+              value={encoding}
+              label="Encoding"
+              onChange={handleEncodingChange}>
+              {ENCODINGS.map(enc => (
+                <MenuItem key={enc.value} value={enc.value}>
+                  {enc.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <InputLabel>Header / skip rows</InputLabel>
+            <Select
+              value={headerRow ?? ''}
+              label="Header / skip rows"
+              onChange={handleHeaderRowChange}>
+              <MenuItem value="">
+                <em>No rows to skip</em>
+              </MenuItem>
+              {rawData.slice(0, Math.min(10, rawData.length)).map((row, i) => (
+                <MenuItem key={i} value={i}>
+                  Row {i + 1}: {row.slice(0, 3).join(' | ')}...
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <InputLabel>Skip last rows</InputLabel>
+            <Select
+              value={skipLastRows}
+              label="Skip last rows"
+              onChange={handleSkipLastRowsChange}>
+              <MenuItem value={0}>
+                <em>None (use all rows)</em>
+              </MenuItem>
+              {rawData.slice(Math.max(0, rawData.length - 10)).map((row, i) => {
+                const distFromEnd = rawData.length - (Math.max(0, rawData.length - 10) + i);
+                return (
+                  <MenuItem key={distFromEnd} value={distFromEnd}>
+                    Last {distFromEnd}: {row.slice(0, 3).join(' | ')}...
+                  </MenuItem>
+                );
+              }).reverse()}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel>Number format</InputLabel>
+            <Select
+              value={numberLocale}
+              label="Number format"
+              onChange={handleLocaleChange}>
+              {NUMBER_LOCALES.map(loc => (
+                <MenuItem key={loc.value} value={loc.value}>
+                  {loc.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      )}
+
+      {headers.length > 0 && (
+        <TableContainer component={Paper} sx={{ maxHeight: 400 }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 'bold' }}>#</TableCell>
+                {headers.map((h, i) => (
+                  <TableCell key={i} sx={{ fontWeight: 'bold' }}>
+                    {h || `Col ${i + 1}`}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {previewFirst.map((row, rowIdx) => (
+                <TableRow key={`first-${rowIdx}`}>
+                  <TableCell>{rowIdx + 1}</TableCell>
+                  {headers.map((_, colIdx) => (
+                    <TableCell key={colIdx}>
+                      {row[colIdx] ?? ''}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+              {previewLast.length > 0 && (
+                <>
+                  <TableRow>
+                    <TableCell
+                      colSpan={headers.length + 1}
+                      align="center"
+                      sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+                      ... {dataRows.length - MAX_PREVIEW_ROWS * 2} rows hidden
+                      ...
+                    </TableCell>
+                  </TableRow>
+                  {previewLast.map((row, rowIdx) => (
+                    <TableRow key={`last-${rowIdx}`}>
+                      <TableCell>
+                        {dataRows.length - MAX_PREVIEW_ROWS + rowIdx + 1}
+                      </TableCell>
+                      {headers.map((_, colIdx) => (
+                        <TableCell key={colIdx}>
+                          {row[colIdx] ?? ''}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+StepUpload.propTypes = {
+  state: PropTypes.shape({
+    rawData: PropTypes.arrayOf(PropTypes.array).isRequired,
+    headerRow: PropTypes.number,
+    numberLocale: PropTypes.string.isRequired,
+    encoding: PropTypes.string.isRequired,
+    fileName: PropTypes.string
+  }).isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export default StepUpload;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/StepValidation.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/StepValidation.jsx
@@ -1,0 +1,223 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert,
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { normalizeNumber } from './numberUtils';
+import { COLUMN_ROLES } from './constants';
+import { buildTimestamp, hasValidTimestampConfig } from './timestampUtils';
+import resolveRow from './resolveRow';
+
+const StepValidation = ({ state, dispatch }) => {
+  const { rawData, headerRow, skipLastRows, columnMappings, dateFormat, dateOnlyFormat, timeOnlyFormat, numberLocale, timezone } = state;
+
+  const validationResult = useMemo(() => {
+    const hasHeader = headerRow != null;
+    const maxCols = rawData.reduce((max, row) => Math.max(max, row.length), 0);
+    const headerRowData = hasHeader && rawData.length > headerRow
+      ? rawData[headerRow]
+      : null;
+    const headers = headerRowData && headerRowData.length >= maxCols
+      ? headerRowData
+      : (maxCols > 0 ? Array.from({ length: maxCols }, (_, i) => `Col ${i + 1}`) : []);
+    const startIdx = hasHeader ? headerRow + 1 : 0;
+    const endIdx = skipLastRows > 0 ? rawData.length - skipLastRows : rawData.length;
+    const dataRows = rawData.slice(startIdx, Math.max(startIdx, endIdx));
+
+    const measurementCols = Object.entries(columnMappings)
+      .filter(([_, m]) => m.role === COLUMN_ROLES.MEASUREMENT)
+      .map(([idx, m]) => ({ index: Number(idx), ...m }));
+
+    const errors = [];
+    const warnings = [];
+    const invalidRows = [];
+    let validCount = 0;
+
+    // Check timestamp config
+    if (!hasValidTimestampConfig(columnMappings)) {
+      errors.push('Timestamp configuration is incomplete.');
+    }
+
+    // Check measurement columns have quantity kind + unit
+    measurementCols.forEach(col => {
+      const colName = headers[col.index] || `Col ${col.index + 1}`;
+      if (!col.quantityKind) {
+        errors.push(`Column "${colName}" is missing a quantity kind.`);
+      }
+      if (!col.unit) {
+        errors.push(`Column "${colName}" is missing a unit.`);
+      }
+    });
+
+    if (measurementCols.length === 0) {
+      errors.push('No measurement columns selected.');
+    }
+
+    // Validate rows
+    dataRows.forEach((rawRow, rowIdx) => {
+      const row = resolveRow(rawRow, columnMappings);
+      const ts = buildTimestamp(row, columnMappings, { dateFormat, dateOnlyFormat, timeOnlyFormat, timezone });
+
+      if (!ts) {
+        invalidRows.push({
+          rowIdx: rowIdx + 1,
+          reason: 'Invalid or missing timestamp',
+          row
+        });
+        return;
+      }
+
+      let hasValidMeasurement = false;
+      measurementCols.forEach(col => {
+        const rawVal = row[col.index];
+        const num = normalizeNumber(rawVal, numberLocale);
+        if (num != null) {
+          hasValidMeasurement = true;
+        }
+      });
+
+      if (!hasValidMeasurement) {
+        invalidRows.push({
+          rowIdx: rowIdx + 1,
+          reason: 'No valid numeric values in measurement columns',
+          row
+        });
+        return;
+      }
+
+      validCount += 1;
+    });
+
+    if (invalidRows.length > 0) {
+      warnings.push(
+        `${invalidRows.length} row(s) have issues and will be skipped.`
+      );
+    }
+
+    return {
+      errors,
+      warnings,
+      invalidRows,
+      validCount,
+      measurementCols,
+      totalRows: dataRows.length
+    };
+  }, [rawData, headerRow, skipLastRows, columnMappings, dateFormat, dateOnlyFormat, timeOnlyFormat, numberLocale, timezone]);
+
+  // Persist validation to parent state
+  React.useEffect(() => {
+    dispatch({
+      type: 'SET_VALIDATION_RESULT',
+      payload: validationResult
+    });
+  }, [validationResult, dispatch]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Validation Summary</Typography>
+
+      {validationResult.errors.length > 0 && (
+        <Alert severity="error">
+          <Typography variant="subtitle2">
+            Blocking errors (fix before importing):
+          </Typography>
+          <ul style={{ margin: 0, paddingLeft: 16 }}>
+            {validationResult.errors.map((err, i) => (
+              <li key={i}>{err}</li>
+            ))}
+          </ul>
+        </Alert>
+      )}
+
+      {validationResult.warnings.length > 0 && (
+        <Alert severity="warning">
+          {validationResult.warnings.map((w, i) => (
+            <Typography key={i} variant="body2">
+              {w}
+            </Typography>
+          ))}
+        </Alert>
+      )}
+
+      {validationResult.errors.length === 0 && (
+        <Alert severity="success">
+          <Typography variant="body2">
+            Ready to generate SQL. {validationResult.validCount} valid rows out
+            of {validationResult.totalRows} total.
+          </Typography>
+        </Alert>
+      )}
+
+      <Paper sx={{ p: 2 }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Time series to create:
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {validationResult.measurementCols?.map(col => (
+            <Chip
+              key={col.index}
+              label={`${col.quantityKind?.code || '?'} (${col.unit?.symbol || '?'})${col.medium ? ` in ${col.medium.code}` : ''}`}
+              color="success"
+              variant="outlined"
+            />
+          ))}
+        </Box>
+      </Paper>
+
+      {validationResult.invalidRows?.length > 0 && (
+        <>
+          <Typography variant="subtitle2">
+            Invalid rows (first 20):
+          </Typography>
+          <TableContainer component={Paper} sx={{ maxHeight: 300 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Row #</TableCell>
+                  <TableCell>Reason</TableCell>
+                  <TableCell>Data</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {validationResult.invalidRows.slice(0, 20).map(inv => (
+                  <TableRow key={inv.rowIdx}>
+                    <TableCell>{inv.rowIdx}</TableCell>
+                    <TableCell>{inv.reason}</TableCell>
+                    <TableCell>
+                      <Typography variant="caption" noWrap>
+                        {inv.row.slice(0, 5).join(' | ')}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Box>
+  );
+};
+
+StepValidation.propTypes = {
+  state: PropTypes.shape({
+    rawData: PropTypes.arrayOf(PropTypes.array).isRequired,
+    headerRow: PropTypes.number,
+    columnMappings: PropTypes.object.isRequired,
+    dateFormat: PropTypes.string.isRequired,
+    numberLocale: PropTypes.string.isRequired
+  }).isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export default StepValidation;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/constants.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/constants.js
@@ -1,0 +1,186 @@
+// Lookup data from t_quantity_kind seed
+export const QUANTITY_KINDS = [
+  { id: 1, code: 'Temperature', symbolSi: 'K', displaySymbol: '°C', siToDisplayFactor: 1, siToDisplayOffset: -273.15 },
+  { id: 2, code: 'RelativeHumidity', symbolSi: '%', displaySymbol: '%', siToDisplayFactor: 100, siToDisplayOffset: 0 },
+  { id: 3, code: 'AtmosphericPressure', symbolSi: 'Pa', displaySymbol: 'hPa', siToDisplayFactor: 0.01, siToDisplayOffset: 0 },
+  { id: 4, code: 'CO2Concentration', symbolSi: 'mol/mol', displaySymbol: 'ppm', siToDisplayFactor: 1000000, siToDisplayOffset: 0 },
+  { id: 5, code: 'WaterLevel', symbolSi: 'm', displaySymbol: 'm', siToDisplayFactor: 1, siToDisplayOffset: 0 },
+  { id: 6, code: 'WaterFlow', symbolSi: 'm³/s', displaySymbol: 'm³/s', siToDisplayFactor: 1, siToDisplayOffset: 0 },
+  { id: 7, code: 'Conductivity', symbolSi: 'S/m', displaySymbol: 'µS/cm', siToDisplayFactor: 10000, siToDisplayOffset: 0 },
+  { id: 8, code: 'pH', symbolSi: 'pH', displaySymbol: 'pH', siToDisplayFactor: 1, siToDisplayOffset: 0 },
+  { id: 9, code: 'Precipitation', symbolSi: 'm', displaySymbol: 'mm', siToDisplayFactor: 1000, siToDisplayOffset: 0 },
+  { id: 10, code: 'DewPointTemperature', symbolSi: 'K', displaySymbol: '°C', siToDisplayFactor: 1, siToDisplayOffset: -273.15 }
+];
+
+// Lookup data from t_unit seed
+export const UNITS = [
+  { id: 1, code: 'degree_celsius', symbol: '°C' },
+  { id: 2, code: 'percent', symbol: '%' },
+  { id: 3, code: 'hectopascal', symbol: 'hPa' },
+  { id: 4, code: 'parts_per_million', symbol: 'ppm' },
+  { id: 5, code: 'meter', symbol: 'm' },
+  { id: 6, code: 'liter_per_second', symbol: 'L/s' },
+  { id: 7, code: 'microsiemens_per_centimeter', symbol: 'µS/cm' },
+  { id: 8, code: 'ph_unit', symbol: 'pH' },
+  { id: 9, code: 'kelvin', symbol: 'K' },
+  { id: 10, code: 'millimeter', symbol: 'mm' },
+  { id: 11, code: 'event_count', symbol: 'count' }
+];
+
+// Lookup data from t_medium seed
+export const MEDIA = [
+  { id: 1, code: 'water' },
+  { id: 2, code: 'air' },
+  { id: 3, code: 'soil' },
+  { id: 4, code: 'sediment' }
+];
+
+// Number locale options for decimal separator handling
+export const NUMBER_LOCALES = [
+  { value: 'en', label: '1,234.56 (dot decimal)', example: '23.5' },
+  { value: 'fr', label: '1.234,56 (comma decimal)', example: '23,5' }
+];
+
+// File encoding options
+export const ENCODINGS = [
+  { value: 'UTF-8', label: 'UTF-8' },
+  { value: 'ISO-8859-1', label: 'Latin-1 (ISO-8859-1)' },
+  { value: 'windows-1252', label: 'Windows-1252' },
+  { value: 'UTF-16', label: 'UTF-16' }
+];
+
+// Common date format patterns (for 'datetime' timestamp type)
+export const DATE_FORMATS = [
+  { value: 'yyyy-MM-dd HH:mm:ss', label: '2025-01-15 14:30:00' },
+  { value: 'dd/MM/yyyy HH:mm:ss', label: '15/01/2025 14:30:00' },
+  { value: 'MM/dd/yyyy HH:mm:ss', label: '01/15/2025 14:30:00' },
+  { value: 'yyyy-MM-dd HH:mm', label: '2025-01-15 14:30' },
+  { value: 'dd/MM/yyyy HH:mm', label: '15/01/2025 14:30' },
+  { value: "yyyy-MM-dd'T'HH:mm:ss", label: '2025-01-15T14:30:00' },
+  { value: "yyyy-MM-dd'T'HH:mm:ssXXX", label: '2025-01-15T14:30:00+01:00' },
+  { value: 'dd/MM/yyyy', label: '15/01/2025' },
+  { value: 'yyyy-MM-dd', label: '2025-01-15' }
+];
+
+// Date-only formats (for 'date' timestamp type)
+export const DATE_ONLY_FORMATS = [
+  { value: 'yyyy-MM-dd', label: '2025-01-15' },
+  { value: 'dd/MM/yyyy', label: '15/01/2025' },
+  { value: 'MM/dd/yyyy', label: '01/15/2025' },
+  { value: 'yy/MM/dd', label: '25/01/15' },
+  { value: 'dd/MM/yy', label: '15/01/25' },
+  { value: 'yyyy/MM/dd', label: '2025/01/15' },
+  { value: 'dd-MM-yyyy', label: '15-01-2025' },
+  { value: 'yyyyMMdd', label: '20250115' }
+];
+
+// Time-only formats (for 'time' timestamp type)
+export const TIME_ONLY_FORMATS = [
+  { value: 'HH:mm:ss', label: '14:30:00' },
+  { value: 'HH:mm', label: '14:30' },
+  { value: 'H:mm:ss', label: '9:30:00' },
+  { value: 'H:mm', label: '9:30' },
+  { value: 'HH:mm:ss.SSS', label: '14:30:00.000' },
+  { value: 'HHmmss', label: '143000' }
+];
+
+// Wizard step IDs
+export const STEPS = {
+  UPLOAD: 0,
+  MAPPING: 1,
+  VALIDATION: 2,
+  DOWNLOAD: 3
+};
+
+// Column roles
+export const COLUMN_ROLES = {
+  TIMESTAMP: 'timestamp',
+  MEASUREMENT: 'measurement',
+  DECIMAL_PART: 'decimal_part',
+  EXCLUDED: 'excluded'
+};
+
+// Timestamp sub-types: what kind of time value does this column hold?
+export const TIMESTAMP_TYPES = [
+  { value: 'datetime', label: 'Full datetime' },
+  { value: 'date', label: 'Date only' },
+  { value: 'time', label: 'Time only' },
+  { value: 'elapsed_seconds', label: 'Elapsed seconds' },
+  { value: 'year', label: 'Year' },
+  { value: 'month', label: 'Month' },
+  { value: 'day', label: 'Day' },
+  { value: 'hour', label: 'Hour' },
+  { value: 'minute', label: 'Minute' },
+  { value: 'second', label: 'Second' }
+];
+
+// Map quantity kind IDs to their compatible unit IDs
+export const QUANTITY_UNIT_MAP = {
+  1: [1, 9],       // Temperature → °C, K
+  2: [2],          // RelativeHumidity → %
+  3: [3],          // AtmosphericPressure → hPa
+  4: [4],          // CO2Concentration → ppm
+  5: [5, 10],      // WaterLevel → m, mm
+  6: [6],          // WaterFlow → L/s
+  7: [7],          // Conductivity → µS/cm
+  8: [8],          // pH → pH
+  9: [10, 11],     // Precipitation → mm, count
+  10: [1, 9]       // DewPointTemperature → °C, K
+};
+
+// Map quantity kind IDs to their default medium ID
+export const QUANTITY_MEDIUM_MAP = {
+  1: 2,   // Temperature → air
+  2: 2,   // RelativeHumidity → air
+  3: 2,   // AtmosphericPressure → air
+  4: 2,   // CO2Concentration → air
+  5: 1,   // WaterLevel → water
+  6: 1,   // WaterFlow → water
+  7: 1,   // Conductivity → water
+  8: 1,   // pH → water
+  9: 1,   // Precipitation → water
+  10: 2   // DewPointTemperature → air
+};
+
+// All IANA timezones with UTC offsets, sorted by offset
+export const TIMEZONES = (() => {
+  const zones = Intl.supportedValuesOf('timeZone');
+  const now = Date.now();
+  const fmt = tz => {
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz,
+        timeZoneName: 'shortOffset'
+      }).formatToParts(now);
+      const offsetPart = parts.find(p => p.type === 'timeZoneName');
+      return offsetPart ? offsetPart.value : '';
+    } catch (e) {
+      return '';
+    }
+  };
+
+  return zones
+    .map(tz => {
+      const offset = fmt(tz);
+      // Parse offset like "GMT+2", "GMT-5:30", "GMT" into minutes
+      let offsetMinutes = 0;
+      if (offset && offset !== 'GMT') {
+        const match = offset.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+        if (match) {
+          const sign = match[1] === '+' ? 1 : -1;
+          const hours = parseInt(match[2], 10);
+          const mins = match[3] ? parseInt(match[3], 10) : 0;
+          offsetMinutes = sign * (hours * 60 + mins);
+        }
+      }
+      const utcLabel = offsetMinutes === 0
+        ? 'UTC'
+        : `UTC${offsetMinutes > 0 ? '+' : ''}${Math.floor(offsetMinutes / 60)}${offsetMinutes % 60 ? `:${String(Math.abs(offsetMinutes % 60)).padStart(2, '0')}` : ''}`;
+      return {
+        value: tz,
+        label: `${tz} (${utcLabel})`,
+        offsetMinutes
+      };
+    })
+    .sort((a, b) => a.offsetMinutes - b.offsetMinutes || a.value.localeCompare(b.value));
+})();

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/detectEncoding.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/detectEncoding.js
@@ -1,0 +1,86 @@
+/**
+ * Detect the most likely encoding of a file by reading a small sample.
+ * Checks for BOM markers and non-UTF-8 byte patterns.
+ *
+ * @param {File} file - The File object to sniff
+ * @returns {Promise<string>} - Detected encoding label
+ */
+const detectEncoding = async file => {
+  const slice = file.slice(0, 4096);
+  const buffer = await slice.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  // Check for BOM (Byte Order Mark)
+  if (bytes[0] === 0xEF && bytes[1] === 0xBB && bytes[2] === 0xBF) {
+    return 'UTF-8';
+  }
+  if (bytes[0] === 0xFF && bytes[1] === 0xFE) {
+    return 'UTF-16';
+  }
+  if (bytes[0] === 0xFE && bytes[1] === 0xFF) {
+    return 'UTF-16';
+  }
+
+  // Try to detect non-UTF-8: look for bytes in the 0x80-0xFF range
+  // that don't form valid UTF-8 sequences
+  let i = 0;
+  let hasHighBytes = false;
+  let invalidUtf8 = false;
+
+  while (i < bytes.length) {
+    const b = bytes[i];
+
+    if (b < 0x80) {
+      // ASCII — valid in all encodings
+      i += 1;
+    } else {
+      hasHighBytes = true;
+
+      // Check if this is a valid UTF-8 multi-byte sequence
+      if ((b & 0xE0) === 0xC0) {
+        // 2-byte sequence: 110xxxxx 10xxxxxx
+        if (i + 1 >= bytes.length || (bytes[i + 1] & 0xC0) !== 0x80) {
+          invalidUtf8 = true;
+          break;
+        }
+        i += 2;
+      } else if ((b & 0xF0) === 0xE0) {
+        // 3-byte sequence: 1110xxxx 10xxxxxx 10xxxxxx
+        if (
+          i + 2 >= bytes.length ||
+          (bytes[i + 1] & 0xC0) !== 0x80 ||
+          (bytes[i + 2] & 0xC0) !== 0x80
+        ) {
+          invalidUtf8 = true;
+          break;
+        }
+        i += 3;
+      } else if ((b & 0xF8) === 0xF0) {
+        // 4-byte sequence
+        if (
+          i + 3 >= bytes.length ||
+          (bytes[i + 1] & 0xC0) !== 0x80 ||
+          (bytes[i + 2] & 0xC0) !== 0x80 ||
+          (bytes[i + 3] & 0xC0) !== 0x80
+        ) {
+          invalidUtf8 = true;
+          break;
+        }
+        i += 4;
+      } else {
+        // Invalid UTF-8 start byte (0x80-0xBF or 0xF8+)
+        invalidUtf8 = true;
+        break;
+      }
+    }
+  }
+
+  if (invalidUtf8 || (hasHighBytes && invalidUtf8)) {
+    // High bytes that aren't valid UTF-8 → likely Latin-1 or Windows-1252
+    return 'windows-1252';
+  }
+
+  return 'UTF-8';
+};
+
+export default detectEncoding;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/generateSql.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/generateSql.js
@@ -1,0 +1,212 @@
+import { toSI } from './numberUtils';
+
+const MAX_VALUES_PER_INSERT = 100;
+
+/**
+ * Generate the full SQL import script from wizard state.
+ *
+ * @param {object} params
+ * @param {string} params.caveId - Cave ID to associate with
+ * @param {string} params.pointLabel - Label for the observation point
+ * @param {number} params.authorId - Caver ID of the importing user
+ * @param {string} params.timezone - Timezone offset string (e.g., 'Europe/Paris', '+02:00')
+ * @param {Array} params.columns - Column mapping array
+ * @param {Array} params.rows - Validated data rows (already normalized numbers + parsed timestamps)
+ * @param {string} params.deviceName - Device name
+ * @returns {string} - The full SQL script
+ */
+const generateSql = ({
+  caveId,
+  pointLabel,
+  authorId,
+  timezone,
+  columns,
+  rows
+}) => {
+  const measurementCols = columns.filter(c => c.role === 'measurement');
+  const timestampCol = columns.find(c => c.role === 'timestamp');
+
+  if (!timestampCol || measurementCols.length === 0 || rows.length === 0) {
+    return '-- No data to import.\n';
+  }
+
+  // Compute stats for each time series
+  const seriesStats = measurementCols.map((col, idx) => {
+    const values = rows
+      .map(r => r[col.index])
+      .filter(v => v != null && Number.isFinite(v));
+    const timestamps = rows
+      .map(r => r[timestampCol.index])
+      .filter(t => t != null);
+
+    return {
+      col,
+      idx,
+      label: `ts_${idx}`,
+      min: values.length ? Math.min(...values) : 0,
+      max: values.length ? Math.max(...values) : 0,
+      count: values.length,
+      startDate: timestamps.length
+        ? timestamps[0]
+        : null,
+      endDate: timestamps.length
+        ? timestamps[timestamps.length - 1]
+        : null
+    };
+  });
+
+  // Detect sampling interval from first few timestamps
+  const detectSamplingInterval = () => {
+    const timestamps = rows
+      .slice(0, 10)
+      .map(r => r[timestampCol.index])
+      .filter(t => t != null);
+    if (timestamps.length < 2) return null;
+    const intervals = [];
+    for (let i = 1; i < timestamps.length; i += 1) {
+      const diff = (new Date(timestamps[i]) - new Date(timestamps[i - 1])) / 1000;
+      intervals.push(diff);
+    }
+    const allSame = intervals.every(d => d === intervals[0]);
+    return allSame ? intervals[0] : null;
+  };
+
+  const samplingInterval = detectSamplingInterval();
+
+  const lines = [];
+
+  // Header
+  lines.push(`-- ============================================================`);
+  lines.push(`-- Import: Cave ${caveId} observation data`);
+  lines.push(`-- Point: ${pointLabel}`);
+  lines.push(`-- Columns: ${measurementCols.map(c => c.quantityKind.code).join(', ')}`);
+  lines.push(`-- Rows: ${rows.length}`);
+  lines.push(`-- Generated: ${new Date().toISOString()}`);
+  lines.push(`-- ============================================================`);
+  lines.push('');
+  lines.push('BEGIN;');
+  lines.push('');
+
+  // Temp table
+  lines.push('CREATE TEMP TABLE _import_ts_ids (');
+  lines.push('  label TEXT PRIMARY KEY,');
+  lines.push('  ts_id INT NOT NULL');
+  lines.push(');');
+  lines.push('');
+
+  // Fix sequences
+  lines.push('SELECT setval(\'t_device_id_seq\', (SELECT COALESCE(MAX(id), 0) FROM t_device));');
+  lines.push('SELECT setval(\'t_sensor_configuration_id_seq\', (SELECT COALESCE(MAX(id), 0) FROM t_sensor_configuration));');
+  lines.push('SELECT setval(\'t_point_id_seq\', (SELECT COALESCE(MAX(id), 0) FROM t_point));');
+  lines.push('SELECT setval(\'t_observation_id_seq\', (SELECT COALESCE(MAX(id), 0) FROM t_observation));');
+  lines.push('SELECT setval(\'t_time_series_id_seq\', (SELECT COALESCE(MAX(id), 0) FROM t_time_series));');
+  lines.push('');
+
+  // Device
+  lines.push(`INSERT INTO t_device (name, brand_name)`);
+  lines.push(`  VALUES ('Imported device', NULL);`);
+  lines.push('');
+
+  // PL/pgSQL block for dynamic IDs
+  lines.push('DO $$');
+  lines.push('DECLARE');
+  lines.push('  v_device_id INT;');
+  lines.push('  v_point_id INT;');
+  lines.push('  v_obs_id INT;');
+  lines.push('  v_ts_id INT;');
+  lines.push('BEGIN');
+  lines.push('');
+  lines.push('  v_device_id := currval(\'t_device_id_seq\');');
+  lines.push('');
+
+  // Sensor configurations
+  measurementCols.forEach(col => {
+    lines.push(`  INSERT INTO t_sensor_configuration (id_device, id_quantity_kind, id_unit)`);
+    lines.push(`    VALUES (v_device_id, ${col.quantityKind.id}, ${col.unit.id});`);
+  });
+  lines.push('');
+
+  // Point
+  lines.push(`  INSERT INTO t_point (id_author, date_inscription, label, id_cave, is_deleted)`);
+  lines.push(`    VALUES (${authorId}, now(), '${escapeSql(pointLabel)}', ${caveId}, false)`);
+  lines.push('    RETURNING id INTO v_point_id;');
+  lines.push('');
+
+  // Observation
+  const obsDate = seriesStats[0].startDate || new Date().toISOString();
+  lines.push(`  INSERT INTO t_observation (`);
+  lines.push(`    id_author, date_inscription, observation_date, id_point, id_cave,`);
+  lines.push(`    id_observation_type, observation_type_code, point_label, is_deleted`);
+  lines.push(`  ) VALUES (`);
+  lines.push(`    ${authorId}, now(), '${obsDate}', v_point_id, ${caveId},`);
+  lines.push(`    2, 'physical_measurements', '${escapeSql(pointLabel)}', false`);
+  lines.push(`  ) RETURNING id INTO v_obs_id;`);
+  lines.push('');
+
+  // Time series
+  const sensorConfigOffset = measurementCols.length;
+  measurementCols.forEach((col, idx) => {
+    const stats = seriesStats[idx];
+    const mediumId = col.medium ? col.medium.id : 'NULL';
+    const mediumCode = col.medium ? `'${col.medium.code}'` : 'NULL';
+    const intervalSql = samplingInterval != null ? samplingInterval : 'NULL';
+    const startSql = stats.startDate ? `'${stats.startDate}'` : 'NULL';
+    const endSql = stats.endDate ? `'${stats.endDate}'` : 'NULL';
+    const tzSql = timezone ? `'${escapeSql(timezone)}'` : 'NULL';
+
+    lines.push(`  INSERT INTO t_time_series (`);
+    lines.push(`    id_author, date_inscription, id_observation, id_sensor_configuration,`);
+    lines.push(`    id_medium, sampling_interval_seconds, start_date, end_date,`);
+    lines.push(`    measurement_count, min_value, max_value, data_quality,`);
+    lines.push(`    quantity_kind_code, unit_symbol, medium_code, timezone_offset, is_deleted`);
+    lines.push(`  ) VALUES (`);
+    lines.push(`    ${authorId}, now(), v_obs_id, currval('t_sensor_configuration_id_seq') - ${sensorConfigOffset - idx - 1},`);
+    lines.push(`    ${mediumId}, ${intervalSql}, ${startSql}, ${endSql},`);
+    lines.push(`    ${stats.count}, ${stats.min}, ${stats.max}, 'raw',`);
+    lines.push(`    '${col.quantityKind.code}', '${col.unit.symbol}', ${mediumCode}, ${tzSql}, false`);
+    lines.push(`  ) RETURNING id INTO v_ts_id;`);
+    lines.push(`  INSERT INTO _import_ts_ids VALUES ('${stats.label}', v_ts_id);`);
+    lines.push('');
+  });
+
+  lines.push('END $$;');
+  lines.push('');
+
+  // Measurements - chunked inserts
+  measurementCols.forEach((col, idx) => {
+    const stats = seriesStats[idx];
+    const validRows = rows.filter(
+      r => r[timestampCol.index] != null && r[col.index] != null && Number.isFinite(r[col.index])
+    );
+
+    for (let chunk = 0; chunk < validRows.length; chunk += MAX_VALUES_PER_INSERT) {
+      const batch = validRows.slice(chunk, chunk + MAX_VALUES_PER_INSERT);
+      lines.push('INSERT INTO t_measurement (id_time_series, value, value_si, timestamp)');
+      lines.push(`SELECT ts_id, v.value, v.value_si, v.ts FROM _import_ts_ids, (VALUES`);
+
+      const valueLines = batch.map((row, i) => {
+        const value = row[col.index];
+        const valueSi = toSI(value, col.quantityKind);
+        const ts = row[timestampCol.index];
+        const comma = i < batch.length - 1 ? ',' : '';
+        return `  (${value}::numeric, ${valueSi}::numeric, '${ts}'::timestamptz)${comma}`;
+      });
+      lines.push(...valueLines);
+
+      lines.push(`) AS v(value, value_si, ts)`);
+      lines.push(`WHERE _import_ts_ids.label = '${stats.label}';`);
+      lines.push('');
+    }
+  });
+
+  // Cleanup
+  lines.push('DROP TABLE _import_ts_ids;');
+  lines.push('');
+  lines.push('COMMIT;');
+
+  return lines.join('\n');
+};
+
+const escapeSql = str => (str || '').replace(/'/g, "''");
+
+export default generateSql;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/index.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/index.jsx
@@ -1,0 +1,304 @@
+import React, { useReducer, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  Step,
+  StepLabel,
+  Stepper,
+  Typography
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import StepUpload from './StepUpload';
+import StepMapping from './StepMapping';
+import StepValidation from './StepValidation';
+import StepDownload from './StepDownload';
+import { COLUMN_ROLES, STEPS } from './constants';
+import { hasValidTimestampConfig } from './timestampUtils';
+
+const STEP_LABELS = ['Upload CSV', 'Map Columns', 'Validate', 'Download SQL'];
+
+const initialState = {
+  activeStep: STEPS.UPLOAD,
+  rawData: [],
+  fileName: null,
+  profileName: null,
+  headerRow: 0,
+  skipLastRows: 0,
+  numberLocale: 'en',
+  encoding: 'UTF-8',
+  columnMappings: {},
+  dateFormat: 'yyyy-MM-dd HH:mm:ss',
+  dateOnlyFormat: 'yyyy-MM-dd',
+  timeOnlyFormat: 'HH:mm:ss',
+  timezone: 'UTC',
+  caveId: '',
+  pointLabel: '',
+  authorId: '',
+  validationResult: null
+};
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_ACTIVE_STEP':
+      return { ...state, activeStep: action.payload };
+    case 'SET_RAW_DATA':
+      return { ...state, rawData: action.payload, columnMappings: {} };
+    case 'SET_FILE_NAME':
+      return { ...state, fileName: action.payload };
+    case 'SET_PROFILE_NAME':
+      return { ...state, profileName: action.payload };
+    case 'SET_ENCODING':
+      return { ...state, encoding: action.payload };
+    case 'SET_HEADER_ROW':
+      return { ...state, headerRow: action.payload, columnMappings: {} };
+    case 'SET_SKIP_LAST_ROWS':
+      return { ...state, skipLastRows: action.payload };
+    case 'SET_NUMBER_LOCALE':
+      return { ...state, numberLocale: action.payload };
+    case 'SET_COLUMN_ROLE': {
+      const { colIndex, role } = action.payload;
+      const newMappings = { ...state.columnMappings };
+      newMappings[colIndex] = { ...newMappings[colIndex], role };
+      // Clear timestampType when switching away from timestamp
+      if (role !== COLUMN_ROLES.TIMESTAMP) {
+        delete newMappings[colIndex].timestampType;
+      }
+      return { ...state, columnMappings: newMappings };
+    }
+    case 'SET_COLUMN_TIMESTAMP_TYPE': {
+      const { colIndex, timestampType } = action.payload;
+      const newMappings = { ...state.columnMappings };
+
+      // Types that can only appear once (datetime, year, month, day, hour, minute, second)
+      // elapsed_seconds can appear multiple times (they stack)
+      if (timestampType !== 'elapsed_seconds') {
+        Object.keys(newMappings).forEach(idx => {
+          if (
+            Number(idx) !== colIndex &&
+            newMappings[idx].role === COLUMN_ROLES.TIMESTAMP &&
+            newMappings[idx].timestampType === timestampType
+          ) {
+            newMappings[idx] = { ...newMappings[idx], timestampType: undefined };
+          }
+        });
+      }
+
+      newMappings[colIndex] = { ...newMappings[colIndex], timestampType };
+      return { ...state, columnMappings: newMappings };
+    }
+    case 'SET_COLUMN_QUANTITY_KIND': {
+      const { colIndex, quantityKind } = action.payload;
+      const newMappings = { ...state.columnMappings };
+      newMappings[colIndex] = { ...newMappings[colIndex], quantityKind };
+      return { ...state, columnMappings: newMappings };
+    }
+    case 'SET_COLUMN_UNIT': {
+      const { colIndex, unit } = action.payload;
+      const newMappings = { ...state.columnMappings };
+      newMappings[colIndex] = { ...newMappings[colIndex], unit };
+      return { ...state, columnMappings: newMappings };
+    }
+    case 'SET_COLUMN_MEDIUM': {
+      const { colIndex, medium } = action.payload;
+      const newMappings = { ...state.columnMappings };
+      newMappings[colIndex] = { ...newMappings[colIndex], medium };
+      return { ...state, columnMappings: newMappings };
+    }
+    case 'SET_DATE_FORMAT':
+      return { ...state, dateFormat: action.payload };
+    case 'SET_DATE_ONLY_FORMAT':
+      return { ...state, dateOnlyFormat: action.payload };
+    case 'SET_TIME_ONLY_FORMAT':
+      return { ...state, timeOnlyFormat: action.payload };
+    case 'SET_TIMEZONE':
+      return { ...state, timezone: action.payload };
+    case 'SET_CAVE_ID':
+      return { ...state, caveId: action.payload };
+    case 'SET_POINT_LABEL':
+      return { ...state, pointLabel: action.payload };
+    case 'SET_AUTHOR_ID':
+      return { ...state, authorId: action.payload };
+    case 'SET_VALIDATION_RESULT':
+      return { ...state, validationResult: action.payload };
+    case 'SET_PROFILE': {
+      const profile = action.payload;
+      return {
+        ...state,
+        encoding: profile.encoding || state.encoding,
+        headerRow: profile.headerRow !== undefined ? profile.headerRow : state.headerRow,
+        skipLastRows: profile.skipLastRows !== undefined ? profile.skipLastRows : state.skipLastRows,
+        numberLocale: profile.numberLocale || state.numberLocale,
+        columnMappings: profile.columnMappings || state.columnMappings,
+        dateFormat: profile.dateFormat || state.dateFormat,
+        dateOnlyFormat: profile.dateOnlyFormat || state.dateOnlyFormat,
+        timeOnlyFormat: profile.timeOnlyFormat || state.timeOnlyFormat,
+        timezone: profile.timezone || state.timezone,
+        caveId: profile.caveId !== undefined ? profile.caveId : state.caveId,
+        pointLabel: profile.pointLabel !== undefined ? profile.pointLabel : state.pointLabel,
+        authorId: profile.authorId !== undefined ? profile.authorId : state.authorId
+      };
+    }
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+};
+
+const canAdvance = (state, step) => {
+  switch (step) {
+    case STEPS.UPLOAD:
+      return state.rawData.length > 1; // at least header + 1 data row
+    case STEPS.MAPPING: {
+      const maxCols = state.rawData.reduce((max, row) => Math.max(max, row.length), 0);
+      const mappings = state.columnMappings;
+
+      // All columns must have a role assigned
+      const allColumnsAssigned = maxCols > 0
+        && Array.from({ length: maxCols }, (_, i) => i)
+          .every(i => mappings[i] && mappings[i].role);
+
+      if (!allColumnsAssigned) return false;
+
+      const timestampOk = hasValidTimestampConfig(mappings);
+
+      const hasMeasurement = Object.values(mappings).some(
+        m =>
+          m.role === COLUMN_ROLES.MEASUREMENT &&
+          m.quantityKind &&
+          m.unit
+      );
+      return timestampOk && hasMeasurement;
+    }
+    case STEPS.VALIDATION:
+      return (
+        state.validationResult &&
+        state.validationResult.errors.length === 0 &&
+        state.validationResult.validCount > 0
+      );
+    default:
+      return false;
+  }
+};
+
+const ImportObservationsCsv = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const handleNext = useCallback(() => {
+    dispatch({
+      type: 'SET_ACTIVE_STEP',
+      payload: state.activeStep + 1
+    });
+  }, [state.activeStep]);
+
+  const handleBack = useCallback(() => {
+    dispatch({
+      type: 'SET_ACTIVE_STEP',
+      payload: state.activeStep - 1
+    });
+  }, [state.activeStep]);
+
+  const handleReset = useCallback(() => {
+    dispatch({ type: 'RESET' });
+  }, []);
+
+  const handleExportProfile = useCallback(() => {
+    const profile = {
+      encoding: state.encoding,
+      headerRow: state.headerRow,
+      skipLastRows: state.skipLastRows,
+      numberLocale: state.numberLocale,
+      columnMappings: state.columnMappings,
+      dateFormat: state.dateFormat,
+      dateOnlyFormat: state.dateOnlyFormat,
+      timeOnlyFormat: state.timeOnlyFormat,
+      timezone: state.timezone,
+      caveId: state.caveId,
+      pointLabel: state.pointLabel,
+      authorId: state.authorId
+    };
+    const blob = new Blob(
+      [JSON.stringify(profile, null, 2)],
+      { type: 'application/json' }
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const profileName = (state.pointLabel || 'import')
+      .replace(/[^a-zA-Z0-9_-]/g, '_')
+      .replace(/_+/g, '_');
+    a.download = `${profileName}_profile.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [state.encoding, state.headerRow, state.skipLastRows, state.numberLocale, state.columnMappings, state.dateFormat, state.dateOnlyFormat, state.timeOnlyFormat, state.timezone, state.caveId, state.pointLabel, state.authorId]);
+
+  const renderStep = () => {
+    switch (state.activeStep) {
+      case STEPS.UPLOAD:
+        return <StepUpload state={state} dispatch={dispatch} />;
+      case STEPS.MAPPING:
+        return <StepMapping state={state} dispatch={dispatch} />;
+      case STEPS.VALIDATION:
+        return <StepValidation state={state} dispatch={dispatch} />;
+      case STEPS.DOWNLOAD:
+        return <StepDownload state={state} dispatch={dispatch} onExportProfile={handleExportProfile} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Import Scientific Observations (CSV)
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Upload a CSV file from a data logger, map columns to measurement types,
+        and generate a SQL import script.
+      </Typography>
+
+      <Stepper activeStep={state.activeStep} sx={{ mb: 4 }}>
+        {STEP_LABELS.map(label => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      <Box sx={{ minHeight: 300, mb: 3 }}>{renderStep()}</Box>
+
+      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            disabled={state.activeStep === STEPS.UPLOAD}
+            onClick={handleBack}
+            startIcon={<ArrowBackIcon />}>
+            Back
+          </Button>
+          <Button
+            disabled={state.rawData.length === 0}
+            onClick={handleReset}
+            color="warning"
+            size="small">
+            Start over
+          </Button>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          {state.activeStep < STEPS.DOWNLOAD && (
+            <Button
+              variant="contained"
+              disabled={!canAdvance(state, state.activeStep)}
+              onClick={handleNext}
+              endIcon={<ArrowForwardIcon />}>
+              Next
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default ImportObservationsCsv;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/numberUtils.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/numberUtils.js
@@ -1,0 +1,48 @@
+/**
+ * Normalize a raw string value to a JavaScript number, handling locale-specific
+ * decimal and thousands separators.
+ *
+ * @param {string} raw - The raw string from the CSV cell
+ * @param {string} locale - 'en' or 'fr'
+ * @returns {number|null} - Parsed number or null if invalid
+ */
+export const normalizeNumber = (raw, locale = 'en') => {
+  if (raw == null || raw.trim() === '') return null;
+  const trimmed = raw.trim();
+
+  let normalized;
+  if (locale === 'fr') {
+    // French: spaces are thousands separators, comma is decimal
+    normalized = trimmed
+      .replace(/[\s\u00A0]/g, '') // remove spaces and non-breaking spaces
+      .replace(/\./g, '') // remove dot thousands separators
+      .replace(',', '.'); // replace comma decimal with dot
+  } else {
+    // English: commas are thousands separators, dot is decimal
+    normalized = trimmed.replace(/,/g, '');
+  }
+
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+};
+
+/**
+ * Convert a display-unit value to SI using the quantity kind's conversion factors.
+ * SI = (displayValue - offset) / factor
+ *
+ * For Temperature: displayValue is °C, SI is K
+ *   K = (°C - (-273.15)) / 1 = °C + 273.15
+ *
+ * For RelativeHumidity: displayValue is %, SI is fraction
+ *   fraction = (% - 0) / 100
+ *
+ * @param {number} displayValue - Value in the display unit
+ * @param {object} quantityKind - Quantity kind object with siToDisplayFactor and siToDisplayOffset
+ * @returns {number} - Value in SI units
+ */
+export const toSI = (displayValue, quantityKind) => {
+  const { siToDisplayFactor, siToDisplayOffset } = quantityKind;
+  // displayValue = siValue * factor + offset
+  // => siValue = (displayValue - offset) / factor
+  return (displayValue - siToDisplayOffset) / siToDisplayFactor;
+};

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/resolveRow.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/resolveRow.js
@@ -1,0 +1,32 @@
+import { COLUMN_ROLES } from './constants';
+
+/**
+ * Resolve a raw CSV row by merging columns marked as DECIMAL_PART with
+ * their preceding column. Returns a new array with merged values.
+ *
+ * Example: if columns are [... "280", "91"] and col 12 is DECIMAL_PART,
+ * the resolved row will have col 11 = "280.91" and col 12 = null.
+ *
+ * @param {Array} row - Raw CSV row (array of strings)
+ * @param {object} columnMappings - Column mappings keyed by column index
+ * @returns {Array} - New row with decimal parts merged into preceding column
+ */
+const resolveRow = (row, columnMappings) => {
+  const resolved = [...row];
+
+  // Process in reverse so indices stay valid
+  for (let i = resolved.length - 1; i > 0; i -= 1) {
+    const mapping = columnMappings[i];
+    if (mapping && mapping.role === COLUMN_ROLES.DECIMAL_PART) {
+      // Merge into previous column: "280" + "." + "91" = "280.91"
+      const prev = resolved[i - 1] || '';
+      const decimal = resolved[i] || '';
+      resolved[i - 1] = `${prev}.${decimal}`;
+      resolved[i] = null;
+    }
+  }
+
+  return resolved;
+};
+
+export default resolveRow;

--- a/packages/web-app/src/components/appli/ImportObservationsCsv/timestampUtils.js
+++ b/packages/web-app/src/components/appli/ImportObservationsCsv/timestampUtils.js
@@ -1,0 +1,195 @@
+import { parse, isValid } from 'date-fns';
+import { COLUMN_ROLES } from './constants';
+
+/**
+ * Get all timestamp columns from the mappings, sorted by column index.
+ */
+const getTimestampColumns = columnMappings =>
+  Object.entries(columnMappings)
+    .filter(([_, m]) => m.role === COLUMN_ROLES.TIMESTAMP && m.timestampType)
+    .map(([idx, m]) => ({ index: Number(idx), timestampType: m.timestampType }))
+    .sort((a, b) => a.index - b.index);
+
+/**
+ * Get the UTC offset in milliseconds for a given IANA timezone at a specific instant.
+ */
+const getTimezoneOffsetMs = (utcMs, timezone) => {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    });
+    const parts = fmt.formatToParts(new Date(utcMs));
+    const get = type => parseInt(parts.find(p => p.type === type).value, 10);
+
+    const tzYear = get('year');
+    const tzMonth = get('month');
+    const tzDay = get('day');
+    const tzHour = get('hour') === 24 ? 0 : get('hour');
+    const tzMinute = get('minute');
+    const tzSecond = get('second');
+
+    const localAsUtcMs = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, tzSecond);
+    return localAsUtcMs - utcMs;
+  } catch (e) {
+    return null;
+  }
+};
+
+/**
+ * Apply timezone correction to a base timestamp (in ms).
+ * Subtracts the source timezone offset to normalize to UTC.
+ */
+const applyTimezoneCorrection = (baseMs, timezone) => {
+  if (!timezone || timezone === 'UTC') return baseMs;
+  const offsetMs = getTimezoneOffsetMs(baseMs, timezone);
+  if (offsetMs != null) return baseMs - offsetMs;
+  return baseMs;
+};
+
+/**
+ * Build a UTC ISO timestamp string from a data row.
+ *
+ * @param {Array} row - A single data row (array of strings)
+ * @param {object} columnMappings - Column mappings keyed by column index
+ * @param {object} options - Format options
+ * @param {string} options.dateFormat - date-fns format for 'datetime' columns
+ * @param {string} options.dateOnlyFormat - date-fns format for 'date' columns
+ * @param {string} options.timeOnlyFormat - date-fns format for 'time' columns
+ * @param {string} options.timezone - IANA timezone the source data is in
+ * @returns {string|null} - Formatted UTC timestamp string or null if invalid
+ */
+export const buildTimestamp = (row, columnMappings, options) => {
+  const { dateFormat, dateOnlyFormat, timeOnlyFormat, timezone } = options;
+
+  const tsCols = getTimestampColumns(columnMappings);
+  if (tsCols.length === 0) return null;
+
+  const colsOfType = type => tsCols.filter(c => c.timestampType === type);
+  const findCol = type => tsCols.find(c => c.timestampType === type);
+
+  // Step 1: Determine the base timestamp (in ms since epoch)
+  let baseMs = 0;
+  let hasBase = false;
+
+  // Priority 1: Full datetime column
+  const datetimeCol = findCol('datetime');
+  if (datetimeCol) {
+    const rawTs = row[datetimeCol.index];
+    if (!rawTs || !rawTs.trim()) return null;
+    const parsed = parse(rawTs.trim(), dateFormat, new Date());
+    if (!isValid(parsed)) return null;
+    baseMs = Date.UTC(
+      parsed.getFullYear(), parsed.getMonth(), parsed.getDate(),
+      parsed.getHours(), parsed.getMinutes(), parsed.getSeconds(),
+      parsed.getMilliseconds()
+    );
+    hasBase = true;
+  }
+
+  // Priority 2: Separate date + time columns
+  if (!hasBase) {
+    const dateCol = findCol('date');
+    const timeCol = findCol('time');
+
+    if (dateCol) {
+      const rawDate = row[dateCol.index];
+      if (!rawDate || !rawDate.trim()) return null;
+      const parsedDate = parse(rawDate.trim(), dateOnlyFormat, new Date());
+      if (!isValid(parsedDate)) return null;
+
+      let hours = 0;
+      let minutes = 0;
+      let seconds = 0;
+      let millis = 0;
+
+      if (timeCol) {
+        const rawTime = row[timeCol.index];
+        if (rawTime && rawTime.trim()) {
+          const parsedTime = parse(rawTime.trim(), timeOnlyFormat, new Date());
+          if (isValid(parsedTime)) {
+            hours = parsedTime.getHours();
+            minutes = parsedTime.getMinutes();
+            seconds = parsedTime.getSeconds();
+            millis = parsedTime.getMilliseconds();
+          }
+        }
+      }
+
+      baseMs = Date.UTC(
+        parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate(),
+        hours, minutes, seconds, millis
+      );
+      hasBase = true;
+    }
+  }
+
+  // Priority 3: Split year/month/day/hour/minute/second columns
+  if (!hasBase) {
+    const yearCol = findCol('year');
+    const monthCol = findCol('month');
+    const dayCol = findCol('day');
+    const hourCol = findCol('hour');
+    const minuteCol = findCol('minute');
+    const secondCol = findCol('second');
+
+    if (yearCol && monthCol && dayCol) {
+      const year = parseInt(row[yearCol.index], 10);
+      const month = parseInt(row[monthCol.index], 10);
+      const day = parseInt(row[dayCol.index], 10);
+      const hour = hourCol ? parseInt(row[hourCol.index], 10) : 0;
+      const minute = minuteCol ? parseInt(row[minuteCol.index], 10) : 0;
+      const second = secondCol ? parseInt(row[secondCol.index], 10) : 0;
+
+      if ([year, month, day, hour, minute, second].some(v => Number.isNaN(v))) {
+        return null;
+      }
+
+      baseMs = Date.UTC(year, month - 1, day, hour, minute, second);
+      hasBase = true;
+    }
+  }
+
+  // Apply timezone correction to the base (if we have one)
+  if (hasBase) {
+    baseMs = applyTimezoneCorrection(baseMs, timezone);
+  }
+
+  // Step 2: Apply all elapsed_seconds columns in order (they stack)
+  const elapsedCols = colsOfType('elapsed_seconds');
+  for (let i = 0; i < elapsedCols.length; i += 1) {
+    const rawVal = row[elapsedCols[i].index];
+    const seconds = parseFloat(rawVal);
+    if (!Number.isFinite(seconds)) return null;
+    baseMs += seconds * 1000;
+  }
+
+  // If we have no base and no elapsed_seconds, fail
+  if (!hasBase && elapsedCols.length === 0) return null;
+
+  const result = new Date(baseMs);
+  if (!isValid(result)) return null;
+
+  return result.toISOString().replace('T', ' ').replace('Z', '+00');
+};
+
+/**
+ * Check if the current timestamp column assignments are sufficient.
+ */
+export const hasValidTimestampConfig = columnMappings => {
+  const tsCols = getTimestampColumns(columnMappings);
+  if (tsCols.length === 0) return false;
+
+  const types = tsCols.map(c => c.timestampType);
+
+  if (types.includes('datetime')) return true;
+  if (types.includes('date')) return true;
+  if (types.includes('elapsed_seconds')) return true;
+  return types.includes('year') && types.includes('month') && types.includes('day');
+};


### PR DESCRIPTION
## 🤔 What

POC for a CSV import wizard that allows users to upload scientific observation data (from data loggers) and generate SQL import scripts matching the backend's scientific observation schema.

- Closes #1365 (partial — POC only, outputs SQL instead of API calls)

## 🤷‍♂️ Why

Researchers collect data via data loggers that export CSV files with heterogeneous formats (different delimiters, date formats, number locales, column layouts). This wizard bridges the gap between raw spreadsheet data and the structured `t_observation` / `t_time_series` / `t_measurement` database schema.

## 🔍 How

4-step wizard at `/ui/import-observations`:

1. **Upload** — CSV parsing with PapaParse, encoding auto-detection, header/footer row skipping, number locale selection
2. **Map Columns** — assign roles (timestamp/measurement/excluded/decimals of prev.), timestamp type (datetime, date, time, Y/M/D/H/M/S, elapsed seconds), quantity kind + unit + medium for measurements. Timezone autocomplete (all IANA zones). Import/export mapping profiles as JSON.
3. **Validate** — timestamp parsing verification, numeric value checks, row-level error reporting
4. **Download SQL** — generates a SQL script following the `import-74138.sql` pattern (BEGIN/temp table/DO block/chunked INSERTs/COMMIT). Also exports the mapping profile.

Key features:
- Composable timestamp: split columns stack (Y+M+D+H+M+S+elapsed_seconds)
- "Decimals of prev." role handles comma-as-decimal in comma-delimited files
- Auto-detect encoding (UTF-8 vs Latin-1/Windows-1252)
- Profile export/import for batch processing of same-format files
- No new dependencies (uses existing react-papaparse + date-fns + MUI)

## 🔗 Related API PR

None — this is frontend-only. SQL output is temporary until the backend bulk import endpoint is implemented.

## 🧪 Testing

1. Navigate to `/ui/import-observations`
2. Upload a CSV file (test files available in `grottocenter-api/data/documents/147251/`)
3. Map columns, validate, download the SQL
4. Verify SQL structure matches expected pattern

## 📸 Previews

POC — no screenshots yet. UI uses standard MUI components (Stepper, Table, Select, Autocomplete).
