### PR TITLE
feat(entrance): add network description link

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -1651,6 +1651,8 @@
   "Network name": "اسم الشبكة",
   "Network properties": "خصائص الشبكة",
   "network_count": "عدد الشبكات",
+  "network.descriptions.callout": "هذه المدخل جزء من {networkLink} التي تحتوي أيضاً على {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {وصف واحد} other {# أوصاف}}",
   "networks": "شبكات",
   "Networks": "الشبكات",
   "Networks and caves": "الشبكات والكهوف",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -1651,6 +1651,8 @@
   "Network name": "Пещерна система",
   "Network properties": "име на Пещерна система",
   "network_count": "брой мрежи",
+  "network.descriptions.callout": "Този вход е част от {networkLink}, която също има {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {едно описание} other {# описания}}",
   "networks": "мрежи",
   "Networks": "Мрежи",
   "Networks and caves": "Мрежи и пещери",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nom del sistema de coves",
   "Network properties": "Propietats del sistema de coves",
   "network_count": "nombre de xarxes",
+  "network.descriptions.callout": "Aquesta entrada forma part de {networkLink} que també té {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {una descripció} other {# descripcions}}",
   "networks": "xarxes",
   "Networks": "Xarxes",
   "Networks and caves": "Xarxes i coves",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -1651,6 +1651,8 @@
   "Network name": "Systemname",
   "Network properties": "Systemeigenschaften",
   "network_count": "Netzwerkanzahl",
+  "network.descriptions.callout": "Dieser Eingang ist Teil von {networkLink}, das auch {descriptionsLink} hat.",
+  "network.descriptions.count": "{count, plural, one {eine Beschreibung} other {# Beschreibungen}}",
   "networks": "Netzwerke",
   "Networks": "Netzwerke",
   "Networks and caves": "Netzwerke und Höhlen",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -1651,6 +1651,8 @@
   "Network name": "Όνομα δικτύου",
   "Network properties": "Ιδιότητες δικτύου",
   "network_count": "αριθμός δικτύων",
+  "network.descriptions.callout": "Αυτή η είσοδος ανήκει στο {networkLink} που έχει επίσης {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {μία περιγραφή} other {# περιγραφές}}",
   "networks": "Δίκτυα",
   "Networks": "Δίκτυα",
   "Networks and caves": "Δίκτυα και σπήλαια",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -1651,6 +1651,8 @@
   "Network name": "Network name",
   "Network properties": "Network properties",
   "network_count": "{count, plural, one {network (cave of more than 1 entrance)} other {networks (cave of more than 1 entrance)}}",
+  "network.descriptions.callout": "This entrance is part of {networkLink} which also has {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {one description} other {# descriptions}}",
   "networks": "networks",
   "Networks": "Networks",
   "Networks and caves": "Networks and caves",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nombre de la red",
   "Network properties": "Propiedades de la red",
   "network_count": "número de redes",
+  "network.descriptions.callout": "Esta entrada forma parte de {networkLink} que también tiene {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {una descripción} other {# descripciones}}",
   "networks": "redes",
   "Networks": "Redes",
   "Networks and caves": "Redes y cuevas",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nom du réseau",
   "Network properties": "Propriétés du réseau",
   "network_count": "{count, plural, one {réseau (cavité avec plus d'une entrée)} other {réseaux (cavité avec plus d'une entrée)}}",
+  "network.descriptions.callout": "Cette entrée fait partie de {networkLink} qui possède également {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {une description} other {# descriptions}}",
   "networks": "réseaux",
   "Networks": "Réseaux",
   "Networks and caves": "Réseaux et cavités",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -1651,6 +1651,8 @@
   "Network name": "שם הרשת",
   "Network properties": "מאפייני הרשת",
   "network_count": "מספר רשתות",
