### PR TITLE
fix(map): center explored entrances map reliably on load

### DIFF
--- a/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
@@ -11,12 +11,18 @@ import useExploredEntrances from './useExploredEntrances';
 // (never a hardcoded region). BoundsFitter then refines the exact zoom/padding.
 const getInitialCenter = points => {
   if (points.length === 0) return [20, 0]; // defensive; map renders only with data
-  const lats = points.map(p => p.latitude);
-  const lngs = points.map(p => p.longitude);
-  return [
-    (Math.min(...lats) + Math.max(...lats)) / 2,
-    (Math.min(...lngs) + Math.max(...lngs)) / 2
-  ];
+  // Single pass — avoids spreading a potentially large array onto the call stack.
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+  points.forEach(({ latitude, longitude }) => {
+    if (latitude < minLat) minLat = latitude;
+    if (latitude > maxLat) maxLat = latitude;
+    if (longitude < minLng) minLng = longitude;
+    if (longitude > maxLng) maxLng = longitude;
+  });
+  return [(minLat + maxLat) / 2, (minLng + maxLng) / 2];
 };
 
 const ExploredEntrancesMapInner = ({ points }) => (
@@ -58,7 +64,7 @@ const ExploredEntrancesMap = ({ userId }) => {
       <CustomMapContainer
         wholePage={false}
         center={initialCenter}
-        zoom={5}
+        zoom={5} // placeholder until BoundsFitter fits to the points
         dragging={!isMobile}
         scrollWheelZoom={false}>
         <ExploredEntrancesMapInner points={points} />

--- a/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Skeleton } from '@mui/material';
 import { isMobile } from 'react-device-detect';
 import CustomMapContainer from '../common/MapContainer';
 import ExploredOverlay from './ExploredOverlay';
 import useExploredEntrances from './useExploredEntrances';
+
+// Initial view derived from the points themselves — the map only mounts once data
+// is present, so we centre on the bounding-box centre of the explored entrances
+// (never a hardcoded region). BoundsFitter then refines the exact zoom/padding.
+const getInitialCenter = points => {
+  if (points.length === 0) return [20, 0]; // defensive; map renders only with data
+  const lats = points.map(p => p.latitude);
+  const lngs = points.map(p => p.longitude);
+  return [
+    (Math.min(...lats) + Math.max(...lats)) / 2,
+    (Math.min(...lngs) + Math.max(...lngs)) / 2
+  ];
+};
 
 const ExploredEntrancesMapInner = ({ points }) => (
   <ExploredOverlay points={points} shouldFitMapBound />
@@ -26,6 +39,8 @@ const ExploredEntrancesMap = ({ userId }) => {
     enabled: true
   });
 
+  const initialCenter = useMemo(() => getInitialCenter(points), [points]);
+
   if (!userId) return null;
   if (hasExploredData === null) {
     return (
@@ -42,6 +57,8 @@ const ExploredEntrancesMap = ({ userId }) => {
     <Box sx={{ mb: 3 }}>
       <CustomMapContainer
         wholePage={false}
+        center={initialCenter}
+        zoom={5}
         dragging={!isMobile}
         scrollWheelZoom={false}>
         <ExploredEntrancesMapInner points={points} />

--- a/packages/web-app/src/components/common/Maps/MapClusters/ExploredOverlay.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/ExploredOverlay.jsx
@@ -39,21 +39,47 @@ const exploredBadgeIcon = L.divIcon({
 // Module-level: stable reference so useMarkers's useCallback deps don't change.
 const BADGE_MARKER_OPTIONS = { zIndexOffset: 1000, keyboard: false };
 
-// Fits the map to the explored points, debounced so progressive batches settle first.
+// Fits the map to the explored points.
+//
+// The map often mounts inside a tab or a collapsible whose Leaflet container is
+// still zero-sized or mid-animation. fitBounds against such a stale viewport lands
+// on wrong coordinates (≈0,0, open ocean) — and a one-shot fit would stay there
+// until a full page reload. So we fit only once the container has a real size, and
+// re-fit on every Leaflet `resize` (CustomMapContainer emits these via invalidateSize
+// as the container settles to its final size) until the user takes over.
 const BoundsFitter = ({ points }) => {
   const map = useMap();
-  const hasFittedRef = useRef(false);
+  const isProgrammaticRef = useRef(false);
 
   useEffect(() => {
-    if (hasFittedRef.current || points.length === 0) return;
-    const timer = setTimeout(() => {
-      hasFittedRef.current = true;
-      map.fitBounds(
-        points.map(p => [p.latitude, p.longitude]),
-        { padding: [40, 40], maxZoom: 16 }
-      );
-    }, 300);
-    return () => clearTimeout(timer);
+    if (points.length === 0) return undefined;
+
+    const bounds = points.map(p => [p.latitude, p.longitude]);
+
+    const fit = () => {
+      const { x, y } = map.getSize();
+      if (x === 0 || y === 0) return; // container not laid out yet
+      isProgrammaticRef.current = true;
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 16, animate: false });
+      isProgrammaticRef.current = false;
+    };
+
+    // Stop auto-fitting once the user interacts — but ignore the move events our
+    // own fitBounds emits (synchronous thanks to animate: false, so the guard holds).
+    const stopAutoFit = () => {
+      if (isProgrammaticRef.current) return;
+      map.off('resize', fit);
+      map.off('dragstart zoomstart', stopAutoFit);
+    };
+
+    fit(); // immediate, in case the container is already sized
+    map.on('resize', fit);
+    map.on('dragstart zoomstart', stopAutoFit);
+
+    return () => {
+      map.off('resize', fit);
+      map.off('dragstart zoomstart', stopAutoFit);
+    };
   }, [map, points]);
 
   return null;


### PR DESCRIPTION
## 🤔 What

Fix the explored-entrances map on the Account and Person profile pages
initializing on wrong coordinates (open ocean) until a full page refresh (F5).
The bug was intermittent.

Closes #1422

## 🤷‍♂️ Why

The map mounts inside a tab and a collapsible (`ScrollableContent`), so its
Leaflet container is often still zero-sized or mid-animation at mount time.
`CustomMapContainer` corrects the size asynchronously via a `ResizeObserver` →
`invalidateSize`.

`BoundsFitter` ran `fitBounds` exactly once, on a blind 300 ms timer, behind a
permanent one-shot guard. When the timer fired before the container reached its
final size, `fitBounds` computed against a stale/zero viewport, landed on the
wrong center+zoom (≈ 0,0), and the one-shot guard made it permanent until reload.
Whether the timer won or lost the race against the resize explained the
intermittency.

Aggravating factor: the map received no initial `center`/`zoom`, so before the
first successful fit it sat at Leaflet's ≈ 0,0 default (open ocean).

## 🔍 How

- **Rewrite `BoundsFitter`** (`ExploredOverlay.jsx`): drop the blind timer and
  the permanent one-shot guard. `fit()` only runs once `map.getSize()` is
  non-zero, and re-fits on every Leaflet `resize` (emitted by
  `CustomMapContainer` via `invalidateSize` as the container settles) until the
  user interacts (`dragstart`/`zoomstart`). Our own `fitBounds` moves are ignored
  via an `isProgrammaticRef` guard (reliable because `animate: false` makes the
  events synchronous). This converges to the correct framing regardless of the
  mount / data-arrival / resize ordering.
- **Derive the initial center** (`ExploredEntrancesMap.jsx`) from the explored
  points' bounding-box center instead of a hardcoded region, so the map is
  always initialized on the user's actual data — anywhere in the world.

## 🔗 Related API PR

_None — frontend-only fix._

## 🧪 Testing

1. Log in with an account that has explored entrances
2. Go to the Account page → Activities tab → "Explored entrances" section
3. The map must center on the explored entrances on first load, **without** a
   refresh — repeat a few times (it was intermittent)
4. Same check on a Person profile page
5. Verify an account whose entrances are outside Europe also centers correctly
6. Pan/zoom the map, then toggle fullscreen — the map should not fight the user
   after interaction

## 📸 Previews

_Before: map showed open ocean until F5. After: centered on the explored
entrances on first load._
