### PR TITLE
feat(advancedSearch): add geo export formats for entrance searches

### DIFF
--- a/packages/web-app/src/actions/Advancedsearch.js
+++ b/packages/web-app/src/actions/Advancedsearch.js
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch';
 import { advancedSearchUrl, advancedSearchExportUrl } from '../conf/apiRoutes';
+import { VALID_EXPORT_FORMATS } from '../conf/exportFormats';
 import { checkAndGetStatus } from './utils';
 
 export const FETCH_ADVANCEDSEARCH = 'FETCH_ADVANCEDSEARCH';
@@ -58,8 +59,10 @@ export const downloadAdvancedSearchResults = async ({
   filter,
   matchAllFields = true,
   columns,
-  columnsName
+  columnsName,
+  format = 'csv'
 }) => {
+  const safeFormat = VALID_EXPORT_FORMATS.has(format) ? format : 'csv';
   const data = {
     query,
     entity,
@@ -74,7 +77,9 @@ export const downloadAdvancedSearchResults = async ({
     body: JSON.stringify(data)
   };
 
-  const blob = await fetch(advancedSearchExportUrl, requestOptions)
+  const exportUrl = `${advancedSearchExportUrl}?format=${encodeURIComponent(safeFormat)}`;
+
+  const blob = await fetch(exportUrl, requestOptions)
     .then(checkAndGetStatus)
     .then(response => response.blob())
     .catch(errorMessage => {
@@ -86,7 +91,7 @@ export const downloadAdvancedSearchResults = async ({
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `Grottocenter_search_export_${Math.trunc(Date.now() / 1000)}.csv`;
+  a.download = `Grottocenter_search_export_${Math.trunc(Date.now() / 1000)}.${safeFormat}`;
   document.body.appendChild(a);
   a.click();
 

--- a/packages/web-app/src/actions/Advancedsearch.test.js
+++ b/packages/web-app/src/actions/Advancedsearch.test.js
@@ -1,0 +1,213 @@
+import fc from 'fast-check';
+
+// Mock isomorphic-fetch
+const mockFetch = jest.fn();
+jest.mock('isomorphic-fetch', () => mockFetch);
+
+// Mock apiRoutes
+jest.mock('../conf/apiRoutes', () => ({
+  advancedSearchUrl: 'http://api/advanced-search',
+  advancedSearchExportUrl: 'http://api/advanced-search/export'
+}));
+
+// Mock exportFormats — use the real values
+jest.mock('../conf/exportFormats', () => ({
+  VALID_EXPORT_FORMATS: new Set(['csv', 'geojson', 'gpx', 'kml'])
+}));
+
+// Mock utils
+jest.mock('./utils', () => ({
+  checkAndGetStatus: response => response
+}));
+
+const { downloadAdvancedSearchResults } = require('./Advancedsearch');
+
+describe('downloadAdvancedSearchResults', () => {
+  let anchorElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.URL.createObjectURL = jest
+      .fn()
+      .mockReturnValue('blob:http://localhost/fake');
+    window.URL.revokeObjectURL = jest.fn();
+
+    anchorElement = document.createElement('a');
+    jest.spyOn(anchorElement, 'click').mockImplementation(() => {});
+    jest.spyOn(document, 'createElement').mockReturnValue(anchorElement);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const setupFetchBlob = () => {
+    const fakeBlob = new Blob(['data'], { type: 'text/plain' });
+    mockFetch.mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) });
+  };
+
+  it('appends ?format=csv when format is "csv"', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances',
+      format: 'csv'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=csv',
+      expect.any(Object)
+    );
+  });
+
+  it('appends ?format=geojson when format is "geojson"', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances',
+      format: 'geojson'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=geojson',
+      expect.any(Object)
+    );
+  });
+
+  it('appends ?format=gpx when format is "gpx"', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances',
+      format: 'gpx'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=gpx',
+      expect.any(Object)
+    );
+  });
+
+  it('appends ?format=kml when format is "kml"', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances',
+      format: 'kml'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=kml',
+      expect.any(Object)
+    );
+  });
+
+  it('defaults to ?format=csv when format is undefined', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=csv',
+      expect.any(Object)
+    );
+  });
+
+  it('uses correct file extension for each format', async () => {
+    const formats = [
+      { format: 'csv', ext: 'csv' },
+      { format: 'geojson', ext: 'geojson' },
+      { format: 'gpx', ext: 'gpx' },
+      { format: 'kml', ext: 'kml' }
+    ];
+
+    for (const { format, ext } of formats) {
+      setupFetchBlob();
+
+      await downloadAdvancedSearchResults({
+        query: 'test',
+        entity: 'entrances',
+        format
+      });
+
+      expect(anchorElement.download).toMatch(
+        new RegExp(`Grottocenter_search_export_\\d+\\.${ext}$`)
+      );
+    }
+  });
+
+  it('falls back to csv for an unsupported format value', async () => {
+    setupFetchBlob();
+    await downloadAdvancedSearchResults({
+      query: 'test',
+      entity: 'entrances',
+      format: 'xlsx'
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://api/advanced-search/export?format=csv',
+      expect.any(Object)
+    );
+    expect(anchorElement.download).toMatch(
+      /Grottocenter_search_export_\d+\.csv$/
+    );
+  });
+
+  /**
+   * Property: For any supported format, the fetch URL contains the format
+   * and the download filename uses the matching extension.
+   * Encodes: format validation + extension derivation are consistent.
+   */
+  it('should produce correct URL and filename for any supported format', async () => {
+    const formatArb = fc.constantFrom('csv', 'geojson', 'gpx', 'kml');
+
+    await fc.assert(
+      fc.asyncProperty(formatArb, async format => {
+        setupFetchBlob();
+
+        await downloadAdvancedSearchResults({
+          query: 'test',
+          entity: 'entrances',
+          format
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `http://api/advanced-search/export?format=${format}`,
+          expect.any(Object)
+        );
+        expect(anchorElement.download).toMatch(
+          new RegExp(`\\.${format}$`)
+        );
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  /**
+   * Property: For any unsupported format string, the function falls back
+   * to csv for both URL and filename.
+   * Encodes: invalid formats never reach the API or appear in filenames.
+   */
+  it('should fall back to csv for any unsupported format string', async () => {
+    const unsupportedArb = fc
+      .string({ minLength: 1, maxLength: 20 })
+      .filter(s => !['csv', 'geojson', 'gpx', 'kml'].includes(s));
+
+    await fc.assert(
+      fc.asyncProperty(unsupportedArb, async format => {
+        setupFetchBlob();
+
+        await downloadAdvancedSearchResults({
+          query: 'test',
+          entity: 'entrances',
+          format
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://api/advanced-search/export?format=csv',
+          expect.any(Object)
+        );
+        expect(anchorElement.download).toMatch(
+          /Grottocenter_search_export_\d+\.csv$/
+        );
+      }),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/packages/web-app/src/actions/Advancedsearch.test.js
+++ b/packages/web-app/src/actions/Advancedsearch.test.js
@@ -10,11 +10,6 @@ jest.mock('../conf/apiRoutes', () => ({
   advancedSearchExportUrl: 'http://api/advanced-search/export'
 }));
 
-// Mock exportFormats — use the real values
-jest.mock('../conf/exportFormats', () => ({
-  VALID_EXPORT_FORMATS: new Set(['csv', 'geojson', 'gpx', 'kml'])
-}));
-
 // Mock utils
 jest.mock('./utils', () => ({
   checkAndGetStatus: response => response
@@ -149,11 +144,6 @@ describe('downloadAdvancedSearchResults', () => {
     );
   });
 
-  /**
-   * Property: For any supported format, the fetch URL contains the format
-   * and the download filename uses the matching extension.
-   * Encodes: format validation + extension derivation are consistent.
-   */
   it('should produce correct URL and filename for any supported format', async () => {
     const formatArb = fc.constantFrom('csv', 'geojson', 'gpx', 'kml');
 
@@ -179,11 +169,6 @@ describe('downloadAdvancedSearchResults', () => {
     );
   });
 
-  /**
-   * Property: For any unsupported format string, the function falls back
-   * to csv for both URL and filename.
-   * Encodes: invalid formats never reach the API or appear in filenames.
-   */
   it('should fall back to csv for any unsupported format string', async () => {
     const unsupportedArb = fc
       .string({ minLength: 1, maxLength: 20 })

--- a/packages/web-app/src/components/appli/AdvancedSearch/SearchResults.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/SearchResults.jsx
@@ -43,8 +43,8 @@ const SearchResults = ({ onSelected, hideExport, entityType, compact }) => {
       onCSVDownload={
         hideExport
           ? null
-          : (columns, columnsName) => {
-              downloadAdvancedSearchResults({ ...queryParams, columns, columnsName });
+          : (columns, columnsName, format) => {
+              downloadAdvancedSearchResults({ ...queryParams, columns, columnsName, format });
             }
       }
       onSelected={!onSelected ? null : ids => onSelected(ids, results)}

--- a/packages/web-app/src/components/appli/AdvancedSearch/SearchResults.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/SearchResults.jsx
@@ -40,7 +40,7 @@ const SearchResults = ({ onSelected, hideExport, entityType, compact }) => {
             }
           : null
       }
-      onCSVDownload={
+      onExport={
         hideExport
           ? null
           : (columns, columnsName, format) => {

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
@@ -32,6 +32,7 @@ import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import ViewListIcon from '@mui/icons-material/ViewList';
 
 import entitiesConfig from './entitiesConfig';
+import ExportFormatDropdown from './ExportFormatDropdown';
 import { LoadingTableHead, LoadingTableBodyInner } from './LoadingTable';
 import VisibleColumnsMenu from './VisibleColumnsMenu';
 import { SORT_FIELD_MAP, getStoredRowsPerPage, renderCell } from './tableUtils';
@@ -211,6 +212,10 @@ const DesktopEntityTable = ({
 
   const entityConfig = entitiesConfig[entityType ?? 'placeholder'];
 
+  const visibleColumns = entityColumns.filter(e => e.visible);
+  const exportColumns = visibleColumns.map(e => e.apiField || e.field);
+  const exportColumnLabels = visibleColumns.map(e => e.label);
+
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
     if (onPageChange) onPageChange(newPage, rowsPerPage);
@@ -301,7 +306,6 @@ const DesktopEntityTable = ({
     setSelected([]);
   }, [isNewQuery]);
 
-  const visibleColumns = entityColumns.filter(e => e.visible);
   const colSpan = visibleColumns.length + (onSelected ? 1 : 0);
 
   const TableContent =
@@ -378,15 +382,28 @@ const DesktopEntityTable = ({
                 alignItems: 'center'
               }}>
               {onCSVDownload &&
+                entityType === 'entrances' && (
+                  <ExportFormatDropdown
+                    disabled={nbTotalRows > MAX_DOCUMENTS_TO_EXPORT_IN_CSV}
+                    onExport={format => {
+                      onCSVDownload(
+                        exportColumns,
+                        exportColumnLabels,
+                        format
+                      );
+                    }}
+                  />
+                )}
+              {onCSVDownload &&
+                entityType !== 'entrances' &&
                 (nbTotalRows <= MAX_DOCUMENTS_TO_EXPORT_IN_CSV ? (
                   <Button
                     variant="outlined"
                     size="small"
                     onClick={() => {
-                      const c = entityColumns.filter(e => e.visible);
                       onCSVDownload(
-                        c.map(e => e.apiField || e.field),
-                        c.map(e => e.label)
+                        exportColumns,
+                        exportColumnLabels
                       );
                     }}
                     startIcon={<FileDownloadIcon />}

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
@@ -191,7 +191,7 @@ const DesktopEntityTable = ({
   pageSizeOptions,
   onPageChange,
   onSortChange,
-  onCSVDownload,
+  onExport,
   isNewQuery,
   shouldHideFooter,
   compact,
@@ -381,12 +381,12 @@ const DesktopEntityTable = ({
                 gap: 1,
                 alignItems: 'center'
               }}>
-              {onCSVDownload &&
+              {onExport &&
                 entityType === 'entrances' && (
                   <ExportFormatDropdown
                     disabled={nbTotalRows > MAX_DOCUMENTS_TO_EXPORT_IN_CSV}
                     onExport={format => {
-                      onCSVDownload(
+                      onExport(
                         exportColumns,
                         exportColumnLabels,
                         format
@@ -394,14 +394,14 @@ const DesktopEntityTable = ({
                     }}
                   />
                 )}
-              {onCSVDownload &&
+              {onExport &&
                 entityType !== 'entrances' &&
                 (nbTotalRows <= MAX_DOCUMENTS_TO_EXPORT_IN_CSV ? (
                   <Button
                     variant="outlined"
                     size="small"
                     onClick={() => {
-                      onCSVDownload(
+                      onExport(
                         exportColumns,
                         exportColumnLabels
                       );
@@ -546,7 +546,7 @@ DesktopEntityTable.propTypes = {
   pageSizeOptions: PropTypes.arrayOf(PropTypes.number).isRequired,
   onPageChange: PropTypes.func,
   onSortChange: PropTypes.func,
-  onCSVDownload: PropTypes.func,
+  onExport: PropTypes.func,
   isNewQuery: PropTypes.bool,
   shouldHideFooter: PropTypes.bool,
   compact: PropTypes.bool,

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
@@ -55,10 +55,10 @@ const renderTable = (props = {}) =>
   );
 
 describe('DesktopEntityTable - Export controls', () => {
-  it('renders ExportFormatDropdown for entrances when onCSVDownload is provided', () => {
+  it('renders ExportFormatDropdown for entrances when onExport is provided', () => {
     renderTable({
       entityType: 'entrances',
-      onCSVDownload: jest.fn()
+      onExport: jest.fn()
     });
 
     // The dropdown renders a button with "Export" text
@@ -72,17 +72,17 @@ describe('DesktopEntityTable - Export controls', () => {
   it('renders CSV button for non-entrance entity types', () => {
     renderTable({
       entityType: 'documents',
-      onCSVDownload: jest.fn()
+      onExport: jest.fn()
     });
 
     expect(screen.getByText('Export to CSV')).toBeInTheDocument();
   });
 
-  it('passes format in onCSVDownload callback when a format is selected', () => {
-    const onCSVDownload = jest.fn();
+  it('passes format in onExport callback when a format is selected', () => {
+    const onExport = jest.fn();
     renderTable({
       entityType: 'entrances',
-      onCSVDownload
+      onExport
     });
 
     const exportButton = screen.getByRole('button', { name: /Export/i });
@@ -91,17 +91,26 @@ describe('DesktopEntityTable - Export controls', () => {
     const gpxOption = screen.getByRole('menuitem', { name: 'GPX' });
     fireEvent.click(gpxOption);
 
-    expect(onCSVDownload).toHaveBeenCalledWith(
+    expect(onExport).toHaveBeenCalledWith(
       expect.any(Array),
       expect.any(Array),
       'gpx'
     );
   });
 
-  it('does not render any export control when onCSVDownload is not provided', () => {
+  it('renders ExportFormatDropdown as disabled when nbTotalRows exceeds limit', () => {
     renderTable({
       entityType: 'entrances',
-      onCSVDownload: undefined
+      onExport: jest.fn(),
+      nbTotalRows: 10001
+    });
+    expect(screen.getByRole('button', { name: /Export/i })).toBeDisabled();
+  });
+
+  it('does not render any export control when onExport is not provided', () => {
+    renderTable({
+      entityType: 'entrances',
+      onExport: undefined
     });
 
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import DesktopEntityTable from './DesktopEntityTable';
+
+// Mock sub-components that are not under test
+jest.mock('./VisibleColumnsMenu', () => {
+  const MockVisibleColumnsMenu = () => (
+    <div data-testid="visible-columns-menu" />
+  );
+  return MockVisibleColumnsMenu;
+});
+
+jest.mock('../../../hooks/useOpenLink', () => () => jest.fn());
+
+const messages = {
+  Export: 'Export',
+  'Export to CSV': 'Export to CSV',
+  'Export unavailable above 10000 results':
+    'Export unavailable above 10 000 results',
+  results_count: '{count, plural, one {# result} other {# results}}',
+  'Results per page:': 'Results per page:',
+  'No results': 'No results',
+  'Try adjusting your search or filters':
+    'Try adjusting your search or filters',
+  'Go to page': 'Go to page',
+  'Card view': 'Card view',
+  'Table view': 'Table view'
+};
+
+const baseColumns = [
+  { field: 'name', label: 'Name', visible: true, sortable: true }
+];
+
+const defaultProps = {
+  entityColumns: baseColumns,
+  setEntityColumns: jest.fn(),
+  pageRows: [{ id: 1, name: 'Cave A' }],
+  nbTotalRows: 1,
+  pageSizeOptions: [20, 100],
+  isLoading: false,
+  isNewQuery: false,
+  shouldHideFooter: false,
+  compact: false,
+  onViewToggle: jest.fn(),
+  viewMode: 'table'
+};
+
+const renderTable = (props = {}) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <DesktopEntityTable {...defaultProps} {...props} />
+    </IntlProvider>
+  );
+
+describe('DesktopEntityTable - Export controls', () => {
+  it('renders ExportFormatDropdown for entrances when onCSVDownload is provided', () => {
+    renderTable({
+      entityType: 'entrances',
+      onCSVDownload: jest.fn()
+    });
+
+    // The dropdown renders a button with "Export" text
+    const exportButton = screen.getByRole('button', { name: /Export/i });
+    expect(exportButton).toBeInTheDocument();
+
+    // Should NOT render "Export to CSV" button
+    expect(screen.queryByText('Export to CSV')).not.toBeInTheDocument();
+  });
+
+  it('renders CSV button for non-entrance entity types', () => {
+    renderTable({
+      entityType: 'documents',
+      onCSVDownload: jest.fn()
+    });
+
+    expect(screen.getByText('Export to CSV')).toBeInTheDocument();
+  });
+
+  it('passes format in onCSVDownload callback when a format is selected', () => {
+    const onCSVDownload = jest.fn();
+    renderTable({
+      entityType: 'entrances',
+      onCSVDownload
+    });
+
+    const exportButton = screen.getByRole('button', { name: /Export/i });
+    fireEvent.click(exportButton);
+
+    const gpxOption = screen.getByRole('menuitem', { name: 'GPX' });
+    fireEvent.click(gpxOption);
+
+    expect(onCSVDownload).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'gpx'
+    );
+  });
+
+  it('does not render any export control when onCSVDownload is not provided', () => {
+    renderTable({
+      entityType: 'entrances',
+      onCSVDownload: undefined
+    });
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText('Export to CSV')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
@@ -113,7 +113,9 @@ describe('DesktopEntityTable - Export controls', () => {
       onExport: undefined
     });
 
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Export/i })
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('Export to CSV')).not.toBeInTheDocument();
   });
 });

--- a/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
@@ -120,6 +120,48 @@ const EntityTable = ({
       if (onSortChange) onSortChange(`${apiField}:${newOrder}`);
     };
 
+    const exportDisabled = nbTotalRows != null && nbTotalRows > MAX_EXPORT_ROWS;
+    const exportCols = visibleColumns.map(c => c.apiField || c.field);
+    const exportLabels = visibleColumns.map(c => c.label);
+    let exportSlot;
+    if (onExport) {
+      if (entityType === 'entrances') {
+        exportSlot = (
+          <ExportFormatDropdown
+            disabled={exportDisabled}
+            onExport={format => onExport(exportCols, exportLabels, format)}
+            iconOnly
+          />
+        );
+      } else {
+        exportSlot = (
+          <Tooltip
+            title={formatMessage({
+              id: exportDisabled
+                ? 'Export unavailable above 10000 results'
+                : 'Export'
+            })}>
+            <span>
+              <IconButton
+                size="small"
+                color="primary"
+                disabled={exportDisabled}
+                onClick={() => onExport(exportCols, exportLabels)}
+                sx={{
+                  border: '1px solid',
+                  borderColor: exportDisabled
+                    ? 'action.disabled'
+                    : 'primary.main',
+                  borderRadius: 1
+                }}>
+                <FileDownloadIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        );
+      }
+    }
+
     return (
       <Box sx={{ width: '100%' }}>
         {!shouldHideFooter && (
@@ -136,46 +178,7 @@ const EntityTable = ({
               entityType={entityType}
               onViewToggle={toggleViewMode}
               viewMode={viewMode}
-              exportSlot={(() => {
-                if (!onExport) return undefined;
-                const exportDisabled =
-                  nbTotalRows != null && nbTotalRows > MAX_EXPORT_ROWS;
-                const exportCols = visibleColumns.map(
-                  c => c.apiField || c.field
-                );
-                const exportLabels = visibleColumns.map(c => c.label);
-                if (entityType === 'entrances') {
-                  return (
-                    <ExportFormatDropdown
-                      disabled={exportDisabled}
-                      onExport={format =>
-                        onExport(exportCols, exportLabels, format)
-                      }
-                      iconOnly
-                    />
-                  );
-                }
-                return (
-                  <Tooltip title={formatMessage({ id: 'Export' })}>
-                    <span>
-                      <IconButton
-                        size="small"
-                        color="primary"
-                        disabled={exportDisabled}
-                        onClick={() => onExport(exportCols, exportLabels)}
-                        sx={{
-                          border: '1px solid',
-                          borderColor: exportDisabled
-                            ? 'action.disabled'
-                            : 'primary.main',
-                          borderRadius: 1
-                        }}>
-                        <FileDownloadIcon fontSize="small" />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                );
-              })()}
+              exportSlot={exportSlot}
             />
             <Divider />
           </>

--- a/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
@@ -55,7 +55,7 @@ const EntityTable = ({
   pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
   onPageChange,
   onSortChange,
-  onCSVDownload,
+  onExport,
   isNewQuery = false,
   shouldHideFooter = false,
   compact = false
@@ -137,7 +137,7 @@ const EntityTable = ({
               onViewToggle={toggleViewMode}
               viewMode={viewMode}
               exportSlot={(() => {
-                if (!onCSVDownload) return undefined;
+                if (!onExport) return undefined;
                 const exportDisabled =
                   nbTotalRows != null && nbTotalRows > MAX_EXPORT_ROWS;
                 const exportCols = visibleColumns.map(
@@ -149,7 +149,7 @@ const EntityTable = ({
                     <ExportFormatDropdown
                       disabled={exportDisabled}
                       onExport={format =>
-                        onCSVDownload(exportCols, exportLabels, format)
+                        onExport(exportCols, exportLabels, format)
                       }
                       iconOnly
                     />
@@ -162,7 +162,7 @@ const EntityTable = ({
                         size="small"
                         color="primary"
                         disabled={exportDisabled}
-                        onClick={() => onCSVDownload(exportCols, exportLabels)}
+                        onClick={() => onExport(exportCols, exportLabels)}
                         sx={{
                           border: '1px solid',
                           borderColor: exportDisabled
@@ -214,7 +214,7 @@ const EntityTable = ({
       pageSizeOptions={pageSizeOptions}
       onPageChange={onPageChange}
       onSortChange={onSortChange}
-      onCSVDownload={onCSVDownload}
+      onExport={onExport}
       isNewQuery={isNewQuery}
       shouldHideFooter={shouldHideFooter}
       compact={compact}
@@ -235,7 +235,7 @@ EntityTable.propTypes = {
   pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
   onPageChange: PropTypes.func,
   onSortChange: PropTypes.func,
-  onCSVDownload: PropTypes.func,
+  onExport: PropTypes.func,
   isNewQuery: PropTypes.bool,
   shouldHideFooter: PropTypes.bool,
   compact: PropTypes.bool

--- a/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { isMobile } from 'react-device-detect';
-import { Box, Divider, LinearProgress } from '@mui/material';
+import { Box, Divider, IconButton, LinearProgress, Tooltip } from '@mui/material';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import { useIntl } from 'react-intl';
 
 import entitiesConfig from './entitiesConfig';
 import DesktopEntityTable from './DesktopEntityTable';
+import ExportFormatDropdown from './ExportFormatDropdown';
 import MobileEntityList from './MobileEntityList';
 import MobileToolbar from './MobileToolbar';
 import {
@@ -39,6 +42,8 @@ const initColumns = (
   return columns;
 };
 
+const MAX_EXPORT_ROWS = 10000;
+
 const EntityTable = ({
   entityType,
   entityColumnsModifier,
@@ -55,6 +60,7 @@ const EntityTable = ({
   shouldHideFooter = false,
   compact = false
 }) => {
+  const { formatMessage } = useIntl();
   const entityConfig = entitiesConfig[entityType ?? 'placeholder'];
 
   const [entityColumns, setEntityColumns] = useState(() =>
@@ -130,6 +136,46 @@ const EntityTable = ({
               entityType={entityType}
               onViewToggle={toggleViewMode}
               viewMode={viewMode}
+              exportSlot={(() => {
+                if (!onCSVDownload) return undefined;
+                const exportDisabled =
+                  nbTotalRows != null && nbTotalRows > MAX_EXPORT_ROWS;
+                const exportCols = visibleColumns.map(
+                  c => c.apiField || c.field
+                );
+                const exportLabels = visibleColumns.map(c => c.label);
+                if (entityType === 'entrances') {
+                  return (
+                    <ExportFormatDropdown
+                      disabled={exportDisabled}
+                      onExport={format =>
+                        onCSVDownload(exportCols, exportLabels, format)
+                      }
+                      iconOnly
+                    />
+                  );
+                }
+                return (
+                  <Tooltip title={formatMessage({ id: 'Export' })}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        color="primary"
+                        disabled={exportDisabled}
+                        onClick={() => onCSVDownload(exportCols, exportLabels)}
+                        sx={{
+                          border: '1px solid',
+                          borderColor: exportDisabled
+                            ? 'action.disabled'
+                            : 'primary.main',
+                          borderRadius: 1
+                        }}>
+                        <FileDownloadIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                );
+              })()}
             />
             <Divider />
           </>

--- a/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.jsx
+++ b/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.jsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Box, Button, Menu, MenuItem, Tooltip } from '@mui/material';
+import { Box, Button, IconButton, Menu, MenuItem, Tooltip } from '@mui/material';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
 import { EXPORT_FORMATS } from '../../../conf/exportFormats';
 
-const ExportFormatDropdown = ({ disabled, onExport }) => {
+const ExportFormatDropdown = ({ disabled, onExport, iconOnly = false }) => {
   const { formatMessage } = useIntl();
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -25,7 +25,20 @@ const ExportFormatDropdown = ({ disabled, onExport }) => {
     onExport(value);
   };
 
-  const button = (
+  const button = iconOnly ? (
+    <IconButton
+      size="small"
+      color="primary"
+      disabled={disabled}
+      onClick={handleClick}
+      sx={{
+        border: '1px solid',
+        borderColor: disabled ? 'action.disabled' : 'primary.main',
+        borderRadius: 1
+      }}>
+      <FileDownloadIcon fontSize="small" />
+    </IconButton>
+  ) : (
     <Button
       variant="outlined"
       size="small"
@@ -58,9 +71,17 @@ const ExportFormatDropdown = ({ disabled, onExport }) => {
     );
   }
 
+  const trigger = iconOnly ? (
+    <Tooltip title={formatMessage({ id: 'Export' })}>
+      <span>{button}</span>
+    </Tooltip>
+  ) : (
+    button
+  );
+
   return (
     <>
-      {button}
+      {trigger}
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
         {EXPORT_FORMATS.map(({ value, label }) => (
           <MenuItem key={value} onClick={() => handleSelect(value)}>
@@ -74,7 +95,8 @@ const ExportFormatDropdown = ({ disabled, onExport }) => {
 
 ExportFormatDropdown.propTypes = {
   disabled: PropTypes.bool.isRequired,
-  onExport: PropTypes.func.isRequired
+  onExport: PropTypes.func.isRequired,
+  iconOnly: PropTypes.bool
 };
 
 export default ExportFormatDropdown;

--- a/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.jsx
+++ b/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Box, Button, Menu, MenuItem, Tooltip } from '@mui/material';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+
+import { EXPORT_FORMATS } from '../../../conf/exportFormats';
+
+const ExportFormatDropdown = ({ disabled, onExport }) => {
+  const { formatMessage } = useIntl();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = value => {
+    handleClose();
+    onExport(value);
+  };
+
+  const button = (
+    <Button
+      variant="outlined"
+      size="small"
+      color="primary"
+      disabled={disabled}
+      onClick={handleClick}
+      startIcon={<FileDownloadIcon />}
+      endIcon={<ArrowDropDownIcon />}
+      sx={{ minWidth: 0 }}>
+      <Box
+        component="span"
+        sx={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        }}>
+        {formatMessage({ id: 'Export' })}
+      </Box>
+    </Button>
+  );
+
+  if (disabled) {
+    return (
+      <Tooltip
+        title={formatMessage({
+          id: 'Export unavailable above 10000 results'
+        })}>
+        <span>{button}</span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <>
+      {button}
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {EXPORT_FORMATS.map(({ value, label }) => (
+          <MenuItem key={value} onClick={() => handleSelect(value)}>
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+ExportFormatDropdown.propTypes = {
+  disabled: PropTypes.bool.isRequired,
+  onExport: PropTypes.func.isRequired
+};
+
+export default ExportFormatDropdown;

--- a/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.stories.jsx
+++ b/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.stories.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import ExportFormatDropdown from './ExportFormatDropdown';
+
+export default {
+  title: 'Common/ExportFormatDropdown',
+  component: ExportFormatDropdown
+};
+
+export const Default = () => (
+  <ExportFormatDropdown disabled={false} onExport={action('onExport')} />
+);
+
+export const Disabled = () => (
+  <ExportFormatDropdown disabled onExport={action('onExport')} />
+);
+
+export const IconOnly = () => (
+  <ExportFormatDropdown
+    disabled={false}
+    onExport={action('onExport')}
+    iconOnly
+  />
+);
+
+export const IconOnlyDisabled = () => (
+  <ExportFormatDropdown disabled onExport={action('onExport')} iconOnly />
+);

--- a/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/ExportFormatDropdown.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import fc from 'fast-check';
+
+import ExportFormatDropdown from './ExportFormatDropdown';
+
+const messages = {
+  Export: 'Export',
+  'Export unavailable above 10000 results':
+    'Export unavailable above 10 000 results'
+};
+
+const renderDropdown = (props = {}) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <ExportFormatDropdown
+        disabled={false}
+        onExport={jest.fn()}
+        {...props}
+      />
+    </IntlProvider>
+  );
+
+describe('ExportFormatDropdown', () => {
+  it('renders 4 menu items when opened', () => {
+    renderDropdown();
+    const button = screen.getByRole('button', { name: /Export/i });
+    fireEvent.click(button);
+
+    const options = screen.getAllByRole('menuitem');
+    expect(options).toHaveLength(4);
+    expect(options[0]).toHaveTextContent('CSV');
+    expect(options[1]).toHaveTextContent('GeoJSON');
+    expect(options[2]).toHaveTextContent('GPX');
+    expect(options[3]).toHaveTextContent('KML');
+  });
+
+  it('calls onExport with the selected format value', () => {
+    const onExport = jest.fn();
+    renderDropdown({ onExport });
+
+    const button = screen.getByRole('button', { name: /Export/i });
+    fireEvent.click(button);
+
+    const geojsonOption = screen.getByRole('menuitem', { name: 'GeoJSON' });
+    fireEvent.click(geojsonOption);
+
+    expect(onExport).toHaveBeenCalledWith('geojson');
+  });
+
+  it('renders tooltip when disabled', () => {
+    renderDropdown({ disabled: true });
+    const tooltip = screen.getByLabelText(
+      'Export unavailable above 10 000 results'
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('menu closes after selection', () => {
+    const onExport = jest.fn();
+    renderDropdown({ onExport });
+
+    const button = screen.getByRole('button', { name: /Export/i });
+    fireEvent.click(button);
+
+    const csvOption = screen.getByRole('menuitem', { name: 'CSV' });
+    fireEvent.click(csvOption);
+
+    // Menu should be closed — no menu items visible
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  /**
+   * Property: For any of the 4 supported formats, selecting it always calls
+   * onExport with exactly that format string.
+   * Encodes: onExport is called with the exact format value, no transformation.
+   */
+  it('should call onExport with the exact format value for any format', () => {
+    const formatArb = fc.constantFrom('csv', 'geojson', 'gpx', 'kml');
+    const labelMap = {
+      csv: 'CSV',
+      geojson: 'GeoJSON',
+      gpx: 'GPX',
+      kml: 'KML'
+    };
+
+    fc.assert(
+      fc.property(formatArb, format => {
+        const onExport = jest.fn();
+        const { unmount } = renderDropdown({ onExport });
+
+        const button = screen.getByRole('button', { name: /Export/i });
+        fireEvent.click(button);
+
+        const option = screen.getByRole('menuitem', {
+          name: labelMap[format]
+        });
+        fireEvent.click(option);
+
+        expect(onExport).toHaveBeenCalledTimes(1);
+        expect(onExport).toHaveBeenCalledWith(format);
+        unmount();
+      }),
+      { numRuns: 20 }
+    );
+  });
+});

--- a/packages/web-app/src/components/common/EntityTable/MobileToolbar.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileToolbar.jsx
@@ -129,9 +129,11 @@ const MobileToolbar = ({
   setEntityColumns,
   entityType,
   onViewToggle,
-  viewMode
+  viewMode,
+  exportSlot
 }) => {
   const { formatMessage } = useIntl();
+
   return (
     <Toolbar
       disableGutters
@@ -156,6 +158,7 @@ const MobileToolbar = ({
           sx={{ flex: 1 }}
         />
       )}
+      {exportSlot}
       <Tooltip
         title={formatMessage({
           id: viewMode === 'cards' ? 'Table view' : 'Card view'
@@ -191,7 +194,8 @@ MobileToolbar.propTypes = {
   setEntityColumns: PropTypes.func.isRequired,
   entityType: PropTypes.string,
   onViewToggle: PropTypes.func.isRequired,
-  viewMode: PropTypes.string.isRequired
+  viewMode: PropTypes.string.isRequired,
+  exportSlot: PropTypes.node
 };
 
 export default MobileToolbar;

--- a/packages/web-app/src/conf/exportFormats.js
+++ b/packages/web-app/src/conf/exportFormats.js
@@ -1,7 +1,3 @@
-/**
- * Supported export formats for search results.
- * Each entry defines the value sent to the API and the display label.
- */
 const EXPORT_FORMATS = [
   { value: 'csv', label: 'CSV' },
   { value: 'geojson', label: 'GeoJSON' },
@@ -9,10 +5,6 @@ const EXPORT_FORMATS = [
   { value: 'kml', label: 'KML' }
 ];
 
-/**
- * Set of valid format values, derived from EXPORT_FORMATS.
- * Used for input validation with csv as fallback for unknown values.
- */
 const VALID_EXPORT_FORMATS = new Set(EXPORT_FORMATS.map(f => f.value));
 
 export { EXPORT_FORMATS, VALID_EXPORT_FORMATS };

--- a/packages/web-app/src/conf/exportFormats.js
+++ b/packages/web-app/src/conf/exportFormats.js
@@ -1,0 +1,18 @@
+/**
+ * Supported export formats for search results.
+ * Each entry defines the value sent to the API and the display label.
+ */
+const EXPORT_FORMATS = [
+  { value: 'csv', label: 'CSV' },
+  { value: 'geojson', label: 'GeoJSON' },
+  { value: 'gpx', label: 'GPX' },
+  { value: 'kml', label: 'KML' }
+];
+
+/**
+ * Set of valid format values, derived from EXPORT_FORMATS.
+ * Used for input validation with csv as fallback for unknown values.
+ */
+const VALID_EXPORT_FORMATS = new Set(EXPORT_FORMATS.map(f => f.value));
+
+export { EXPORT_FORMATS, VALID_EXPORT_FORMATS };


### PR DESCRIPTION
# Add geo export formats for entrance searches

## 🤔 What

- Add GeoJSON, GPX, and KML export options alongside CSV for entrance search results
- Introduce an `ExportFormatDropdown` component that replaces the "Export to CSV" button when viewing entrances
- Non-entrance entity types retain the existing CSV-only export button unchanged
- Closes #1397

## 🤷‍♂️ Why

Cavers need to export entrance data in geo-aware formats (GeoJSON, GPX, KML) to use in mapping applications and GPS devices. The backend already supports (or will support via GrottoCenter/grottocenter-api#1677) a `format` query parameter on the export endpoint — this PR exposes that capability in the UI.

## 🔍 How

- **Shared config** (`src/conf/exportFormats.js`): Single source of truth for supported formats (array + derived `Set` for validation)
- **Action** (`actions/Advancedsearch.js`): `downloadAdvancedSearchResults` accepts a `format` parameter, validates it against `VALID_EXPORT_FORMATS`, appends `?format=` to the export URL, and uses the format as the file extension. Invalid formats fall back to CSV.
- **ExportFormatDropdown** component: MUI Button + Menu with 4 format options. Handles disabled state with tooltip (row limit exceeded). Text truncates gracefully on mobile via overflow ellipsis.
- **DesktopEntityTable**: Conditionally renders the dropdown for `entrances`, retains the CSV button for other entity types. Derives `visibleColumns`, `exportColumns`, and `exportColumnLabels` as plain constants (no redundant function wrappers).
- **SearchResults**: Passes `format` through to `downloadAdvancedSearchResults`.

## 🔗 Related API PR

- GrottoCenter/grottocenter-api#1677 (backend `?format=` support)

When `format=csv` is passed (the default), behavior is identical to the current implementation — this PR can be merged before or after the API PR.

## 🧪 Testing

- Unit tests for `downloadAdvancedSearchResults`: URL format param, filename extension, fallback for invalid formats
- Property-based tests: valid formats produce correct URL + filename; invalid formats always fall back to CSV
- Component tests for `ExportFormatDropdown`: menu items, selection callback, disabled tooltip, menu close
- Component tests for `DesktopEntityTable`: dropdown for entrances, CSV button for others, format passthrough

All tests pass locally: `yarn test --testPathPattern="(Advancedsearch.test|ExportFormatDropdown.test|DesktopEntityTable.test)"`
