### PR TITLE
feat(snapshot): manage renamed entrances

### DIFF
--- a/packages/web-app/public/lang/ar.json
+++ b/packages/web-app/public/lang/ar.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "إزالة الحساسية",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "إزالة الحساسية عن الكتلة الجبلية لن يؤدي تلقائياً إلى إزالة علامة الحساسية عن المداخل الفردية.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "إزالة الحساسية عن الكتلة الجبلية لن يؤدي تلقائياً إلى إزالة علامة الحساسية عن المداخل الفردية. يجب إدارة هذه العلامات بشكل منفصل. هل تريد الاستمرار؟",
+  "Renamed": "أُعيد التسمية",
   "Repeat your password here.": "أعد كتابة كلمة المرور هنا.",
   "Report": "تقرير",
   "Report message": "الإبلاغ عن الرسالة",

--- a/packages/web-app/public/lang/bg.json
+++ b/packages/web-app/public/lang/bg.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Премахване на чувствителност",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Премахването на чувствителността от масива няма автоматично да премахне флага за чувствителност от отделните входове.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Премахването на чувствителността от масива няма автоматично да премахне флага за чувствителност от отделните входове. Тези флагове трябва да се управляват отделно. Искате ли да продължите?",
+  "Renamed": "Преименувано",
   "Repeat your password here.": "Повторете паролата си тук.",
   "Report": "Доклад",
   "Report message": "Докладване на съобщение",

--- a/packages/web-app/public/lang/ca.json
+++ b/packages/web-app/public/lang/ca.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Elimina la sensibilitat",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "L'eliminació de la sensibilitat del massís no eliminarà automàticament la marca de sensibilitat de les entrades individuals.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "L'eliminació de la sensibilitat del massís no eliminarà automàticament la marca de sensibilitat de les entrades individuals. Aquestes marques s'han de gestionar per separat. Vols continuar?",
+  "Renamed": "Reanomenat",
   "Repeat your password here.": "Repetiu aquí la vostra contrasenya.",
   "Report": "Informe",
   "Report message": "Denunciar missatge",

--- a/packages/web-app/public/lang/de.json
+++ b/packages/web-app/public/lang/de.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Sensibilität entfernen",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Das Entfernen der Sensibilität vom Massiv entfernt nicht automatisch die Sensibilitätskennzeichnung von einzelnen Eingängen.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Das Entfernen der Sensibilität vom Massiv entfernt nicht automatisch die Sensibilitätskennzeichnung von einzelnen Eingängen. Diese Kennzeichnungen müssen separat verwaltet werden. Möchten Sie fortfahren?",
+  "Renamed": "Umbenannt",
   "Repeat your password here.": "Wiederholen Sie hier Ihr Passwort.",
   "Report": "Bericht",
   "Report message": "Nachricht melden",

--- a/packages/web-app/public/lang/el.json
+++ b/packages/web-app/public/lang/el.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Αφαίρεση ευαισθησίας",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Η αφαίρεση της ευαισθησίας από τον ορεινό όγκο δεν θα αφαιρέσει αυτόματα τη σημαία ευαισθησίας από τις μεμονωμένες εισόδους.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Η αφαίρεση της ευαισθησίας από τον ορεινό όγκο δεν θα αφαιρέσει αυτόματα τη σημαία ευαισθησίας από τις μεμονωμένες εισόδους. Αυτές οι σημαίες πρέπει να διαχειρίζονται ξεχωριστά. Θέλετε να συνεχίσετε;",
+  "Renamed": "Μετονομάστηκε",
   "Repeat your password here.": "Επαναλάβετε τον κωδικό σας εδώ.",
   "Report": "Έκθεση",
   "Report message": "Αναφορά μηνύματος",

--- a/packages/web-app/public/lang/en.json
+++ b/packages/web-app/public/lang/en.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Remove sensitivity",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?",
+  "Renamed": "Renamed",
   "Repeat your password here.": "Repeat your password here.",
   "Report": "Report",
   "Report message": "Report message",

--- a/packages/web-app/public/lang/es.json
+++ b/packages/web-app/public/lang/es.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Eliminar sensibilidad",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Eliminar la sensibilidad del macizo no eliminará automáticamente la marca de sensibilidad de las entradas individuales.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Eliminar la sensibilidad del macizo no eliminará automáticamente la marca de sensibilidad de las entradas individuales. Esas marcas deben gestionarse por separado. ¿Desea continuar?",
+  "Renamed": "Renombrado",
   "Repeat your password here.": "Repita su contraseña aquí.",
   "Report": "Informe",
   "Report message": "Reportar mensaje",

--- a/packages/web-app/public/lang/fr.json
+++ b/packages/web-app/public/lang/fr.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Supprimer la sensibilité",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "La suppression de la sensibilité du massif ne supprimera pas automatiquement le marquage de sensibilité des entrées individuelles.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "La suppression de la sensibilité du massif ne supprimera pas automatiquement le marquage de sensibilité des entrées individuelles. Ces marquages doivent être gérés séparément. Voulez-vous continuer ?",
+  "Renamed": "Renommé",
   "Repeat your password here.": "Saisissez de nouveau votre mot de passe ici.",
   "Report": "Rapport",
   "Report message": "Signaler un message",

