### PR TITLE
fix(notifications): handle missing notificationType verbs in formatMessage

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "أجرِ بحثاً متقدماً في جميع الحقول. ستحتوي النتائج المعروضة على حقل واحد على الأقل يطابق طلبك.",
   "Periodical issue": "عدد دوري",
   "Permanently delete": "حذف نهائي",
+  "permanently_deleted": "تم الحذف نهائيًا",
   "Person": "شخص",
   "Personal information": "المعلومات الشخصية",
   "Persons": "أشخاص",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Извършете разширено търсене във всички полета. В показваните резултати ще имат поне едно поле, отговарящо на вашата заявка.",
   "Periodical issue": "Периодично издание",
   "Permanently delete": "Изтрий окончателно",
+  "permanently_deleted": "окончателно изтрито",
   "Person": "Личност",
   "Personal information": "Лична информация",
   "Persons": "Лица",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Fes una cerca avançada a tots els camps. Els resultats que es mostrin tindran com a mínim un camp que coincideixi amb la teva sol·licitud.",
   "Periodical issue": "Número periòdic",
   "Permanently delete": "Eliminar permanentment",
+  "permanently_deleted": "eliminat permanentment",
   "Person": "Persona",
   "Personal information": "Informació personal",
   "Persons": "Persones",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Führen Sie eine erweiterte Suche über alle Felder durch. Die angezeigten Ergebnisse haben mindestens ein Feld, das Ihrer Anfrage entspricht.",
   "Periodical issue": "Periodische Ausgabe",
   "Permanently delete": "Dauerhaft löschen",
+  "permanently_deleted": "endgültig gelöscht",
   "Person": "Person",
   "Personal information": "Persönliche Informationen",
   "Persons": "Personen",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Εκτελέστε μια προχωρημένη αναζήτηση σε όλα τα πεδία. Τα αποτελέσματα που εμφανίζονται θα έχουν τουλάχιστον ένα πεδίο που ταιριάζει με το αίτημά σας.",
   "Periodical issue": "Περιοδικό τεύχος",
   "Permanently delete": "Μόνιμη διαγραφή",
+  "permanently_deleted": "διαγράφηκε οριστικά",
   "Person": "Άτομο",
   "Personal information": "Προσωπικές πληροφορίες",
   "Persons": "Πρόσωπα",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.",
   "Periodical issue": "Periodical issue",
   "Permanently delete": "Permanently delete",
+  "permanently_deleted": "permanently deleted",
   "Person": "Person",
   "Personal information": "Personal information",
   "Persons": "Persons",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Realice una búsqueda avanzada en todos los campos. Los resultados mostrados tendrán al menos un campo que coincida con su búsqueda.",
   "Periodical issue": "Edición periódica",
   "Permanently delete": "Eliminar permanentemente",
+  "permanently_deleted": "eliminado permanentemente",
   "Person": "Persona",
   "Personal information": "Información personal",
   "Persons": "Personas",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Exécuter la recherche avancée sur tous les champs. Les résultats affichés auront au moins un champ correspondant à votre requête.",
   "Periodical issue": "Numéro du périodique",
   "Permanently delete": "Supprimer définitivement",
+  "permanently_deleted": "supprimé définitivement",
   "Person": "Personne",
   "Personal information": "Informations personnelles",
   "Persons": "Personnes",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "בצע חיפוש מתקדם בכל השדות. התוצאות המוצגות יכללו לפחות שדה אחד התואם לבקשתך.",
   "Periodical issue": "גיליון תקופתי",
   "Permanently delete": "מחק לצמיתות",
+  "permanently_deleted": "נמחק לצמיתות",
   "Person": "אדם",
   "Personal information": "מידע אישי",
   "Persons": "אנשים",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Lakukan pencarian lanjutan di semua bidang. Hasil yang ditampilkan akan memiliki setidaknya satu bidang yang cocok dengan permintaan Anda.",
   "Periodical issue": "Edisi berkala",
   "Permanently delete": "Hapus permanen",
+  "permanently_deleted": "dihapus secara permanen",
   "Person": "Orang",
   "Personal information": "Informasi pribadi",
   "Persons": "Orang",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Esegui una ricerca avanzata su tutti i campi. I risultati visualizzati avranno almeno un campo corrispondente alla tua richiesta.",
   "Periodical issue": "Numero periodico",
   "Permanently delete": "Elimina definitivamente",
+  "permanently_deleted": "eliminato definitivamente",
   "Person": "Persona",
   "Personal information": "Informazioni personali",
   "Persons": "Persone",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "すべてのフィールドで詳細検索を実行します。表示された結果には、リクエストに一致するフィールドが少なくとも1つあります。",
   "Periodical issue": "定期刊行物号",
   "Permanently delete": "完全に削除",
+  "permanently_deleted": "完全に削除されました",
   "Person": "人物",
   "Personal information": "個人情報",
   "Persons": "人物",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Voer een geavanceerde zoekopdracht uit op alle velden. De weergegeven resultaten hebben minimaal één veld dat overeenkomt met uw verzoek.",
   "Periodical issue": "Periodiek nummer",
   "Permanently delete": "Permanent verwijderen",