+  "network.descriptions.callout": "כניסה זו היא חלק מ-{networkLink} שיש לה גם {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {תיאור אחד} other {# תיאורים}}",
   "networks": "רשתות",
   "Networks": "רשתות",
   "Networks and caves": "רשתות ומערות",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nama jaringan",
   "Network properties": "Properti jaringan",
   "network_count": "jumlah jaringan",
+  "network.descriptions.callout": "Pintu masuk ini adalah bagian dari {networkLink} yang juga memiliki {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {satu deskripsi} other {# deskripsi}}",
   "networks": "jaringan",
   "Networks": "Jaringan",
   "Networks and caves": "Jaringan dan gua",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nome della rete",
   "Network properties": "Proprietà della rete",
   "network_count": "numero di reti",
+  "network.descriptions.callout": "Questo ingresso fa parte di {networkLink} che ha anche {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {una descrizione} other {# descrizioni}}",
   "networks": "reti",
   "Networks": "Reti",
   "Networks and caves": "Reti e grotte",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -1651,6 +1651,8 @@
   "Network name": "ネットワーク",
   "Network properties": "財産",
   "network_count": "ネットワーク数",
+  "network.descriptions.callout": "このエントランスは {networkLink} の一部であり、{descriptionsLink} もあります。",
+  "network.descriptions.count": "{count, plural, one {説明1件} other {#件の説明}}",
   "networks": "ネットワーク",
   "Networks": "ネットワーク",
   "Networks and caves": "ネットワークと洞窟",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -1651,6 +1651,8 @@
   "Network name": "Grot naam",
   "Network properties": "Grot eigenschappen",
   "network_count": "aantal netwerken",
+  "network.descriptions.callout": "Deze ingang maakt deel uit van {networkLink} dat ook {descriptionsLink} heeft.",
+  "network.descriptions.count": "{count, plural, one {een beschrijving} other {# beschrijvingen}}",
   "networks": "netwerken",
   "Networks": "Netwerken",
   "Networks and caves": "Netwerken en grotten",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -1651,6 +1651,8 @@
   "Network name": "Nome da rede",
   "Network properties": "Propriedades da rede",
   "network_count": "número de redes",
+  "network.descriptions.callout": "Esta entrada faz parte de {networkLink} que também tem {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {uma descrição} other {# descrições}}",
   "networks": "redes",
   "Networks": "Redes",
   "Networks and caves": "Redes e cavernas",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -1651,6 +1651,8 @@
   "Network name": "Numele rețelei",
   "Network properties": "Caracteristicele rețelei",
   "network_count": "număr de rețele",
+  "network.descriptions.callout": "Această intrare face parte din {networkLink} care are și {descriptionsLink}.",
+  "network.descriptions.count": "{count, plural, one {o descriere} other {# descrieri}}",
   "networks": "rețele",
   "Networks": "Rețele",
   "Networks and caves": "Rețele și peșteri",

--- a/packages/web-app/src/actions/Cave/GetNetworkCaveDescriptionsCount.js
+++ b/packages/web-app/src/actions/Cave/GetNetworkCaveDescriptionsCount.js
@@ -22,5 +22,12 @@ export const fetchNetworkCaveDescriptionsCount =
       )
       .catch(error => {
         if (error.isAuthError) return;
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch network descriptions count', error);
       });
   };
+
+export const resetNetworkCaveDescriptionsCount = () => ({
+  type: FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS,
+  count: 0
+});

--- a/packages/web-app/src/actions/Cave/GetNetworkCaveDescriptionsCount.js
+++ b/packages/web-app/src/actions/Cave/GetNetworkCaveDescriptionsCount.js
@@ -1,0 +1,26 @@
+import fetch from 'isomorphic-fetch';
+import { getCaveUrl } from '../../conf/apiRoutes';
+import { checkAuthStatus } from '../utils';
+
+export const FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS =
+  'FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS';
+
+export const fetchNetworkCaveDescriptionsCount =
+  caveId => (dispatch, getState) => {
+    const requestOptions = {
+      headers: getState().login.authorizationHeader
+    };
+
+    return fetch(getCaveUrl + caveId, requestOptions)
+      .then(checkAuthStatus(dispatch))
+      .then(response => response.json())
+      .then(data =>
+        dispatch({
+          type: FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS,
+          count: data.descriptions?.length ?? 0
+        })
+      )
+      .catch(error => {
+        if (error.isAuthError) return;
+      });
+  };