--- a/packages/web-app/public/lang/he.json
+++ b/packages/web-app/public/lang/he.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "הסר רגישות",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "הסרת הרגישות מהמאסיב לא תסיר באופן אוטומטי את דגל הרגישות מכניסות בודדות.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "הסרת הרגישות מהמאסיב לא תסיר באופן אוטומטי את דגל הרגישות מכניסות בודדות. יש לנהל דגלים אלה בנפרד. האם ברצונך להמשיך?",
+  "Renamed": "שונה שם",
   "Repeat your password here.": "חזור על הסיסמה שלך כאן.",
   "Report": "דוח",
   "Report message": "דווח על הודעה",

--- a/packages/web-app/public/lang/id.json
+++ b/packages/web-app/public/lang/id.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Hapus sensitivitas",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Menghapus sensitivitas dari massif tidak akan secara otomatis menghapus tanda sensitivitas dari masing-masing pintu masuk.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Menghapus sensitivitas dari massif tidak akan secara otomatis menghapus tanda sensitivitas dari masing-masing pintu masuk. Tanda tersebut harus dikelola secara terpisah. Apakah Anda ingin melanjutkan?",
+  "Renamed": "Diganti nama",
   "Repeat your password here.": "Ulangi kata sandi Anda di sini.",
   "Report": "Laporan",
   "Report message": "Laporkan pesan",

--- a/packages/web-app/public/lang/it.json
+++ b/packages/web-app/public/lang/it.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Rimuovi sensibilità",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "La rimozione della sensibilità dal massiccio non rimuoverà automaticamente il contrassegno di sensibilità dai singoli ingressi.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "La rimozione della sensibilità dal massiccio non rimuoverà automaticamente il contrassegno di sensibilità dai singoli ingressi. Tali contrassegni devono essere gestiti separatamente. Vuoi continuare?",
+  "Renamed": "Rinominato",
   "Repeat your password here.": "Ripeti qui la tua password.",
   "Report": "Relazione",
   "Report message": "Segnala messaggio",

--- a/packages/web-app/public/lang/ja.json
+++ b/packages/web-app/public/lang/ja.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "感度設定を解除",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "山塊から感度設定を解除しても、個々の入り口の感度フラグは自動的には削除されません。",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "山塊から感度設定を解除しても、個々の入り口の感度フラグは自動的には削除されません。これらのフラグは個別に管理する必要があります。続行しますか？",
+  "Renamed": "名前変更済み",
   "Repeat your password here.": "ここにパスワードを繰り返し入力してください。",
   "Report": "レポート",
   "Report message": "メッセージを通報",

--- a/packages/web-app/public/lang/nl.json
+++ b/packages/web-app/public/lang/nl.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Gevoeligheid verwijderen",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Het verwijderen van de gevoeligheid van het massief verwijdert niet automatisch de gevoeligheidsvlag van individuele ingangen.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Het verwijderen van de gevoeligheid van het massief verwijdert niet automatisch de gevoeligheidsvlag van individuele ingangen. Die vlaggen moeten afzonderlijk worden beheerd. Wilt u doorgaan?",
+  "Renamed": "Hernoemd",
   "Repeat your password here.": "Herhaal hier uw wachtwoord.",
   "Report": "Verslag",
   "Report message": "Bericht rapporteren",

--- a/packages/web-app/public/lang/pt.json
+++ b/packages/web-app/public/lang/pt.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Remover sensibilidade",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "A remoção da sensibilidade do maciço não removerá automaticamente a marca de sensibilidade das entradas individuais.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "A remoção da sensibilidade do maciço não removerá automaticamente a marca de sensibilidade das entradas individuais. Essas marcas devem ser geridas separadamente. Deseja continuar?",
+  "Renamed": "Renomeado",
   "Repeat your password here.": "Repita aqui a sua palavra-passe.",
   "Report": "Relatório",
   "Report message": "Denunciar mensagem",

--- a/packages/web-app/public/lang/ro.json
+++ b/packages/web-app/public/lang/ro.json
@@ -2040,6 +2040,7 @@
   "Remove sensitivity": "Eliminare sensibilitate",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances.": "Eliminarea sensibilității de la masiv nu va elimina automat marcajul de sensibilitate de la intrările individuale.",
   "Removing sensitivity from the massif will not automatically remove the sensitivity flag from individual entrances. Those flags must be managed separately. Do you want to continue?": "Eliminarea sensibilității de la masiv nu va elimina automat marcajul de sensibilitate de la intrările individuale. Aceste marcaje trebuie gestionate separat. Doriți să continuați?",
+  "Renamed": "Redenumit",
   "Repeat your password here.": "Repetați parola aici.",
   "Report": "Raport",
   "Report message": "Raportează mesajul",

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -78,15 +78,17 @@ const AccordionSnapshot = ({
             overflow: 'hidden'
           }}>
           <Box
