### PR TITLE
fix(massif): filter entrances by massif ID instead of name

### DIFF
--- a/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/EntrancesSearch.jsx
@@ -54,6 +54,7 @@ const FILTER_LABELS = {
   // iso3166 is the ISO 3166-2 subdivision code used as a locked filter when navigating from a
   // country/region page. It maps to the same "Region" label as the freeform `region` field.
   iso3166: 'Region',
+  'massifs.id': 'Massif',
   'massifs.name': 'Massif',
   region: 'Region',
   'cave.name': 'Network name',
@@ -75,6 +76,7 @@ const initialFilterState = {
   iso3166: '',
   region: '',
   county: '',
+  'massifs.id': null,
   'massifs.name': '',
   city: '',
   // postalCode is intentionally absent: the entrances API endpoint does not support postal code filtering
@@ -167,7 +169,7 @@ const EntrancesSearch = ({ initialFilter = {}, lockedFilter = [], valueLabels = 
               value={filterState.country}
             />
           )}
-          {!lockedFilter.includes('massifs.name') && (
+          {!lockedFilter.includes('massifs.name') && !lockedFilter.includes('massifs.id') && (
             <SearchTextAutocomplete
               ressourceType={searchEntity}
               ressourceField="massifs.name"

--- a/packages/web-app/src/pages/EntrancesList/index.jsx
+++ b/packages/web-app/src/pages/EntrancesList/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
@@ -6,14 +6,12 @@ import { useIntl } from 'react-intl';
 import { fetchCountry } from '../../actions/Country/GetCountry';
 import { fetchRegion } from '../../actions/Region/GetRegion';
 import { loadMassif } from '../../actions/Massif/GetMassif';
-import { fetchFieldSearch } from '../../actions/FieldSearch';
 import getLocalizedCountryName from '../../helpers/countryName';
 import REDUCER_STATUS from '../../reducers/ReducerStatus';
 import EntitySearchPage from '../../components/appli/AdvancedSearch/EntitySearchPage';
 import EntrancesSearch from '../../components/appli/AdvancedSearch/EntrancesSearch';
 import CustomIcon from '../../components/common/CustomIcon';
 import EntranceBadgeIcon from './EntranceBadgeIcon';
-import { ADVANCED_SEARCH_TYPES } from '../../conf/config';
 
 const getFlagEmoji = iso =>
   typeof iso === 'string' && iso.length === 2
@@ -36,7 +34,6 @@ const EntrancesListPage = () => {
   const { massif, isFetching: massifFetching } = useSelector(
     state => state.massif
   );
-  const [massifValue, setMassifValue] = useState(undefined);
 
   useEffect(() => {
     if (countryId) dispatch(fetchCountry(countryId));
@@ -47,21 +44,6 @@ const EntrancesListPage = () => {
     if (massifId) dispatch(loadMassif(massifId));
   }, [massifId, dispatch]);
 
-  useEffect(() => {
-    if (!massifId || !massif) return;
-    let cancelled = false;
-    setMassifValue(undefined);
-    fetchFieldSearch({
-      entity: ADVANCED_SEARCH_TYPES.ENTRANCES,
-      field: 'massifs.name',
-      query: massif.name,
-      filter: {}
-    })
-      .then(r => { if (!cancelled) setMassifValue(r?.hits?.[0]?.[0] ?? null); })
-      .catch(() => { if (!cancelled) setMassifValue(null); });
-    return () => { cancelled = true; };
-  }, [massif, massifId]);
-
   let initialFilter = {};
   let lockedFilter = [];
   let searchKey = 'open';
@@ -70,11 +52,11 @@ const EntrancesListPage = () => {
   const label = formatMessage({ id: 'Entrances' });
   let pageTitle = label;
 
-  if (massifId && massif && !massifFetching && massifValue !== undefined) {
-    const resolvedMassif = massifValue ?? massif.name;
-    initialFilter = { 'massifs.name': resolvedMassif };
-    lockedFilter = ['massifs.name'];
-    searchKey = resolvedMassif;
+  if (massifId && massif && !massifFetching) {
+    initialFilter = { 'massifs.id': parseInt(massifId, 10) };
+    lockedFilter = ['massifs.id'];
+    searchKey = massifId;
+    valueLabels = { 'massifs.id': massif.name };
     pageTitle = `${label} - ${massif.name}`;
     pageIcon = (
       <EntranceBadgeIcon badge={<CustomIcon type="massif" size={16} />} />


### PR DESCRIPTION
# fix(massif): filter entrances by massif ID instead of name

## 🤔 What

- On massif pages, the entrances list is now filtered by `massifs.id` (integer) instead of `massifs.name` (tokenized string)
- Removed the pre-flight `fetchFieldSearch` call that was used to resolve the massif name to its exact Typesense facet value
- The active filter chip still displays the human-readable massif name (via `valueLabels`) rather than the raw ID

## 🤷‍♂️ Why

Filtering by name was fragile: massifs sharing common words (e.g. several "causse de…" massifs) could produce ambiguous text matches, causing the wrong entrances to be displayed. The massif ID is already known from the URL params and is unambiguous.

Fixes #1387.

## 🔍 How

**`EntrancesList/index.jsx`**
- Replaced `initialFilter: { 'massifs.name': resolvedMassif }` with `initialFilter: { 'massifs.id': parseInt(massifId, 10) }`
- Dropped the async `fetchFieldSearch` effect and its `massifValue` state (one fewer network round-trip)
- Passed `valueLabels: { 'massifs.id': massif.name }` so the locked filter chip shows the massif name instead of its numeric ID — same pattern already used for the `iso3166` → region name display

**`EntrancesSearch.jsx`**
- Registered `'massifs.id'` in `FILTER_LABELS` and `initialFilterState`
- The massif name autocomplete is now hidden when `massifs.id` is locked (in addition to when `massifs.name` is locked)

`massifs.id` is indexed as `int32[], facet: true` in the Typesense entrances schema, so no backend change is required.

## 🔗 Related API PR

- Context: GrottoCenter/grottocenter-api#1646
- Backend fix: GrottoCenter/grottocenter-api#1651

## 🧪 Testing

1. Navigate to any massif page that has entrances (e.g. a massif with a name shared with other massifs like "causse d'…")
2. Verify the entrances list shows only entrances belonging to that specific massif
3. Verify the "Massif: [name]" chip appears locked in the search form

## 📸 Previews

N/A — no visual change (the filter chip already displayed the massif name before).