--- a/packages/web-app/src/components/appli/Descriptions/index.jsx
+++ b/packages/web-app/src/components/appli/Descriptions/index.jsx
@@ -1,10 +1,19 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { useIntl } from 'react-intl';
-import { Button, Divider, List, Tooltip } from '@mui/material';
+import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  Box,
+  Button,
+  Divider,
+  Link as MuiLink,
+  List,
+  Tooltip,
+  Typography
+} from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
+import CustomIcon from '../../common/CustomIcon';
 
 import ScrollableContent from '../../common/Layouts/Fixed/ScrollableContent';
 import { DescriptionPropTypes } from '../../../types/description.type';
@@ -13,6 +22,7 @@ import CreateDescriptionForm from '../EntitiesForm/Description';
 import { postDescription } from '../../../actions/Description/CreateDescription';
 import { moveDescriptionRelevance } from '../../../actions/Description/MoveRelevance';
 import { usePermissions } from '../../../hooks';
+import useOpenLink from '../../../hooks/useOpenLink';
 import { useMoveRelevanceWithUndo } from '../../../hooks/useMoveRelevanceWithUndo';
 import { sortByRelevance } from '../../../helpers/sortByRelevance';
 import Alert from '../../common/Alert';
@@ -22,11 +32,16 @@ const Descriptions = ({
   entityId,
   descriptions,
   isEditAllowed = true,
-  isAddAllowed = true
+  isAddAllowed = true,
+  networkId = undefined,
+  networkName = undefined,
+  networkDescriptionsCount = 0
 }) => {
   const { formatMessage } = useIntl();
   const permissions = usePermissions();
+  const hasNetworkDescriptions = !!networkId && !!networkName && networkDescriptionsCount > 0;
   const dispatch = useDispatch();
+  const openLink = useOpenLink();
   const [isFormVisible, setIsFormVisible] = useState(false);
   const { movingId, handleMove } = useMoveRelevanceWithUndo(
     moveDescriptionRelevance
@@ -48,7 +63,7 @@ const Descriptions = ({
     <ScrollableContent
       dense
       anchorId="description"
-      defaultExpanded={descriptions.length > 0}
+      defaultExpanded={descriptions.length > 0 || hasNetworkDescriptions}
       title={formatMessage({ id: 'Description' })}
       icon={
         permissions.isAuth &&
@@ -59,15 +74,13 @@ const Descriptions = ({
               isFormVisible
                 ? formatMessage({ id: 'Cancel adding a new description' })
                 : formatMessage({ id: 'Add a new description' })
-            }
-          >
+            }>
             <Button
               color={isFormVisible ? 'inherit' : 'secondary'}
               size="small"
               variant="outlined"
               onClick={() => setIsFormVisible(!isFormVisible)}
-              startIcon={isFormVisible ? <CancelIcon /> : <AddCircleIcon />}
-            >
+              startIcon={isFormVisible ? <CancelIcon /> : <AddCircleIcon />}>
               {formatMessage({ id: isFormVisible ? 'Cancel' : 'New' })}
             </Button>
           </Tooltip>
@@ -75,6 +88,51 @@ const Descriptions = ({
       }
       content={
         <>
+          {hasNetworkDescriptions && (
+            <>
+              <Divider sx={{ mb: 1 }} />
+              <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
+                <FormattedMessage
+                  id="network.descriptions.callout"
+                  values={{
+                    networkLink: (
+                      <MuiLink
+                        component="button"
+                        variant="body1"
+                        onClick={() => openLink(`/ui/caves/${networkId}`)}
+                        sx={{ display: 'inline', verticalAlign: 'baseline' }}>
+                        <Box
+                          component="span"
+                          sx={{
+                            display: 'inline-block',
+                            verticalAlign: 'middle',
+                            mr: '2px'
+                          }}>
+                          <CustomIcon type="network" size={18} />
+                        </Box>
+                        {networkName}
+                      </MuiLink>
+                    ),
+                    descriptionsLink: (
+                      <MuiLink
+                        component="button"
+                        variant="body1"
+                        onClick={() =>
+                          openLink(`/ui/caves/${networkId}#description`)
+                        }
+                        sx={{ display: 'inline', verticalAlign: 'baseline' }}>
+                        {formatMessage(
+                          { id: 'network.descriptions.count' },
+                          { count: networkDescriptionsCount }
+                        )}
+                      </MuiLink>
+                    )
+                  }}
+                />
+              </Typography>
+            </>
+          )}
+
           {isFormVisible && (
             <>
               <CreateDescriptionForm isNewDescription onSubmit={onSubmitForm} />
@@ -125,7 +183,10 @@ Descriptions.propTypes = {
   entityId: PropTypes.number.isRequired,
   descriptions: PropTypes.arrayOf(DescriptionPropTypes),
   isEditAllowed: PropTypes.bool,
-  isAddAllowed: PropTypes.bool
+  isAddAllowed: PropTypes.bool,
+  networkId: PropTypes.number,
+  networkName: PropTypes.string,
+  networkDescriptionsCount: PropTypes.number
 };
 
 export default Descriptions;

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -135,8 +135,10 @@ export const Entry = ({ isLoading, error, entrance, networkDescriptionsCount = 0
     isAuth && entrance?.cave?.id && !entrance?.isDeleted;
   const canEdit = isAuth && entrance && !entrance.isDeleted;
 
+  const isNetwork = entrance?.cave?.entrances?.length > 1;
+
   const snapshotUrl = entrance
-    ? `/ui/entrances/${entrance.id}/snapshots?isNetwork=${entrance.cave?.entrances?.length > 1}`
+    ? `/ui/entrances/${entrance.id}/snapshots?isNetwork=${isNetwork}`
     : null;
 
   const actions = entrance ? (
@@ -247,7 +249,7 @@ export const Entry = ({ isLoading, error, entrance, networkDescriptionsCount = 0
           ))}
         </Box>
       )}
-      {entrance.cave?.entrances?.length > 1 && (
+      {isNetwork && (
         <Link
           component={RouterLink}
           to={`/ui/caves/${entrance.cave.id}`}
@@ -423,8 +425,8 @@ export const Entry = ({ isLoading, error, entrance, networkDescriptionsCount = 0
                 entityType="entrance"
                 entityId={entrance.id}
                 isEditAllowed={!entrance.isDeleted}
-                networkId={entrance.cave?.entrances?.length > 1 ? entrance.cave?.id : undefined}
-                networkName={entrance.cave?.entrances?.length > 1 ? entrance.cave?.name : undefined}
+                networkId={isNetwork ? entrance.cave.id : undefined}
+                networkName={isNetwork ? entrance.cave.name : undefined}
                 networkDescriptionsCount={networkDescriptionsCount}
               />
               <Riggings

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -74,7 +74,7 @@ const HalfSplitContainer = styled('div')`
   }
 `;
 
-export const Entry = ({ isLoading, error, entrance }) => {
+export const Entry = ({ isLoading, error, entrance, networkDescriptionsCount = 0 }) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
@@ -423,6 +423,9 @@ export const Entry = ({ isLoading, error, entrance }) => {
                 entityType="entrance"
                 entityId={entrance.id}
                 isEditAllowed={!entrance.isDeleted}
+                networkId={entrance.cave?.entrances?.length > 1 ? entrance.cave?.id : undefined}
+                networkName={entrance.cave?.entrances?.length > 1 ? entrance.cave?.name : undefined}
+                networkDescriptionsCount={networkDescriptionsCount}
               />
               <Riggings
                 riggings={entrance.riggings}
@@ -490,7 +493,8 @@ export const Entry = ({ isLoading, error, entrance }) => {
 Entry.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   error: PropTypes.shape({}),
-  entrance: EntrancePropTypes
+  entrance: EntrancePropTypes,
+  networkDescriptionsCount: PropTypes.number
 };
 
 export default Entry;

--- a/packages/web-app/src/pages/Entry/index.jsx
+++ b/packages/web-app/src/pages/Entry/index.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Entry from '../../components/appli/Entry';
 import { fetchEntrance } from '../../actions/Entrance/GetEntrance';
-import { fetchCave } from '../../actions/Cave/GetCave';
+import { fetchNetworkCaveDescriptionsCount } from '../../actions/Cave/GetNetworkCaveDescriptionsCount';
 import { usePermissions } from '../../hooks';
 import {
   Deleted,
@@ -15,7 +15,9 @@ const EntryPage = () => {
   const { entranceId } = useParams();
   const permissions = usePermissions();
   const { loading, data, error } = useSelector(state => state.entrance);
-  const { cave: networkCave } = useSelector(state => state.cave);
+  const networkDescriptionsCount = useSelector(
+    state => state.cave.networkDescriptionsCount
+  );
 
   useEffect(() => {
     dispatch(fetchEntrance(entranceId));
@@ -24,11 +26,8 @@ const EntryPage = () => {
   const networkCaveId = data?.cave?.entrances?.length > 1 ? data?.cave?.id : undefined;
 
   useEffect(() => {
-    if (networkCaveId) dispatch(fetchCave(networkCaveId));
+    if (networkCaveId) dispatch(fetchNetworkCaveDescriptionsCount(networkCaveId));
   }, [networkCaveId, dispatch]);
-
-  const networkDescriptionsCount =
-    networkCave?.id === networkCaveId ? (networkCave?.descriptions?.length ?? 0) : 0;
 
   return data?.isDeleted && !permissions.isModerator ? (
     <Deleted entityType={DELETED_ENTITIES.entrance} entity={data} />

--- a/packages/web-app/src/pages/Entry/index.jsx
+++ b/packages/web-app/src/pages/Entry/index.jsx
@@ -3,7 +3,10 @@ import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Entry from '../../components/appli/Entry';
 import { fetchEntrance } from '../../actions/Entrance/GetEntrance';
-import { fetchNetworkCaveDescriptionsCount } from '../../actions/Cave/GetNetworkCaveDescriptionsCount';
+import {
+  fetchNetworkCaveDescriptionsCount,
+  resetNetworkCaveDescriptionsCount
+} from '../../actions/Cave/GetNetworkCaveDescriptionsCount';
 import { usePermissions } from '../../hooks';
 import {
   Deleted,
@@ -21,6 +24,7 @@ const EntryPage = () => {
 
   useEffect(() => {
     dispatch(fetchEntrance(entranceId));
+    dispatch(resetNetworkCaveDescriptionsCount());
   }, [entranceId, dispatch]);
 
   const networkCaveId = data?.cave?.entrances?.length > 1 ? data?.cave?.id : undefined;

--- a/packages/web-app/src/pages/Entry/index.jsx
+++ b/packages/web-app/src/pages/Entry/index.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Entry from '../../components/appli/Entry';
 import { fetchEntrance } from '../../actions/Entrance/GetEntrance';
+import { fetchCave } from '../../actions/Cave/GetCave';
 import { usePermissions } from '../../hooks';
 import {
   Deleted,
@@ -14,15 +15,30 @@ const EntryPage = () => {
   const { entranceId } = useParams();
   const permissions = usePermissions();
   const { loading, data, error } = useSelector(state => state.entrance);
+  const { cave: networkCave } = useSelector(state => state.cave);
 
   useEffect(() => {
     dispatch(fetchEntrance(entranceId));
   }, [entranceId, dispatch]);
 
+  const networkCaveId = data?.cave?.entrances?.length > 1 ? data?.cave?.id : undefined;
+
+  useEffect(() => {
+    if (networkCaveId) dispatch(fetchCave(networkCaveId));
+  }, [networkCaveId, dispatch]);
+
+  const networkDescriptionsCount =
+    networkCave?.id === networkCaveId ? (networkCave?.descriptions?.length ?? 0) : 0;
+
   return data?.isDeleted && !permissions.isModerator ? (
     <Deleted entityType={DELETED_ENTITIES.entrance} entity={data} />
   ) : (
-    <Entry isLoading={loading} error={error} entrance={data} />
+    <Entry
+      isLoading={loading}
+      error={error}
+      entrance={data}
+      networkDescriptionsCount={networkDescriptionsCount}
+    />
   );
 };
 

--- a/packages/web-app/src/reducers/CaveReducer.js
+++ b/packages/web-app/src/reducers/CaveReducer.js
@@ -5,6 +5,7 @@ import {
   FETCH_CAVE_ERROR,
   FETCH_CAVE_LOADING
 } from '../actions/Cave/GetCave';
+import { FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS } from '../actions/Cave/GetNetworkCaveDescriptionsCount';
 import {
   DELETE_CAVE_SUCCESS,
   DELETE_CAVE_PERMANENT_SUCCESS
@@ -21,6 +22,7 @@ import { MOVE_DESCRIPTION_RELEVANCE_SUCCESS } from '../actions/Description/MoveR
 
 const initialState = {
   cave: undefined,
+  networkDescriptionsCount: 0,
   loading: false,
   error: null
 };
@@ -47,6 +49,9 @@ const reducer = (state = initialState, action) => {
         loading: false,
         error: action.error
       };
+
+    case FETCH_NETWORK_CAVE_DESCRIPTIONS_COUNT_SUCCESS:
+      return { ...state, networkDescriptionsCount: action.count };
 
     case POST_DESCRIPTION_SUCCESS:
     case UPDATE_DESCRIPTION_SUCCESS:


### PR DESCRIPTION
# feat(entrance): add network description link

## 🤔 What

On the entrance page, when the entrance belongs to a network (a cave with 2+ entrances), show a callout in the Descriptions panel that links to the network and its description count.

## 🤷‍♂️ Why

Network descriptions are stored on the cave, not on the individual entrance. Previously, nothing indicated their existence when viewing an entrance — users had no path to find them from the entrance page.

## 🔍 How

- `EntryPage` fetches the network cave when `entrance.cave.entrances.length > 1`, reads `descriptions.length` from Redux state, and passes `networkDescriptionsCount` down
- `Entry` forwards `networkId`, `networkName`, and `networkDescriptionsCount` to the `Descriptions` panel
- `Descriptions` renders a callout with two inline `MuiLink` buttons: one opening `/ui/caves/<id>` (network page) and one opening `/ui/caves/<id>#description` (anchor to descriptions), via `useOpenLink`
- The panel auto-expands when network descriptions exist, even if the entrance itself has none
- i18n keys `network.descriptions.callout` and `network.descriptions.count` added to all lang files

## 🔗 Related API PR

None.

## 🧪 Testing

1. Open an entrance that belongs to a network (cave with 2+ entrances)
2. The Descriptions panel should show a callout mentioning the network name and description count
3. Click the network link → navigates to `/ui/caves/<id>`
4. Click the descriptions count link → navigates to `/ui/caves/<id>#description`
5. Open an entrance that does **not** belong to a network → no callout

## 📸 Previews

<img width="1649" height="723" alt="image" src="https://github.com/user-attachments/assets/8d6b1f1f-f27f-42c1-8e04-53b64d694711" />

