### PR TITLE
chore(ci): split dependabot groups into minor/patch and major subgroups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,14 @@ updates:
     schedule:
       interval: 'monthly'
     groups:
-      all-root-dependencies:
+      root-minor-patch:
         patterns:
           - '*'
+        update-types: ['minor', 'patch']
+      root-major:
+        patterns:
+          - '*'
+        update-types: ['major']
     ignore:
       # Pinned at v8 — eslint-config-airbnb does not support ESLint v9+ flat config
       - dependency-name: 'eslint'
@@ -29,9 +34,14 @@ updates:
     schedule:
       interval: 'monthly'
     groups:
-      all-webapp-dependencies:
+      webapp-minor-patch:
         patterns:
           - '*'
+        update-types: ['minor', 'patch']
+      webapp-major:
+        patterns:
+          - '*'
+        update-types: ['major']
     ignore:
       # Requires coordinated ecosystem upgrade (separate PR)
       - dependency-name: '@storybook/*'


### PR DESCRIPTION
# chore(ci): split dependabot groups into minor/patch and major subgroups

## 🤔 What

Split each Dependabot group into two subgroups:

- `*-minor-patch`: bundles all minor and patch updates (low-risk, one-click merge)
- `*-major`: bundles major version bumps (requires review)

Applies to both `npm` ecosystems: root and `packages/web-app/`.

## 🤷‍♂️ Why

Grouping minors/patches separately from majors makes it easier to merge routine updates without being blocked by breaking changes that need dedicated attention. Major bumps remain visible and isolated.

## 🔍 How

Added `update-types` to each group definition in `.github/dependabot.yml`:

```yaml
groups:
  root-minor-patch:
    patterns: ['*']
    update-types: ['minor', 'patch']
  root-major:
    patterns: ['*']
    update-types: ['major']
```

The existing `ignore` rules for pinned packages (eslint, storybook, react-intl…) still apply — the `major` group will simply be sparse or empty when all majors are blocked.

## 🔗 Related API PR

N/A

## 🧪 Testing

No code change — CI will validate the YAML syntax. Next Dependabot run will produce split PRs.

## 📸 Previews

N/A
