### PR TITLE
fix(map): restore display of embedded maps

### DIFF
--- a/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
+++ b/packages/web-app/src/components/common/Maps/common/MapContainer.jsx
@@ -15,6 +15,8 @@ const Wrapper = styled('div', {
   shouldForwardProp: prop => !prop.startsWith('$')
 })(
   ({ theme, $wholePage }) => `
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
   min-height: 400px;
@@ -149,7 +151,7 @@ const CustomMapContainer = ({
   return (
     <Wrapper $wholePage={wholePage}>
       <MapContainer
-        style={{ height: '100%', width: '100%', ...style }}
+        style={{ flex: '1 1 auto', minHeight: 0, width: '100%', ...style }}
         wholePage={wholePage}
         center={center}
         zoom={zoom}


### PR DESCRIPTION
# fix(map): restore display of embedded maps

## 🤔 What

- Fixes embedded maps (`wholePage={false}`) no longer rendering — e.g. the "Explored entrances" map on the personal/account page, as well as the Country, Region and Organization maps.
- Only the white placeholder area was shown, with no actual Leaflet map.

## 🤷‍♂️ Why

A recent change (#1429, _"adapt map height to adjacent content"_) replaced the map `Wrapper`'s definite `height: 400px` with `height: 100%`.

For embedded maps the parent container has no defined height, so:

- `height: 100%` on the `Wrapper` resolves to `auto`
- the inner Leaflet `<MapContainer>` (`height: 100%`) then resolves against an indefinite parent and **collapses to 0**
- only the white `min-height: 400px` box remains, with no visible map

The full-page map kept working because its `height: calc(100dvh …)` is a definite value.

## 🔍 How

In `MapContainer.jsx`, made the `Wrapper` a flex column so the layout height is driven reliably in both cases:

- `Wrapper`: added `display: flex; flex-direction: column;` (keeping `height: 100%; min-height: 400px`)
- inner `<MapContainer>`: `height: '100%'` → `flex: '1 1 auto', minHeight: 0`

Result:

- **Embedded map, no parent height** → flex column falls back to `min-height: 400px`, the map fills it.
- **Parent with a real height (or full-page)** → the `Wrapper` fills it and the map grows with it, preserving #1429's "adapt to adjacent content" goal.
- Consumers passing an explicit `style.height` (e.g. `MapMarkerSelector`, `MapLine`) still override via `...style`.

## 🔗 Related API PR

_None._

## 🧪 Testing

1. Open the personal/account page and check the "Explored entrances" map renders.
2. Check the Country, Region and Organization detail maps still render.
3. Check the full-page map (MapClusters) is unchanged.

## 📸 Previews

_To be added._