+  "permanently_deleted": "permanent verwijderd",
   "Person": "Persoon",
   "Personal information": "Persoonlijke informatie",
   "Persons": "Personen",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Efetue uma pesquisa avançada em todos os campos. Os resultados apresentados terão pelo menos um campo que corresponde ao seu pedido.",
   "Periodical issue": "Número periódico",
   "Permanently delete": "Eliminar permanentemente",
+  "permanently_deleted": "eliminado permanentemente",
   "Person": "Pessoa",
   "Personal information": "Informações pessoais",
   "Persons": "Pessoas",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1617,6 +1617,7 @@
   "Perform an advanced search on all the fields. Results displayed will have at least one field matching your request.": "Efectuați o căutare avansată în toate câmpurile. Rezultatele afișate vor avea cel puțin un câmp care corespunde cererii dvs.",
   "Periodical issue": "Apariție periodică",
   "Permanently delete": "Ștergeți definitiv",
+  "permanently_deleted": "șters definitiv",
   "Person": "Persoană",
   "Personal information": "Informații personale",
   "Persons": "Persoane",

--- a/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
@@ -62,8 +62,12 @@ const NotificationsMenuItem = ({ notification, onClick }) => {
                 defaultMessage: '{entity} {verb}'
               },
               {
-                entity: `(${formatMessage({ id: entityType })})`,
-                verb: formatMessage({ id: verb })
+                entity: entityType
+                  ? `(${formatMessage({ id: entityType, defaultMessage: entityType })})`
+                  : '',
+                verb: verb
+                  ? formatMessage({ id: verb, defaultMessage: verb })
+                  : ''
               }
             )}
             .

--- a/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/NotificationMenuItem.jsx
@@ -62,6 +62,8 @@ const NotificationsMenuItem = ({ notification, onClick }) => {
                 defaultMessage: '{entity} {verb}'
               },
               {
+                // Guard: entityType is always truthy from formatNotification today,
+                // but we keep the check as defense against future regressions.
                 entity: entityType
                   ? `(${formatMessage({ id: entityType, defaultMessage: entityType })})`
                   : '',

--- a/packages/web-app/src/utils/formatNotification.js
+++ b/packages/web-app/src/utils/formatNotification.js
@@ -124,6 +124,10 @@ const formatNotification = notification => {
       verb = 'validated';
       break;
     default:
+      // Warn so unhandled types surface during development
+      console.warn(
+        `[formatNotification] Unknown notificationType: ${notificationType.name}`
+      );
       verb = notificationType.name
         ? notificationType.name.toLowerCase()
         : '';

--- a/packages/web-app/src/utils/formatNotification.js
+++ b/packages/web-app/src/utils/formatNotification.js
@@ -108,6 +108,12 @@ const formatNotification = notification => {
     case 'DELETE':
       verb = 'deleted';
       break;
+    case 'PERMANENT_DELETE':
+      verb = 'permanently_deleted';
+      break;
+    case 'RESTORE':
+      verb = 'restored';
+      break;
     case 'UPDATE':
       verb = 'updated';
       break;
@@ -118,6 +124,9 @@ const formatNotification = notification => {
       verb = 'validated';
       break;
     default:
+      verb = notificationType.name
+        ? notificationType.name.toLowerCase()
+        : '';
   }
 
   // Entity data


### PR DESCRIPTION
# fix(notifications): handle missing notificationType verbs in formatMessage

## 🤔 What

- Fix crash in `NotificationMenuItem` when `formatMessage` is called with an empty `id`
- Add support for `PERMANENT_DELETE` and `RESTORE` notification types
- Add defensive fallback for any future unknown notification types

## 🤷‍♂️ Why

The API returns `notificationType.name = "PERMANENT_DELETE"` (and can return `"RESTORE"`), which the frontend switch statement didn't handle. This left `verb` as an empty string, and `formatMessage({ id: '' })` throws:

```
Error: [@formatjs/intl] An `id` must be provided to format a message.
```

Introduced in `12cf35dd` when the translation normalization refactored verb interpolation into a separate `formatMessage` call.

## 🔍 How

- **`formatNotification.js`**: Added `PERMANENT_DELETE` and `RESTORE` cases. The `default` branch now falls back to `notificationType.name.toLowerCase()` instead of `''`, so future unknown verbs render as-is without crashing.
- **`NotificationMenuItem.jsx`**: Added guards (truthy check before calling `formatMessage`) and `defaultMessage` fallbacks so missing translation keys display the raw string instead of throwing.
- **Translation files**: Added `permanently_deleted` key to all 15 language files. `restored` already existed.

## 🔗 Related API PR

None — backend already sends `PERMANENT_DELETE` and `RESTORE`.

## 🧪 Testing

1. Log in as a user who has notifications with `PERMANENT_DELETE` type
2. Open the notification menu — no console error, notification renders with "permanently deleted" verb
3. Verify other notification types (`UPDATE`, `CREATE`, etc.) still render correctly
