### PR TITLE
feat(map): reveal network entrances on hover and refine map popups

### DIFF
--- a/packages/web-app/src/App.css
+++ b/packages/web-app/src/App.css
@@ -72,6 +72,35 @@ code {
   margin: 2px 0;
 }
 
+/*
+ * Compact popup title (map info-card style, not an h-heading).
+ * Scoped with the parent so specificity (0,2,0) reliably beats MUI's single
+ * generated font-size class (0,1,0), regardless of stylesheet injection order.
+ * rem keeps it responsive to the user's root font-size (accessibility).
+ */
+.map-popup-property .map-popup-title {
+  font-size: 1.7rem;
+  font-weight: 600;
+  line-height: 1.3;
+  /* MUI renders subtitle1 as an <h6>, which inherits Skeleton's global
+     `h1..h6 { margin-bottom: 2rem }`. Override it here (scoped) rather than
+     changing the global heading margin app-wide. */
+  margin-bottom: 1rem;
+  /* Reserve room for Leaflet's absolutely-positioned close button (top-right),
+     so a long title wraps instead of running under the × */
+  padding-right: 5px;
+}
+
+/*
+ * Popup links (GCLink renders a bare <a> with no app styling, so in the
+ * detached popup HTML it falls back to the browser-default blue). Align with
+ * the app convention: MUI <Link> defaults to palette.primary.main (brown[700]).
+ * Also avoids clashing with blue, which now means "network highlight".
+ */
+.leaflet-popup-content a {
+  color: #5d4037;
+}
+
 .map-popup-property > img,
 .map-popup-property > svg {
   margin-right: 0;

--- a/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
@@ -42,10 +42,7 @@ const Markers = ({
   // no hover), and only hide on mouseout when nothing is pinned.
   const pinnedNetworkRef = useRef(null);
 
-  const handleNetworkOver = useCallback(
-    network => showHighlight(network),
-    [showHighlight]
-  );
+  const handleNetworkOver = showHighlight;
   const handleNetworkOut = useCallback(() => {
     if (pinnedNetworkRef.current == null) hideHighlight();
   }, [hideHighlight]);

--- a/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/Markers.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { includes, values } from 'ramda';
 import PropTypes from 'prop-types';
 import { heatmapTypes } from './DataControl';
 import useMarkers, { MarkerGlobalCss } from '../common/Markers/useMarkers';
+import useNetworkHighlight from './useNetworkHighlight';
 import { getEntranceCircleStyle } from './constants';
 import {
   OrganizationMarker,
@@ -36,6 +37,30 @@ const Markers = ({
   entrances = [],
   networks = []
 }) => {
+  const { showHighlight, hideHighlight } = useNetworkHighlight();
+  // Keep the highlight visible while a network popup is open (touch devices have
+  // no hover), and only hide on mouseout when nothing is pinned.
+  const pinnedNetworkRef = useRef(null);
+
+  const handleNetworkOver = useCallback(
+    network => showHighlight(network),
+    [showHighlight]
+  );
+  const handleNetworkOut = useCallback(() => {
+    if (pinnedNetworkRef.current == null) hideHighlight();
+  }, [hideHighlight]);
+  const handleNetworkPopupOpen = useCallback(
+    network => {
+      pinnedNetworkRef.current = network.id;
+      showHighlight(network);
+    },
+    [showHighlight]
+  );
+  const handleNetworkPopupClose = useCallback(() => {
+    pinnedNetworkRef.current = null;
+    hideHighlight();
+  }, [hideHighlight]);
+
   const updateEntranceMarkers = useMarkers({
     circleMarkerStyle: getEntranceCircleStyle,
     popupContent: entrancePopup,
@@ -44,7 +69,11 @@ const Markers = ({
   const updateNetworkMarkers = useMarkers({
     icon: NetworkMarker,
     popupContent: networkPopup,
-    tooltipContent: networkTip
+    tooltipContent: networkTip,
+    onMarkerOver: handleNetworkOver,
+    onMarkerOut: handleNetworkOut,
+    onPopupOpen: handleNetworkPopupOpen,
+    onPopupClose: handleNetworkPopupClose
   });
   const updateOrganizationMarkers = useMarkers({
     icon: OrganizationMarker,
@@ -57,8 +86,14 @@ const Markers = ({
   }, [entrances, visibleMarkers, updateEntranceMarkers]);
 
   useEffect(() => {
-    updateNetworkMarkers(isNetworks(visibleMarkers) ? networks : null);
-  }, [networks, visibleMarkers, updateNetworkMarkers]);
+    const networksVisible = isNetworks(visibleMarkers);
+    updateNetworkMarkers(networksVisible ? networks : null);
+    // Drop any lingering highlight when the network layer is hidden.
+    if (!networksVisible) {
+      pinnedNetworkRef.current = null;
+      hideHighlight();
+    }
+  }, [networks, visibleMarkers, updateNetworkMarkers, hideHighlight]);
 
   useEffect(() => {
     updateOrganizationMarkers(

--- a/packages/web-app/src/components/common/Maps/MapClusters/constants.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/constants.js
@@ -106,6 +106,47 @@ export const ENTRANCE_HEAT_COLORS = [brown[200], brown[900]];
 export const NETWORK_HEAT_COLORS = [blue[200], blue[900]];
 export const MASSIF_HEAT_COLORS = [green[200], green[900]];
 
+// Network highlight overlay — revealed on hover/tap of a network marker to show
+// which entrances belong to it, even when the entrances layer is hidden.
+//
+// Visual hierarchy (strongest → faintest): highlighted entrances > spokes > hull.
+// Blue is the network semantic in this app (networks heatmap), so the surfaced
+// entrances read as "this network's entrances" and stand out from brown caves.
+export const NETWORK_HIGHLIGHT_ACCENT = blue[700];
+// Blue hull recedes to the background — it only conveys rough footprint.
+export const NETWORK_HULL_STYLE = {
+  color: NETWORK_HIGHLIGHT_ACCENT,
+  weight: 1,
+  opacity: 0.6,
+  fillColor: NETWORK_HIGHLIGHT_ACCENT,
+  fillOpacity: 0.06,
+  dashArray: '4 4',
+  interactive: false
+};
+export const NETWORK_SPOKE_STYLE = {
+  color: NETWORK_HIGHLIGHT_ACCENT,
+  weight: 1.5,
+  opacity: 0.65,
+  interactive: false
+};
+// Ghost entrances are drawn as two stacked circles: a translucent halo for the
+// "glow", then a solid white-ringed core so they pop against brown/orange caves.
+export const NETWORK_ENTRANCE_HALO_STYLE = {
+  radius: 9,
+  stroke: false,
+  fillColor: NETWORK_HIGHLIGHT_ACCENT,
+  fillOpacity: 0.25,
+  interactive: false
+};
+export const NETWORK_ENTRANCE_GHOST_STYLE = {
+  radius: 5,
+  color: '#FFFFFF',
+  weight: 2,
+  fillColor: NETWORK_HIGHLIGHT_ACCENT,
+  fillOpacity: 1,
+  interactive: false
+};
+
 // Massif polygon style for the Leaflet GeoJSON layer
 export const MASSIF_POLYGON_STYLE = {
   color: green[700],

--- a/packages/web-app/src/components/common/Maps/MapClusters/useNetworkHighlight.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/useNetworkHighlight.js
@@ -40,6 +40,11 @@ const useNetworkHighlight = () => {
       const entrances = (network?.entrances ?? []).filter(hasCoords);
       if (entrances.length === 0) return;
 
+      if (
+        typeof network.latitude !== 'number' ||
+        typeof network.longitude !== 'number'
+      )
+        return;
       const center = [network.latitude, network.longitude];
 
       // Convex hull needs at least 3 points. d3 works on planar [x, y];

--- a/packages/web-app/src/components/common/Maps/MapClusters/useNetworkHighlight.js
+++ b/packages/web-app/src/components/common/Maps/MapClusters/useNetworkHighlight.js
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import * as L from 'leaflet';
+import { polygonHull } from 'd3-polygon';
+import {
+  NETWORK_HULL_STYLE,
+  NETWORK_SPOKE_STYLE,
+  NETWORK_ENTRANCE_HALO_STYLE,
+  NETWORK_ENTRANCE_GHOST_STYLE
+} from './constants';
+
+const hasCoords = e =>
+  typeof e?.latitude === 'number' && typeof e?.longitude === 'number';
+
+// Draws a temporary overlay linking a network to its entrances:
+// a convex-hull footprint, spokes from the centroid to each entrance,
+// and ghost markers for the entrances. Rendered on demand (hover/tap) so
+// it works even when the entrances layer is toggled off, without cluttering
+// the map at rest.
+const useNetworkHighlight = () => {
+  const map = useMap();
+  const layerRef = useRef(null);
+
+  const getLayer = useCallback(() => {
+    if (!layerRef.current) {
+      layerRef.current = L.layerGroup().addTo(map);
+    }
+    return layerRef.current;
+  }, [map]);
+
+  const hideHighlight = useCallback(() => {
+    if (layerRef.current) layerRef.current.clearLayers();
+  }, []);
+
+  const showHighlight = useCallback(
+    network => {
+      const layer = getLayer();
+      layer.clearLayers();
+
+      const entrances = (network?.entrances ?? []).filter(hasCoords);
+      if (entrances.length === 0) return;
+
+      const center = [network.latitude, network.longitude];
+
+      // Convex hull needs at least 3 points. d3 works on planar [x, y];
+      // lng/lat is fine here since we only need the enclosing shape.
+      if (entrances.length >= 3) {
+        const hull = polygonHull(entrances.map(e => [e.longitude, e.latitude]));
+        if (hull) {
+          L.polygon(
+            hull.map(([lng, lat]) => [lat, lng]),
+            NETWORK_HULL_STYLE
+          ).addTo(layer);
+        }
+      }
+
+      // Draw in z-order (later = on top): spokes, then entrance halos, then
+      // the solid cores, so the highlighted entrances always sit above the lines.
+      entrances.forEach(e => {
+        L.polyline(
+          [center, [e.latitude, e.longitude]],
+          NETWORK_SPOKE_STYLE
+        ).addTo(layer);
+      });
+      entrances.forEach(e => {
+        L.circleMarker(
+          [e.latitude, e.longitude],
+          NETWORK_ENTRANCE_HALO_STYLE
+        ).addTo(layer);
+      });
+      entrances.forEach(e => {
+        L.circleMarker(
+          [e.latitude, e.longitude],
+          NETWORK_ENTRANCE_GHOST_STYLE
+        ).addTo(layer);
+      });
+    },
+    [getLayer]
+  );
+
+  useEffect(
+    () => () => {
+      if (layerRef.current) {
+        layerRef.current.remove();
+        layerRef.current = null;
+      }
+    },
+    []
+  );
+
+  return { showHighlight, hideHighlight };
+};
+
+export default useNetworkHighlight;

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/EntrancePopup.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/EntrancePopup.jsx
@@ -61,8 +61,6 @@ EntrancePopup.propTypes = {
     name: PropTypes.string,
     region: PropTypes.string,
     city: PropTypes.string,
-    longitude: PropTypes.number,
-    latitude: PropTypes.number,
     caveName: PropTypes.string,
     caveId: PropTypes.number,
     depth: PropTypes.number,

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/EntrancePopup.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/EntrancePopup.jsx
@@ -7,7 +7,7 @@ import {
   getDataQualityValue,
   getDataQualityLabelKey
 } from '../../../../../../utils/dataQuality';
-import { Information, makeCoordinatesValue } from './utils';
+import { Information } from './utils';
 
 export const EntrancePopup = ({ entrance }) => {
   const { formatMessage } = useIntl();
@@ -33,10 +33,6 @@ export const EntrancePopup = ({ entrance }) => {
           icon={<CustomIcon size={25} type="location" />}
         />
       )}
-      <Information
-        value={makeCoordinatesValue(entrance.latitude, entrance.longitude)}
-        icon={<CustomIcon size={25} type="coordinates" />}
-      />
       {entrance.depth > 0 && (
         <Information
           value={`${entrance.depth} m`}

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationPopup.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationPopup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CustomIcon from '../../../../CustomIcon';
-import { Information, makeCoordinatesValue } from './utils';
+import { Information } from './utils';
 
 export const OrganizationPopup = ({ organization }) => (
   <>
@@ -16,10 +16,6 @@ export const OrganizationPopup = ({ organization }) => (
         icon={<CustomIcon size={25} type="location" />}
       />
     )}
-    <Information
-      value={makeCoordinatesValue(organization.latitude, organization.longitude)}
-      icon={<CustomIcon size={25} type="coordinates" />}
-    />
   </>
 );
 

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationPopup.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/OrganizationPopup.jsx
@@ -23,9 +23,7 @@ OrganizationPopup.propTypes = {
   organization: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.number,
-    address: PropTypes.string,
-    latitude: PropTypes.number,
-    longitude: PropTypes.number
+    address: PropTypes.string
   }).isRequired
 };
 

--- a/packages/web-app/src/components/common/Maps/common/Markers/Components/utils.js
+++ b/packages/web-app/src/components/common/Maps/common/Markers/Components/utils.js
@@ -10,7 +10,15 @@ export const makeCoordinatesValue = (latitude, longitude) =>
 export const Information = ({ icon, value, url, isTitle = false }) => (
   <div className="map-popup-property">
     {icon}
-    <Typography variant={isTitle ? 'h5' : 'body2'}>
+    {/*
+      Popup title kept to a compact card size rather than an h-heading. Styled via
+      the global `.map-popup-title` class (in App.css), not sx: popups are serialized
+      with renderToString into a detached HTML string where emotion's hashed sx
+      classes aren't injected — global classes always are. See sibling .map-popup-property.
+    */}
+    <Typography
+      variant={isTitle ? 'subtitle1' : 'body2'}
+      className={isTitle ? 'map-popup-title' : undefined}>
       {!url && value}
       {url && (
         <GCLink internal href={url}>

--- a/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
+++ b/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
@@ -20,6 +20,10 @@ const useMarkers = ({
   popupContent = null,
   tooltipContent = null,
   onMarkerClick = null,
+  onMarkerOver = null,
+  onMarkerOut = null,
+  onPopupOpen = null,
+  onPopupClose = null,
   shouldFitMapBound = false,
   markerOptions = null
 }) => {
@@ -58,9 +62,26 @@ const useMarkers = ({
         });
       }
 
+      if (onMarkerOver) markerEl.on('mouseover', () => onMarkerOver(marker));
+      if (onMarkerOut) markerEl.on('mouseout', () => onMarkerOut(marker));
+      if (onPopupOpen) markerEl.on('popupopen', () => onPopupOpen(marker));
+      if (onPopupClose) markerEl.on('popupclose', () => onPopupClose(marker));
+
       return markerEl;
     },
-    [icon, circleMarkerStyle, popupContent, renderPopup, tooltipContent, onMarkerClick, markerOptions]
+    [
+      icon,
+      circleMarkerStyle,
+      popupContent,
+      renderPopup,
+      tooltipContent,
+      onMarkerClick,
+      onMarkerOver,
+      onMarkerOut,
+      onPopupOpen,
+      onPopupClose,
+      markerOptions
+    ]
   );
 
   const updateMarkers = useCallback(

--- a/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
+++ b/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.js
@@ -62,6 +62,10 @@ const useMarkers = ({
         });
       }
 
+      // Listeners are cleaned up by Leaflet when markerEl.remove() is called.
+      // This relies on callbacks being stable references (useCallback with stable
+      // deps in Markers.jsx). If deps ever change identity, existing markers won't
+      // get updated listeners — updateMarkers only adds/removes, never replaces.
       if (onMarkerOver) markerEl.on('mouseover', () => onMarkerOver(marker));
       if (onMarkerOut) markerEl.on('mouseout', () => onMarkerOut(marker));
       if (onPopupOpen) markerEl.on('popupopen', () => onPopupOpen(marker));


### PR DESCRIPTION
# feat(map): reveal network entrances on hover and refine map popups

## 🤔 What

Two related improvements to the general map:

- **Network → entrances association**: hovering (or tapping on touch) a network marker now reveals which entrances belong to it, even when the entrances layer is hidden. The overlay draws:
  - blue **spokes** from the network centroid to each of its entrances,
  - highlighted **entrance markers** (blue core + halo) that stand out from the brown caves,
  - a discreet **convex-hull footprint** of the network.
- **Map popup refresh** (all types — entrances, caves/networks, organizations):
  - compact title (info-card size) instead of an oversized `h5` heading,
  - title no longer collides with the Leaflet close button,
  - links aligned with the app palette (brown, `primary.main`) instead of the browser-default blue,
  - removed the coordinates row from entrance and organization popups (no added value there).

## 🤷‍♂️ Why

The API now returns each network's entrances, but nothing on the map showed which entrances made up a network — and the answer had to hold even when the user chose not to display the entrances layer. A hover/tap reveal is the standard, low-clutter pattern for this.

Along the way, the shared popups had UX issues surfaced during testing: a giant title, a title running under the `×`, and links in browser-default blue that clashed with the app's brown/orange palette (and, now, with blue being used for the network highlight).

## 🔍 How

- New `useNetworkHighlight` hook manages a temporary Leaflet `LayerGroup`; the convex hull is computed with `d3-polygon`'s `polygonHull`. No extra API call — it uses the `entrances[]` already returned per network.
- `useMarkers` gained optional `onMarkerOver/Out` and `onPopupOpen/Close` handlers (all default `null`, backward-compatible with its other callers). `Markers.jsx` wires them: hover shows the highlight, and it stays pinned while a popup is open so touch devices (no hover) work via tap.
- Highlight styles live in `MapClusters/constants.js`; blue is the app's network semantic (networks heatmap).
- Popup title styled via a global `.map-popup-title` class in `App.css` (scoped specificity beats MUI's generated class) rather than `sx`, because popups are serialized with `renderToString` into detached HTML where emotion's hashed classes aren't injected. Same reasoning for the brown link color rule.
- Coordinates rows removed from `EntrancePopup`/`OrganizationPopup` (still reachable via the map right-click menu and the entity detail pages).

## 🔗 Related API PR

https://github.com/GrottoCenter/grottocenter-api/pull/1712

## 🧪 Testing

1. Open the general map and zoom in until network markers appear.
2. Hover a network marker (desktop) → spokes + blue entrances + faint hull appear, including entrances even if the entrances layer is toggled off.
3. Tap a network marker (mobile/touch) → same reveal while the popup is open.
4. Open entrance/cave/organization popups → compact title, no overlap with the `×`, brown links, no coordinates row.

## 📸 Previews

<img width="499" height="767" alt="image" src="https://github.com/user-attachments/assets/23685857-9552-44c2-b5e1-1b26b8f0c592" />
<img width="659" height="756" alt="image" src="https://github.com/user-attachments/assets/7fed7805-c102-4501-af3b-fb1e4d778665" />
<img width="1053" height="338" alt="image" src="https://github.com/user-attachments/assets/70b6d82f-4710-4e0d-8e4e-ff786a33b2cf" />
<img width="390" height="372" alt="image" src="https://github.com/user-attachments/assets/23565769-a7d0-4628-aaae-c46443e84bd1" />
<img width="559" height="777" alt="image" src="https://github.com/user-attachments/assets/3521de59-f6e0-40d1-b815-993fb38cca62" />