-            onClick={() => setOpen(prev => !prev)}
+            onClick={isNameChange ? undefined : () => setOpen(prev => !prev)}
             sx={{
-              cursor: 'pointer',
+              cursor: isNameChange ? 'default' : 'pointer',
               display: 'flex',
               alignItems: 'flex-start',
               gap: 1,
               px: 1,
               py: 1,
-              '&:hover': { bgcolor: 'action.hover' }
+              ...(isNameChange
+                ? {}
+                : { '&:hover': { bgcolor: 'action.hover' } })
             }}>
             <Box
               sx={{
@@ -183,18 +185,20 @@ const AccordionSnapshot = ({
                 )}
               </Box>
             </Box>
-            <IconButton
-              size="small"
-              color="action"
-              sx={{ flexShrink: 0, mt: '-2px' }}>
-              {open ? (
-                <ExpandLessIcon fontSize="small" />
-              ) : (
-                <ExpandMoreIcon fontSize="small" />
-              )}
-            </IconButton>
+            {!isNameChange && (
+              <IconButton
+                size="small"
+                color="action"
+                sx={{ flexShrink: 0, mt: '-2px' }}>
+                {open ? (
+                  <ExpandLessIcon fontSize="small" />
+                ) : (
+                  <ExpandMoreIcon fontSize="small" />
+                )}
+              </IconButton>
+            )}
           </Box>
-          <Collapse in={open}>
+          <Collapse in={open && !isNameChange}>
             <Box
               sx={{
                 px: 2,

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Chip,
-  Collapse,
-  IconButton,
-  Typography
-} from '@mui/material';
+import { Box, Chip, Collapse, IconButton, Typography } from '@mui/material';
 import {
   TimelineItem,
   TimelineSeparator,
@@ -15,6 +9,7 @@ import {
 } from '@mui/lab';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
@@ -40,8 +35,26 @@ const AccordionSnapshot = ({
   const { formatMessage } = useIntl();
   const [open, setOpen] = useState(isCurrent ?? false);
 
-  const snapshotTitle = snapshot.title ?? snapshot.name ?? snapshot.description?.title ?? '';
-  const previousVersionTitle = previous?.title ?? previous?.name ?? previous?.description?.title ?? undefined;
+  const isNameChange = snapshot.isNameChangeSnapshot === true;
+  const isEntranceType = snapshotType === 'entrances';
+
+  const snapshotTitle = isEntranceType
+    ? (snapshot.caveName ??
+      snapshot.name ??
+      snapshot.title ??
+      snapshot.description?.title ??
+      '')
+    : (snapshot.title ?? snapshot.name ?? snapshot.description?.title ?? '');
+  const previousVersionTitle = isEntranceType
+    ? (previous?.caveName ??
+      previous?.name ??
+      previous?.title ??
+      previous?.description?.title ??
+      undefined)
+    : (previous?.title ??
+      previous?.name ??
+      previous?.description?.title ??
+      undefined);
   const rawDate = isCurrent
     ? (snapshot.dateReviewed ?? snapshot.dateInscription)
     : snapshot.id;
@@ -51,13 +64,13 @@ const AccordionSnapshot = ({
     <TimelineItem sx={{ '&::before': { flex: 0, padding: 0 } }}>
       <TimelineSeparator>
         <TimelineDot
-          color={isCurrent ? 'primary' : 'grey'}
+          color={isNameChange ? 'secondary' : isCurrent ? 'primary' : 'grey'}
           variant={isCurrent ? 'filled' : 'outlined'}
           sx={{ mt: '10px' }}
         />
         <TimelineConnector />
       </TimelineSeparator>
-      <TimelineContent sx={{ pb: 2, pt: 0 }}>
+      <TimelineContent sx={{ pb: 2, pt: 0, pr: 0 }}>
         <Box
           sx={{
             borderRadius: 1,
@@ -77,58 +90,121 @@ const AccordionSnapshot = ({
               py: 1,
               '&:hover': { bgcolor: 'action.hover' }
             }}>
-            <Box sx={{ flex: '0 0 auto' }}>
-              {all && (
-                <Typography variant="caption" color="text.secondary" display="block">
-                  <Translate>{snapshotType === 'entrances' ? 'Information' : capitalize(snapshotType)}</Translate>
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                flexDirection: { xs: 'column', sm: 'row' },
+                alignItems: { xs: 'stretch', sm: 'flex-start' },
+                gap: 1
+              }}>
+              <Box sx={{ flex: '0 0 auto' }}>
+                {all && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block">
+                    <Translate>
+                      {snapshotType === 'entrances'
+                        ? 'Information'
+                        : capitalize(snapshotType)}
+                    </Translate>
+                  </Typography>
+                )}
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block">
+                  {displayDate
+                    ? `${displayDate.toLocaleDateString()} - ${displayDate.toLocaleTimeString()}`
+                    : ''}
                 </Typography>
-              )}
-              <Typography variant="caption" color="text.secondary" display="block">
-                {displayDate
-                  ? `${displayDate.toLocaleDateString()} - ${displayDate.toLocaleTimeString()}`
-                  : ''}
-              </Typography>
-              {reviewer ? (
-                <AuthorAndDate author={reviewer} verb="Updated" textColor="inherit" />
-              ) : author ? (
-                <AuthorAndDate author={author} verb="Created" textColor="inherit" />
-              ) : null}
-            </Box>
-            <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-              <Typography variant="body2" component="span" fontWeight={isCurrent ? 'bold' : 'regular'}>
-                {isCurrent ? (
-                  snapshotTitle
-                ) : (
-                  <HighLightsChar
-                    oldText={previousVersionTitle}
-                    newText={snapshotTitle}
+                {reviewer ? (
+                  <AuthorAndDate
+                    author={reviewer}
+                    verb="Updated"
+                    textColor="inherit"
+                  />
+                ) : author ? (
+                  <AuthorAndDate
+                    author={author}
+                    verb="Created"
+                    textColor="inherit"
+                  />
+                ) : null}
+              </Box>
+              <Box
+                sx={{
+                  flex: 1,
+                  minWidth: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  flexWrap: 'wrap'
+                }}>
+                <Typography
+                  variant="body2"
+                  component="span"
+                  fontWeight={isCurrent ? 'bold' : 'regular'}>
+                  {isCurrent ? (
+                    snapshotTitle
+                  ) : (
+                    <HighLightsChar
+                      oldText={previousVersionTitle}
+                      newText={snapshotTitle}
+                    />
+                  )}
+                </Typography>
+                {isCurrent && (
+                  <Chip
+                    label={formatMessage({ id: 'Current version' })}
+                    color="primary"
+                    size="small"
+                    sx={{ flexShrink: 0 }}
                   />
                 )}
-              </Typography>
-              {isCurrent && (
-                <Chip
-                  label={formatMessage({ id: 'Current version' })}
-                  color="primary"
-                  size="small"
-                  sx={{ flexShrink: 0 }}
-                />
-              )}
-              {!previous && (
-                <Chip
-                  label={formatMessage({ id: 'Initial version' })}
-                  color="primary"
-                  variant="outlined"
-                  size="small"
-                  sx={{ flexShrink: 0 }}
-                />
-              )}
+                {!previous && (
+                  <Chip
+                    label={formatMessage({ id: 'Initial version' })}
+                    color="primary"
+                    variant="outlined"
+                    size="small"
+                    sx={{ flexShrink: 0 }}
+                  />
+                )}
+                {isNameChange && (
+                  <Chip
+                    icon={<DriveFileRenameOutlineIcon />}
+                    label={formatMessage({ id: 'Renamed' })}
+                    color="secondary"
+                    variant="outlined"
+                    size="small"
+                    sx={{ flexShrink: 0 }}
+                  />
+                )}
+              </Box>
             </Box>
-            <IconButton size="small" color="action" sx={{ flexShrink: 0, mt: '-2px' }}>
-              {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            <IconButton
+              size="small"
+              color="action"
+              sx={{ flexShrink: 0, mt: '-2px' }}>
+              {open ? (
+                <ExpandLessIcon fontSize="small" />
+              ) : (
+                <ExpandMoreIcon fontSize="small" />
+              )}
             </IconButton>
           </Box>
           <Collapse in={open}>
-            <Box sx={{ px: 2, pt: 1, pb: 1, borderTop: '1px solid', borderColor: 'grey.200' }}>
+            <Box
+              sx={{
+                px: 2,
+                pt: 1,
+                pb: 1,
+                borderTop: '1px solid',
+                borderColor: 'grey.200'
+              }}>
               {getAccordionBodyFromType(
                 snapshotType,
                 snapshot,
@@ -158,6 +234,8 @@ AccordionSnapshot.propTypes = {
     id: PropTypes.string,
     title: PropTypes.string,
     name: PropTypes.string,
+    caveName: PropTypes.string,
+    isNameChangeSnapshot: PropTypes.bool,
     description: PropTypes.shape({ title: PropTypes.string }),
     dateInscription: PropTypes.string,
     dateReviewed: PropTypes.string
@@ -170,6 +248,7 @@ AccordionSnapshot.propTypes = {
     id: PropTypes.string,
     title: PropTypes.string,
     name: PropTypes.string,
+    caveName: PropTypes.string,
     date: PropTypes.string,
     dateReviewed: PropTypes.string
   }),

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -37,15 +37,15 @@ const AccordionSnapshot = ({
   const [open, setOpen] = useState(isCurrent ?? false);
 
   const isNameChange = !!snapshot.isNameChangeSnapshot;
-  const isEntranceType = snapshotType === 'entrances';
+  const isEntranceSnapshot = snapshotType === 'entrances';
 
-  // For entrance snapshots, prioritize the cave/network name over the entrance
-  // name: it's the value most relevant to disambiguate renamed entrances and
-  // networks, and it still matches the entrance name for single-entrance caves.
-  const snapshotTitle = isEntranceType
+  // For entrance snapshots, use the entrance name directly (falling back to
+  // title/description title); cave/network renames are surfaced by dedicated
+  // rename snapshots, so this stays a plain contextual label, not a diff.
+  const snapshotTitle = isEntranceSnapshot
     ? (snapshot.name ?? snapshot.title ?? snapshot.description?.title ?? '')
     : (snapshot.title ?? snapshot.name ?? snapshot.description?.title ?? '');
-  const previousVersionTitle = isEntranceType
+  const previousVersionTitle = isEntranceSnapshot
     ? (previous?.name ??
       previous?.title ??
       previous?.description?.title ??
@@ -161,7 +161,7 @@ const AccordionSnapshot = ({
                     // snapshotTitle holds the OLD name (raw h_name value);
                     // newName is resolved from the next real snapshot.
                     <HighLightsChar oldText={snapshotTitle} newText={newName} />
-                  ) : isEntranceType ? (
+                  ) : isEntranceSnapshot ? (
                     // Regular entrance snapshot: name/caveName are contextual
                     // labels resolved across tables, not diffable fields. Renames
                     // are surfaced by the dedicated rename snapshot above.

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -120,7 +120,13 @@ const AccordionSnapshot = ({
                     ? `${displayDate.toLocaleDateString()} - ${displayDate.toLocaleTimeString()}`
                     : ''}
                 </Typography>
-                {reviewer ? (
+                {isNameChange ? (
+                  <AuthorAndDate
+                    author={reviewer}
+                    verb="Updated"
+                    textColor="inherit"
+                  />
+                ) : reviewer ? (
                   <AuthorAndDate
                     author={reviewer}
                     verb="Updated"

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -35,9 +35,12 @@ const AccordionSnapshot = ({
   const { formatMessage } = useIntl();
   const [open, setOpen] = useState(isCurrent ?? false);
 
-  const isNameChange = snapshot.isNameChangeSnapshot === true;
+  const isNameChange = !!snapshot.isNameChangeSnapshot;
   const isEntranceType = snapshotType === 'entrances';
 
+  // For entrance snapshots, prioritize the cave/network name over the entrance
+  // name: it's the value most relevant to disambiguate renamed entrances and
+  // networks, and it still matches the entrance name for single-entrance caves.
   const snapshotTitle = isEntranceType
     ? (snapshot.caveName ??
       snapshot.name ??
@@ -212,7 +215,7 @@ const AccordionSnapshot = ({
                 previous
               )}
             </Box>
-            {!isCurrent && snapshotType !== 'documents' && (
+            {!isCurrent && snapshotType !== 'documents' && !isNameChange && (
               <Box sx={{ px: 2, pb: 2 }}>
                 <RestoreSnapshot
                   snapshot={snapshot}

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -42,15 +42,10 @@ const AccordionSnapshot = ({
   // name: it's the value most relevant to disambiguate renamed entrances and
   // networks, and it still matches the entrance name for single-entrance caves.
   const snapshotTitle = isEntranceType
-    ? (snapshot.caveName ??
-      snapshot.name ??
-      snapshot.title ??
-      snapshot.description?.title ??
-      '')
+    ? (snapshot.name ?? snapshot.title ?? snapshot.description?.title ?? '')
     : (snapshot.title ?? snapshot.name ?? snapshot.description?.title ?? '');
   const previousVersionTitle = isEntranceType
-    ? (previous?.caveName ??
-      previous?.name ??
+    ? (previous?.name ??
       previous?.title ??
       previous?.description?.title ??
       undefined)

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -29,6 +29,7 @@ const AccordionSnapshot = ({
   reviewer,
   previous,
   actualItem,
+  newName,
   all,
   isCurrent
 }) => {
@@ -122,7 +123,7 @@ const AccordionSnapshot = ({
                 </Typography>
                 {isNameChange ? (
                   <AuthorAndDate
-                    author={reviewer}
+                    author={reviewer ?? author}
                     verb="Updated"
                     textColor="inherit"
                   />
@@ -154,6 +155,16 @@ const AccordionSnapshot = ({
                   component="span"
                   fontWeight={isCurrent ? 'bold' : 'regular'}>
                   {isCurrent ? (
+                    snapshotTitle
+                  ) : isNameChange ? (
+                    // Rename snapshot: the name IS the change — show old → new.
+                    // snapshotTitle holds the OLD name (raw h_name value);
+                    // newName is resolved from the next real snapshot.
+                    <HighLightsChar oldText={snapshotTitle} newText={newName} />
+                  ) : isEntranceType ? (
+                    // Regular entrance snapshot: name/caveName are contextual
+                    // labels resolved across tables, not diffable fields. Renames
+                    // are surfaced by the dedicated rename snapshot above.
                     snapshotTitle
                   ) : (
                     <HighLightsChar
@@ -252,6 +263,7 @@ AccordionSnapshot.propTypes = {
   isNetwork: PropTypes.bool,
   author: authorType,
   reviewer: authorType,
+  newName: PropTypes.string,
   previous: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
@@ -63,28 +63,42 @@ const AccordionSnapshotList = ({
   const snapshotElements = hasRevisions
     ? Object.keys(filteredData).map(snapshotType => {
         const snapshotItems = filteredData[snapshotType];
-        const { items } = snapshotItems.reduce(
-          ({ items: acc, prev }, snapshot) => ({
-            items: [
-              ...acc,
-              <AccordionSnapshot
-                key={snapshot.id + snapshot.t_id}
-                snapshot={snapshot}
-                snapshotType={snapshotType}
-                isNetwork={isNetwork}
-                author={snapshot.author}
-                reviewer={snapshot.reviewer}
-                previous={prev}
-                actualItem={currentItem}
-              />
-            ],
-            // Rename snapshots are ignored in the history chain: they carry no
-            // data beyond the renaming, so they must not become the previous
-            // version used to diff the next real snapshot.
-            prev: snapshot.isNameChangeSnapshot ? prev : snapshot
-          }),
-          { items: [], prev: null }
-        );
+
+        // Rename snapshots come from h_name: they only carry the OLD name and
+        // have no reviewer. The NEW name and the actual reviewer live on the
+        // next real (non-rename) snapshot — resolve them here.
+        const nextRealSnapshot = index => {
+          for (let j = index + 1; j < snapshotItems.length; j += 1) {
+            if (!snapshotItems[j].isNameChangeSnapshot) return snapshotItems[j];
+          }
+          return null;
+        };
+
+        let prev = null;
+        const items = snapshotItems.map((snapshot, index) => {
+          const isRename = !!snapshot.isNameChangeSnapshot;
+          const nextReal = isRename ? nextRealSnapshot(index) : null;
+          const element = (
+            <AccordionSnapshot
+              key={snapshot.id + snapshot.t_id}
+              snapshot={snapshot}
+              snapshotType={snapshotType}
+              isNetwork={isNetwork}
+              author={snapshot.author}
+              reviewer={snapshot.reviewer ?? nextReal?.reviewer}
+              previous={prev}
+              actualItem={currentItem}
+              newName={
+                isRename ? (nextReal?.name ?? nextReal?.caveName) : undefined
+              }
+            />
+          );
+          // Rename snapshots are ignored in the history chain: they carry no
+          // data beyond the renaming, so they must not become the previous
+          // version used to diff the next real snapshot.
+          if (!isRename) prev = snapshot;
+          return element;
+        });
         return [...items].reverse();
       })
     : null;

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
@@ -51,7 +51,13 @@ const AccordionSnapshotList = ({
     if (!hasRevisions) return null;
     const firstType = Object.keys(filteredData)[0];
     const items = filteredData[firstType];
-    return items?.length > 0 ? items[items.length - 1] : null;
+    if (!items?.length) return null;
+    // Skip rename snapshots: they only carry the renaming and no other data, so
+    // they must not be used as the previous version to diff the current item.
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      if (!items[i].isNameChangeSnapshot) return items[i];
+    }
+    return null;
   })();
 
   const snapshotElements = hasRevisions
@@ -72,7 +78,10 @@ const AccordionSnapshotList = ({
                 actualItem={currentItem}
               />
             ],
-            prev: snapshot
+            // Rename snapshots are ignored in the history chain: they carry no
+            // data beyond the renaming, so they must not become the previous
+            // version used to diff the next real snapshot.
+            prev: snapshot.isNameChangeSnapshot ? prev : snapshot
           }),
           { items: [], prev: null }
         );

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotListPage.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotListPage.jsx
@@ -24,8 +24,9 @@ const AccordionSnapshotListPage = ({
   // sortSnapshots flattens data: each element is { [type]: [singleSnapshot] }.
   // Group all snapshots per (snapshotType, t_id) to compute `previous` and
   // find the most recent snapshot per entity (used as `previous` for current items).
-  const { previousMap, latestByGroup } = useMemo(() => {
-    if (!hasData) return { previousMap: {}, latestByGroup: {} };
+  const { previousMap, latestByGroup, renameInfoMap } = useMemo(() => {
+    if (!hasData)
+      return { previousMap: {}, latestByGroup: {}, renameInfoMap: {} };
     const groups = {};
     data.forEach(snapshotGroup => {
       const snapshotType = Object.keys(snapshotGroup)[0];
@@ -36,15 +37,40 @@ const AccordionSnapshotListPage = ({
     });
     const prevMap = {};
     const latest = {};
+    const renameInfo = {};
     Object.entries(groups).forEach(([key, group]) => {
       group.sort((a, b) => new Date(a.id) - new Date(b.id));
+      // Rename snapshots come from h_name: they only carry the OLD name and have
+      // no reviewer, and they carry no other data. So they must not become the
+      // `previous` used to diff the next real snapshot, and their NEW name and
+      // reviewer are resolved from the next real (non-rename) snapshot.
+      const nextRealSnapshot = index => {
+        for (let j = index + 1; j < group.length; j += 1) {
+          if (!group[j].isNameChangeSnapshot) return group[j];
+        }
+        return null;
+      };
+      let prev = null;
       group.forEach((snapshot, index) => {
-        prevMap[`${snapshot.id}_${snapshot.t_id}`] =
-          index > 0 ? group[index - 1] : null;
+        const snapKey = `${snapshot.id}_${snapshot.t_id}`;
+        prevMap[snapKey] = prev;
+        if (snapshot.isNameChangeSnapshot) {
+          const nextReal = nextRealSnapshot(index);
+          renameInfo[snapKey] = {
+            newName: nextReal?.name ?? nextReal?.caveName,
+            reviewer: nextReal?.reviewer
+          };
+        } else {
+          prev = snapshot;
+          latest[key] = snapshot;
+        }
       });
-      latest[key] = group[group.length - 1];
     });
-    return { previousMap: prevMap, latestByGroup: latest };
+    return {
+      previousMap: prevMap,
+      latestByGroup: latest,
+      renameInfoMap: renameInfo
+    };
   }, [data, hasData]);
 
   // Build a unified sorted timeline: current items + snapshots interleaved by date.
@@ -93,6 +119,7 @@ const AccordionSnapshotListPage = ({
       data.forEach(snapshotGroup => {
         const snapshotType = Object.keys(snapshotGroup)[0];
         const snapshot = snapshotGroup[snapshotType][0];
+        const rename = renameInfoMap[`${snapshot.id}_${snapshot.t_id}`];
         items.push({
           date: snapshot.id ? new Date(snapshot.id) : new Date(0),
           element: (
@@ -102,8 +129,9 @@ const AccordionSnapshotListPage = ({
               snapshotType={snapshotType}
               isNetwork={isNetwork}
               author={snapshot.author ?? snapshot.creator}
-              reviewer={snapshot.reviewer}
+              reviewer={snapshot.reviewer ?? rename?.reviewer}
               previous={previousMap[`${snapshot.id}_${snapshot.t_id}`]}
+              newName={rename?.newName}
               all
               actualItem={currentTItem}
             />
@@ -114,7 +142,7 @@ const AccordionSnapshotListPage = ({
 
     items.sort((a, b) => b.date - a.date);
     return items;
-  }, [data, hasData, currentTItem, isCurrentItemLoading, type, isNetwork, latestByGroup, previousMap]);
+  }, [data, hasData, currentTItem, isCurrentItemLoading, type, isNetwork, latestByGroup, previousMap, renameInfoMap]);
 
   const hasItems = timelineItems.length > 0;
 

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCaveSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCaveSnapshots.jsx
@@ -11,6 +11,9 @@ const EntranceCaveSnapshots = ({ entrance, previous }) => {
   const { cave } = entrance;
 
   const { formatMessage } = useIntl();
+  const hasCoordinates = entrance.latitude != null && entrance.longitude != null;
+  const hasPreviousCoordinates =
+    previous?.latitude != null && previous?.longitude != null;
   const lat = Number(entrance.latitude);
   const long = Number(entrance.longitude);
   const previousLat = Number(previous?.latitude);
@@ -28,13 +31,13 @@ const EntranceCaveSnapshots = ({ entrance, previous }) => {
         gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
         width: '100%'
       }}>
-      {!(Number.isNaN(lat) && Number.isNaN(long)) && (
+      {hasCoordinates && (
         <Property
           label={`${formatMessage({ id: 'Coordinates' })} (WGS84)`}
           value={
             <HighLightsLine
               oldText={
-                !(Number.isNaN(previousLat) && Number.isNaN(previousLong))
+                hasPreviousCoordinates
                   ? makeCoordinatesValue([previousLat, previousLong])
                   : undefined
               }

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCaveSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCaveSnapshots.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Property } from '../../../../common/Properties';
 import CustomIcon from '../../../../common/CustomIcon';
 import { HighLightsLine } from '../../../../common/Highlights';
-import { ENTRANCE_BOOLEAN_CHARACTERISTICS } from '../../../../../conf/entranceCharacteristics';
+import EntranceCharacteristicsSnapshot from './EntranceCharacteristicsSnapshot';
 
 const EntranceCaveSnapshots = ({ entrance, previous }) => {
   const { cave } = entrance;
@@ -107,32 +107,7 @@ const EntranceCaveSnapshots = ({ entrance, previous }) => {
           secondary
         />
       )}
-      {ENTRANCE_BOOLEAN_CHARACTERISTICS
-        .filter(({ field }) => {
-          if (previous == null) return !!entrance[field];
-          return !!entrance[field] || previous[field] !== entrance[field];
-        })
-        .map(({ field, label, icon }) => {
-          const isAdded = previous != null && !!entrance[field] && !previous[field];
-          const isRemoved = previous != null && !entrance[field] && !!previous[field];
-          return (
-            <Box
-              key={field}
-              sx={
-                isAdded
-                  ? { bgcolor: 'rgba(70, 149, 74, 0.2)', borderRadius: 1, px: 0.5 }
-                  : isRemoved
-                  ? { bgcolor: 'rgba(229, 83, 74, 0.2)', borderRadius: 1, px: 0.5 }
-                  : undefined
-              }>
-              <Property
-                value={formatMessage({ id: label })}
-                icon={<CustomIcon type={icon} />}
-                secondary={!entrance[field]}
-              />
-            </Box>
-          );
-        })}
+      <EntranceCharacteristicsSnapshot entrance={entrance} previous={previous} />
     </Box>
   );
 };

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCharacteristicsSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCharacteristicsSnapshot.jsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+import { Box } from '@mui/material';
+import PropTypes from 'prop-types';
+
+import { Property } from '../../../../common/Properties';
+import CustomIcon from '../../../../common/CustomIcon';
+import { ENTRANCE_BOOLEAN_CHARACTERISTICS } from '../../../../../conf/entranceCharacteristics';
+
+// Renders the entrance boolean characteristics (hazards, restrictions, touristic
+// flag) as a diff against the previous snapshot: added ones are highlighted green,
+// removed ones red. Shared by the cave and network entrance snapshot variants.
+const EntranceCharacteristicsSnapshot = ({ entrance, previous }) => {
+  const { formatMessage } = useIntl();
+
+  return ENTRANCE_BOOLEAN_CHARACTERISTICS.filter(({ field }) => {
+    if (previous == null) return !!entrance[field];
+    return !!entrance[field] || previous[field] !== entrance[field];
+  }).map(({ field, label, icon }) => {
+    const isAdded = previous != null && !!entrance[field] && !previous[field];
+    const isRemoved = previous != null && !entrance[field] && !!previous[field];
+    return (
+      <Box
+        key={field}
+        sx={
+          isAdded
+            ? { bgcolor: 'rgba(70, 149, 74, 0.2)', borderRadius: 1, px: 0.5 }
+            : isRemoved
+            ? { bgcolor: 'rgba(229, 83, 74, 0.2)', borderRadius: 1, px: 0.5 }
+            : undefined
+        }>
+        <Property
+          value={formatMessage({ id: label })}
+          icon={<CustomIcon type={icon} />}
+          secondary={!entrance[field]}
+        />
+      </Box>
+    );
+  });
+};
+
+EntranceCharacteristicsSnapshot.propTypes = {
+  entrance: PropTypes.shape({}),
+  previous: PropTypes.shape({})
+};
+
+export default EntranceCharacteristicsSnapshot;

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
@@ -49,7 +49,7 @@ const EntranceNetworkSnapshots = information => {
       )}
       {entrance.cave && (
         <Property
-          label={formatMessage({ id: 'Cave' })}
+          label={formatMessage({ id: 'Network' })}
           value={
             <HighLightsLine
               oldText={previous?.caveName}

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
@@ -53,12 +53,9 @@ const EntranceNetworkSnapshots = information => {
       {entrance.cave && (
         <Property
           label={formatMessage({ id: 'Network' })}
-          value={
-            <HighLightsLine
-              oldText={previous?.caveName}
-              newText={entrance.caveName}
-            />
-          }
+          // caveName is a contextual label (resolved across tables), not a
+          // diffable field: network renames are surfaced by rename snapshots.
+          value={entrance.caveName}
           icon={<CustomIcon type="network" />}
           url={`/ui/caves/${entrance.cave}`}
         />

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Property } from '../../../../common/Properties';
 import CustomIcon from '../../../../common/CustomIcon';
 import { HighLightsLine } from '../../../../common/Highlights';
+import EntranceCharacteristicsSnapshot from './EntranceCharacteristicsSnapshot';
 
 const EntranceNetworkSnapshots = information => {
   const { entrance, previous } = information;
@@ -16,6 +17,12 @@ const EntranceNetworkSnapshots = information => {
   const long = Number(entrance.longitude);
   const previousLat = Number(previous?.latitude);
   const previousLong = Number(previous?.longitude);
+
+  // The network reference has two shapes: on snapshots `cave` is the id and
+  // `caveName` the resolved name; on the current entrance `cave` is an object
+  // carrying both id and name. Normalize so both render (and the link works).
+  const caveId = entrance.cave?.id ?? entrance.cave;
+  const caveName = entrance.caveName ?? entrance.cave?.name;
 
   const { formatMessage } = useIntl();
 
@@ -50,16 +57,17 @@ const EntranceNetworkSnapshots = information => {
           icon={<CustomIcon type="altitude" />}
         />
       )}
-      {entrance.cave && (
+      {caveId && (
         <Property
           label={formatMessage({ id: 'Network' })}
           // caveName is a contextual label (resolved across tables), not a
           // diffable field: network renames are surfaced by rename snapshots.
-          value={entrance.caveName}
+          value={caveName}
           icon={<CustomIcon type="network" />}
-          url={`/ui/caves/${entrance.cave}`}
+          url={`/ui/caves/${caveId}`}
         />
       )}
+      <EntranceCharacteristicsSnapshot entrance={entrance} previous={previous} />
     </Box>
   );
 };

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceNetworkSnapshots.jsx
@@ -9,6 +9,9 @@ import { HighLightsLine } from '../../../../common/Highlights';
 
 const EntranceNetworkSnapshots = information => {
   const { entrance, previous } = information;
+  const hasCoordinates = entrance.latitude != null && entrance.longitude != null;
+  const hasPreviousCoordinates =
+    previous?.latitude != null && previous?.longitude != null;
   const lat = Number(entrance.latitude);
   const long = Number(entrance.longitude);
   const previousLat = Number(previous?.latitude);
@@ -24,13 +27,13 @@ const EntranceNetworkSnapshots = information => {
 
   return (
     <Box display="flex" flexDirection="column" width="100%">
-      {!(Number.isNaN(lat) && Number.isNaN(long)) && (
+      {hasCoordinates && (
         <Property
           label={`${formatMessage({ id: 'Coordinates' })} (WGS84)`}
           value={
             <HighLightsLine
               oldText={
-                !(Number.isNaN(previousLat) && Number.isNaN(previousLong))
+                hasPreviousCoordinates
                   ? makeCoordinatesValue([previousLat, previousLong])
                   : undefined
               }


### PR DESCRIPTION
# feat(snapshot): manage renamed entrances

## 🤔 What

- Display the cave name (`caveName`) in the entrance revision history timeline, instead of the entrance name, since the cave name is the value that can change over time for network entrances.
- Add a distinct visual marker (chip + timeline dot color) for synthetic rename snapshots (`isNameChangeSnapshot`).
- Rename the "Cave" label to "Network" in the entrance network snapshot body, since that property is only shown in network context.
- Fix a responsive layout issue on the timeline entry header (meta column and title/chips column now stack on mobile instead of overlapping/truncating).
- Add i18n keys (`Renamed`) across all supported languages.

Closes #1446

## 🤷‍♂️ Why

The backend (grottocenter-api PR #1718) now resolves the cave name temporally per snapshot, since a cave can be renamed independently of its entrances. The frontend needs to surface that per-snapshot `caveName` and clearly flag the snapshot where the rename happened, instead of always showing the (unchanged) entrance name.

## 🔍 How

- `AccordionSnapshot.jsx`: for `entrances` snapshots, the header title/diff now resolves from `caveName` (falling back to `name`/`title` if absent, so `null` values are handled gracefully) instead of always using the entrance name. Added a `Renamed` chip + secondary timeline dot color when `snapshot.isNameChangeSnapshot` is `true`. Reworked the header layout to stack responsively on small screens (`flexDirection: { xs: 'column', sm: 'row' }`) and reclaimed unused right-hand padding on `TimelineContent`.
- `EntranceNetworkSnapshots.jsx`: renamed the displayed label from `Cave` to `Network`.
- Added the `Renamed` translation key to `en.json` and all other language files, kept sorted and in sync via `yarn translations:sync-with-en` / `yarn translations:sort`.

## 🔗 Related API PR

grottocenter-api #1718

## 🧪 Testing

- `yarn lint` passes on the changed files.
- Manually verified in the running dev app (mocked API responses) that:
  - the cave name diff displays correctly across current/rename/initial timeline entries,
  - a `null` `caveName` falls back gracefully instead of showing "null",
  - the `Renamed` chip and marker only appear on `isNameChangeSnapshot` entries,
  - the header layout no longer overlaps/truncates on mobile widths.

## 📸 Previews

_Screenshots available on request — not attached to keep the PR focused on the diff._
