### PR TITLE
fix(map): adapt map height to adjacent content

### DIFF
--- a/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
+++ b/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
@@ -16,7 +16,8 @@ const Wrapper = styled('div', {
 })(
   ({ theme, $wholePage }) => `
   width: 100%;
-  height: 400px;
+  height: 100%;
+  min-height: 400px;
 
 ${$wholePage && `height: calc(100vh - ${theme.appBarHeight}px); /* fallback for old browsers */`}
 ${$wholePage && `height: calc(100dvh - ${theme.appBarHeight}px);`}


### PR DESCRIPTION
## 🤔 What

- The map height on entrance and cavity pages now adapts to the height of the adjacent content panel
- Removes the empty space that appeared below the map when the information panel was taller than 400px

Closes #1426

## 🤷‍♂️ Why

When the adjacent content (localisation, characteristics, vigilance points, data quality…) exceeds 400px, the map container was left with a visible blank area underneath, creating an unbalanced layout.

## 🔍 How

Single-line change in `MapContainer.jsx`: replaced the fixed `height: 400px` with `height: 100%; min-height: 400px`.

The parent `HalfSplitContainer` already uses `align-items: stretch` (flex row on desktop), so both columns grow to the same height. Switching the map wrapper to `height: 100%` lets it fill that stretched height rather than staying capped at 400px.

On mobile (stacked column layout), the parent has no fixed height, so `height: 100%` would collapse — `min-height: 400px` acts as the floor, preserving the existing mobile behaviour.

## 🔗 Related API PR

N/A

## 🧪 Testing

Open an entrance page where the right-hand panel is tall (e.g. https://grottocenter.org/ui/entrances/2772) and verify there is no blank space below the map.

## 📸 Previews

<img width="1420" height="829" alt="image" src="https://github.com/user-attachments/assets/63a81217-bef0-46df-8f40-65dd904b6ff4" />

