### PR TITLE
fix(entrance): restore form→map sync when editing lat/lng fields manually

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -80,6 +80,9 @@ const toFloat = value => {
 };
 
 const LOCATE_ZOOM = 18;
+// How long after the map writes to the form before we allow form→map updates.
+// Prevents the map pan → form update → map recenter loop.
+const MAP_WRITE_GUARD_MS = 400;
 const hasGeolocation = typeof navigator !== 'undefined' && Boolean(navigator.geolocation);
 const ACCURACY_CIRCLE_STYLE = {
   color: '#1976d2',
@@ -95,6 +98,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   const [currentPosition, setCurrentPosition] = useState(defaultCoord);
   const [zoomLevel, setZoomLevel] = useState(defaultZoom);
   const [locationAccuracy, setLocationAccuracy] = useState(null);
+  const lastSetFormTs = useRef(0);
 
   const rawLatitude = useWatch({ control, name: formLatitudeKey });
   const rawLongitude = useWatch({ control, name: formLongitudeKey });
@@ -122,8 +126,23 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
     }
   }, [initialized, validLatitude, validLongitude]);
 
+  // form → map: recentre when user edits lat/lng fields manually.
+  // `initialized` is intentionally omitted from deps: we read its current value
+  // as a guard but only want this effect to fire on coordinate changes, not on
+  // the initialization transition (which is already handled by the effect above).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!initialized) return;
+    const isValid =
+      !Number.isNaN(validLatitude) && !Number.isNaN(validLongitude);
+    if (isValid && Date.now() - lastSetFormTs.current > MAP_WRITE_GUARD_MS) {
+      setCurrentPosition({ lat: validLatitude, lng: validLongitude });
+    }
+  }, [validLatitude, validLongitude]);
+
   // map → form (only direction after initialization)
   const onMoveEnd = newLocation => {
+    lastSetFormTs.current = Date.now();
     setFormLatitude(newLocation.lat.toFixed(6));
     setFormLongitude(newLocation.lng.toFixed(6));
   };

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -130,7 +130,6 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
   // `initialized` is intentionally omitted from deps: we read its current value
   // as a guard but only want this effect to fire on coordinate changes, not on
   // the initialization transition (which is already handled by the effect above).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!initialized) return;
     const isValid =
@@ -138,6 +137,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey }) => {
     if (isValid && Date.now() - lastSetFormTs.current > MAP_WRITE_GUARD_MS) {
       setCurrentPosition({ lat: validLatitude, lng: validLongitude });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [validLatitude, validLongitude]);
 
   // map → form (only direction after initialization)


### PR DESCRIPTION
# fix(entrance): restore form→map sync when editing lat/lng fields manually

## 🤔 What

- Restores the ability to recentre the map by manually editing the latitude or longitude fields in the entrance creation/edit form.

## 🤷‍♂️ Why

A previous refactor of `MapMarkerSelector.jsx` removed the `useEffect` responsible for syncing form field changes back to the map. Panning the map still updated the fields correctly (map → form), but editing a field by hand no longer moved the map to the new coordinates (form → map was broken).

## 🔍 How

Re-introduced the form → map sync with two key pieces:

- `lastSetFormTs` ref — stamped by `onMoveEnd` each time the map writes to the form.
- A `useEffect` on `[validLatitude, validLongitude]` that recentres the map only when coordinates are valid **and** enough time has passed since the last map-triggered form update (`MAP_WRITE_GUARD_MS = 400ms`). This guard prevents the pan → form update → map recenter loop.

`initialized` is intentionally omitted from the effect's deps array: it is read as a guard to skip the effect before the first valid coordinates are set (handled by the existing init effect), but the effect should only re-run on coordinate changes, not on the initialization transition.

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Open the entrance creation form.
2. Type a latitude and longitude manually — the map should recentre on the new coordinates.
3. Pan the map — the fields should update without the map jumping back.
4. Open an existing entrance edit form — the map should initialise on the saved coordinates.

## 📸 Previews

N/A
