### PR TITLE
chore(ci): group dependabot PRs and ignore blocked upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,49 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
+  - package-ecosystem: 'npm'
     directory: '/'
-    # Updates currently disabled: re-enable them (with the value 5) when we had tests checking everything is ok after updating the packages
-    open-pull-requests-limit: 5
     schedule:
       interval: 'monthly'
+    groups:
+      all-root-dependencies:
+        patterns:
+          - '*'
+    ignore:
+      # Pinned at v8 — eslint-config-airbnb does not support ESLint v9+ flat config
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      # v6 targets ESLint v10 (flat config); incompatible with our v8 setup
+      - dependency-name: 'eslint-plugin-cypress'
+        update-types: ['version-update:semver-major']
+      # Tied to Storybook v10 major upgrade
+      - dependency-name: 'eslint-plugin-storybook'
+        update-types: ['version-update:semver-major']
+      # Breaking changes: strict:true by default, types defaults to []; needs dedicated migration
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
-  - package-ecosystem: 'npm' # See documentation for possible values
+  - package-ecosystem: 'npm'
     directory: '/packages/web-app/'
-    # Updates currently disabled: re-enable them (with the value 5) when we had tests checking everything is ok after updating the packages
-    open-pull-requests-limit: 10
     schedule:
       interval: 'monthly'
+    groups:
+      all-webapp-dependencies:
+        patterns:
+          - '*'
+    ignore:
+      # Requires coordinated ecosystem upgrade (separate PR)
+      - dependency-name: '@storybook/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'storybook'
+        update-types: ['version-update:semver-major']
+      # v9/v10 require migration guide; keeping at ^8
+      - dependency-name: 'react-intl'
+        update-types: ['version-update:semver-major']
+      # v4.6.0 uses pure-rand subpath exports that Jest 27 (CRA 5.x) cannot resolve;
+      # all versions suppressed (not just major) because the breaking change is in a minor
+      - dependency-name: 'fast-check'
+      # Pre-1.0 package, no changelog available; conservative skip —
+      # all versions suppressed until upstream stabilizes with a 1.0 release
+      - dependency-name: 'leaflet.locatecontrol'


### PR DESCRIPTION
# chore(ci): group dependabot PRs and ignore blocked upgrades

## 🤔 What

Reconfigure Dependabot to:
- Group all dependency updates into a single PR per directory (root `/` and `/packages/web-app/`)
- Ignore major version bumps for packages we can't upgrade yet

## 🤷‍♂️ Why

Dependabot was opening individual PRs for each dependency, most of which got closed without merging because we handle upgrades in manual batches. This reduces noise and stops it from repeatedly proposing upgrades we've intentionally skipped.

## 🔍 How

Added `groups` with a `*` wildcard pattern so all updates are batched into one PR per ecosystem entry.

Added `ignore` rules for blocked packages (from PR #1263 analysis):

| Package | Reason |
|---|---|
| `eslint` (major) | Pinned at v8 — `eslint-config-airbnb` doesn't support v9+ flat config |
| `eslint-plugin-cypress` (major) | v6 targets ESLint v10 flat config |
| `eslint-plugin-storybook` (major) | Tied to Storybook v10 upgrade |
| `typescript` (major) | v6 has breaking defaults (`strict: true`, `types: []`) |
| `@storybook/*` (major) | Requires coordinated ecosystem migration |
| `storybook` (major) | Same as above |
| `react-intl` (major) | v9/v10 require migration guide |
| `fast-check` (all) | v4.6.0 uses `pure-rand` subpath exports incompatible with Jest 27 / CRA 5.x |
| `leaflet.locatecontrol` (all) | Pre-1.0, no changelog; conservative skip |

Removed explicit `open-pull-requests-limit` since the default (5) is more than enough when everything is grouped.

## 🔗 Related API PR

N/A

## 🧪 Testing

N/A — config-only change. Dependabot will pick up the new config on next scheduled run.

## 📸 Previews

N/A
