### PR TITLE
fix(massif): description not saved/displayed after creation

### DIFF
--- a/packages/web-app/src/reducers/MassifReducer.js
+++ b/packages/web-app/src/reducers/MassifReducer.js
@@ -13,6 +13,13 @@ import { RESTORE_MASSIF_SUCCESS } from '../actions/Massif/RestoreMassif';
 import { LINK_DOCUMENT_TO_MASSIF_SUCCESS } from '../actions/LinkDocumentToMassif';
 import { UNLINK_DOCUMENT_TO_MASSIF_SUCCESS } from '../actions/UnlinkDocumentToMassif';
 import { MOVE_DESCRIPTION_RELEVANCE_SUCCESS } from '../actions/Description/MoveRelevance';
+import { POST_DESCRIPTION_SUCCESS } from '../actions/Description/CreateDescription';
+import { UPDATE_DESCRIPTION_SUCCESS } from '../actions/Description/UpdateDescription';
+import {
+  DELETE_DESCRIPTION_SUCCESS,
+  DELETE_DESCRIPTION_PERMANENT_SUCCESS
+} from '../actions/Description/DeleteDescription';
+import { RESTORE_DESCRIPTION_SUCCESS } from '../actions/Description/RestoreDescription';
 import { UPDATE_MASSIF_SUCCESS } from '../actions/Massif/UpdateMassif';
 import { MARK_MASSIF_SENSITIVE_SUCCESS } from '../actions/Massif/MarkSensitiveMassif';
 import { UNMARK_MASSIF_SENSITIVE_SUCCESS } from '../actions/Massif/UnmarkSensitiveMassif';
@@ -57,6 +64,31 @@ const reducer = (state = initialState, action) => {
           documents: [
             ...state.massif.documents.filter(e => e.id !== action.documentId)
           ]
+        }
+      };
+    case POST_DESCRIPTION_SUCCESS:
+    case UPDATE_DESCRIPTION_SUCCESS:
+    case DELETE_DESCRIPTION_SUCCESS:
+    case RESTORE_DESCRIPTION_SUCCESS:
+      return {
+        ...initialState,
+        massif: {
+          ...state.massif,
+          descriptions: arrFindReplaceOrAdd(
+            state.massif?.descriptions ?? [],
+            e => e.id === action.description.id,
+            action.description
+          )
+        }
+      };
+    case DELETE_DESCRIPTION_PERMANENT_SUCCESS:
+      return {
+        ...initialState,
+        massif: {
+          ...state.massif,
+          descriptions: state.massif?.descriptions?.filter(
+            e => e.id !== action.description.id
+          )
         }
       };
     case MOVE_DESCRIPTION_RELEVANCE_SUCCESS:


### PR DESCRIPTION
# fix(massif): description not saved/displayed after creation

## 🤔 What

- Fix massif description not appearing after creation
- Add missing Redux action handlers in `MassifReducer` for all description lifecycle actions

## 🤷‍♂️ Why

When a user created a description on a massif, the description was correctly sent to the API and saved in the database, but never appeared in the UI afterward. The Redux state for the massif was never updated because `MassifReducer` did not listen to the description action types.

Closes #1368

## 🔍 How

`CaveReducer` and `EntranceReducer` already handle `POST_DESCRIPTION_SUCCESS`, `UPDATE_DESCRIPTION_SUCCESS`, `DELETE_DESCRIPTION_SUCCESS`, `RESTORE_DESCRIPTION_SUCCESS`, and `DELETE_DESCRIPTION_PERMANENT_SUCCESS` to keep their entity's `descriptions` array in sync with the server response via `arrFindReplaceOrAdd`.

`MassifReducer` was missing all five of these cases. Added them following the exact same pattern as the other two reducers.

## 🔗 Related API PR

None — this is a pure frontend fix; the API was already creating the description correctly.

## 🧪 Testing

1. Open any massif page (e.g. one with no existing description)
2. Click **New** in the Description section
3. Fill in title, body, and language, then submit
4. The description should appear immediately without requiring a page reload

## 📸 Previews

_No visual change beyond the description now appearing after creation._
