### PR TITLE
feat(search): exclude documents and add networks to quick search

### DIFF
--- a/packages/web-app/src/components/appli/QuickSearch.jsx
+++ b/packages/web-app/src/components/appli/QuickSearch.jsx
@@ -53,7 +53,7 @@ const QuickSearch = ({ hasFixWidth, onClose }) => {
     }
     const criterias = {
       query: debouncedInput.trim(),
-      entities: ['entrances', 'documents', 'organizations', 'massifs']
+      entities: ['entrances', 'caves', 'organizations', 'massifs']
     };
 
     dispatch(fetchQuicksearchResult(criterias));


### PR DESCRIPTION
## 🤔 What

Rework the quick search entity set to improve usability (front-side part of #1430):

- Remove `document` from the default quick-search collections.
- Add `cave` so **networks** (caves with `nbEntrances > 1`) become findable by name.

Closes part of #1430 (front-side).

## 🤷‍♂️ Why

- **Documents overwhelm results** — the document collection is by far the largest in the database, so document hits flood the result list and drown out entrances, caves, massifs and organizations. Users of the quick search bar are typically navigating to a cave/entrance/massif, not looking for a bibliographic reference. Documents stay available in the advanced search.
- **Networks are not findable** — a network is a cave with more than one entrance. Networks were not part of the quick-search entity set, so a search for a known network name returned nothing meaningful.

## 🔍 How

Single change in [`QuickSearch.jsx`](packages/web-app/src/components/appli/QuickSearch.jsx): swap `'documents'` for `'caves'` in the `entities` sent to `POST /api/v1/search`.

```diff
-      entities: ['entrances', 'documents', 'organizations', 'massifs']
+      entities: ['entrances', 'caves', 'organizations', 'massifs']
```

Everything else was already in place:

- **Navigation** — `handleSelection` already routes `_type === 'caves'` to `/ui/caves/:id` (a network is a cave).
- **Rendering** — `nomelizeSearchEntity` (`helpers/Entity.jsx`) already shows the network icon for a cave with `nbEntrances > 1`, otherwise the entrance icon, with a region + depth/length subtitle.

No Redux/action changes needed — `entities` and `results` flow generically.

## 🔗 Related API PR

Nothing

## 🧪 Testing

1. Open the quick search bar and type a query.
2. Confirm no document results appear by default.
3. Search a known network name → the network appears with the network icon and navigates to its cave page on selection.

## 📸 Previews
<img width="866" height="770" alt="image" src="https://github.com/user-attachments/assets/eef7e0d4-f4a9-4aab-9691-6f2797acd830" />

