### PR TITLE
feat(documents): use responsive image thumbnails from API

### DIFF
--- a/packages/web-app/src/components/common/DocumentsList/Files.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/Files.jsx
@@ -4,8 +4,13 @@ import { Button, ListItem, Grid } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import ImageThumbnail from './ImageThumbnail';
 import ImageLightbox from './ImageLightbox';
-import { isImageFile, decodeFileName } from './utils/imageUtils';
+import {
+  isImageFile,
+  decodeFileName,
+  getThumbnailSources
+} from './utils/imageUtils';
 import { getFileIcon } from './utils/fileIcons';
+import { ThumbnailsPropTypes } from '../../../types/document.type';
 
 const FileListItem = styled(ListItem)`
   margin: 0;
@@ -41,15 +46,19 @@ const Files = ({ files = [], description, onImageClick, imageIndexOffset = 0 }) 
       {/* Image thumbnails section */}
       {imageFiles.length > 0 && (
         <Grid container rowSpacing={2} columnSpacing={{ xs: 0, sm: 2 }} sx={{ mb: 2 }}>
-          {imageFiles.map((file, index) => (
-            <Grid key={file.fileName} sx={{ width: { xs: '100%', sm: 'auto' } }}>
-              <ImageThumbnail
-                src={file.completePath}
-                alt={decodeFileName(file.fileName)}
-                onClick={() => handleThumbnailClick(index)}
-              />
-            </Grid>
-          ))}
+          {imageFiles.map((file, index) => {
+            const { src, srcSet } = getThumbnailSources(file);
+            return (
+              <Grid key={file.fileName} sx={{ width: { xs: '100%', sm: 'auto' } }}>
+                <ImageThumbnail
+                  src={src}
+                  srcSet={srcSet}
+                  alt={decodeFileName(file.fileName)}
+                  onClick={() => handleThumbnailClick(index)}
+                />
+              </Grid>
+            );
+          })}
         </Grid>
       )}
 
@@ -100,7 +109,8 @@ Files.propTypes = {
   files: PropTypes.arrayOf(
     PropTypes.shape({
       fileName: PropTypes.string.isRequired,
-      completePath: PropTypes.string.isRequired
+      completePath: PropTypes.string.isRequired,
+      thumbnails: ThumbnailsPropTypes
     })
   ),
   description: PropTypes.string,

--- a/packages/web-app/src/components/common/DocumentsList/ImageLightbox.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/ImageLightbox.jsx
@@ -9,7 +9,8 @@ import {
   Download
 } from '@mui/icons-material';
 import { useIntl } from 'react-intl';
-import { decodeFileName, downloadFile } from './utils/imageUtils';
+import { decodeFileName, downloadFile, getLightboxSrc } from './utils/imageUtils';
+import { ThumbnailsPropTypes } from '../../../types/document.type';
 
 const LightboxDialog = styled(Dialog)`
   .MuiDialog-paper {
@@ -292,7 +293,7 @@ const ImageLightbox = ({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}>
         <LightboxImage
-          src={currentImage.completePath}
+          src={getLightboxSrc(currentImage)}
           alt={decodeFileName(currentImage.fileName)}
           draggable={false}
           style={{
@@ -383,6 +384,7 @@ ImageLightbox.propTypes = {
     PropTypes.shape({
       fileName: PropTypes.string.isRequired,
       completePath: PropTypes.string.isRequired,
+      thumbnails: ThumbnailsPropTypes,
       description: PropTypes.string
     })
   ).isRequired,

--- a/packages/web-app/src/components/common/DocumentsList/ImageThumbnail.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/ImageThumbnail.jsx
@@ -36,7 +36,10 @@ const FallbackIconWrapper = styled(Box)`
   border-radius: 4px;
 `;
 
-const ImageThumbnail = ({ src, alt, onClick }) => {
+// Mirrors ThumbnailCard's breakpoint above: full width below `sm`, fixed 240px from `sm` up.
+const DEFAULT_SIZES = '(max-width: 599px) 100vw, 240px';
+
+const ImageThumbnail = ({ src, srcSet, sizes = DEFAULT_SIZES, alt, onClick }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -75,6 +78,8 @@ const ImageThumbnail = ({ src, alt, onClick }) => {
         )}
         <ThumbnailImage
           src={src}
+          srcSet={srcSet}
+          sizes={sizes}
           alt={alt}
           loading="lazy"
           onLoad={handleLoad}
@@ -88,6 +93,8 @@ const ImageThumbnail = ({ src, alt, onClick }) => {
 
 ImageThumbnail.propTypes = {
   src: PropTypes.string.isRequired,
+  srcSet: PropTypes.string,
+  sizes: PropTypes.string,
   alt: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired
 };

--- a/packages/web-app/src/components/common/DocumentsList/utils/imageUtils.js
+++ b/packages/web-app/src/components/common/DocumentsList/utils/imageUtils.js
@@ -102,3 +102,40 @@ export const isImageFile = fileName => {
   const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
   return imageExtensions.includes(extension);
 };
+
+/**
+ * Build `src`/`srcSet` for a responsive thumbnail card, falling back to
+ * `completePath` when `thumbnails` (or a given variant) is null - e.g.
+ * non-image files, failed generation, or uploads predating the backfill.
+ * @param {object} file - File object with `completePath` and optional `thumbnails`
+ * @returns {{src: string, srcSet: string|undefined}}
+ */
+export const getThumbnailSources = file => {
+  const { completePath, thumbnails } = file;
+
+  if (!thumbnails) {
+    return { src: completePath, srcSet: undefined };
+  }
+
+  const { small, medium, large } = thumbnails;
+  const srcSet = [
+    small && `${small} 480w`,
+    medium && `${medium} 1280w`,
+    large && `${large} 1920w`
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return {
+    src: small || medium || large || completePath,
+    srcSet: srcSet || undefined
+  };
+};
+
+/**
+ * Pick the best image source for a full-screen lightbox view: the `large`
+ * thumbnail variant, falling back to `completePath` when unavailable.
+ * @param {object} file - File object with `completePath` and optional `thumbnails`
+ * @returns {string}
+ */
+export const getLightboxSrc = file => file.thumbnails?.large || file.completePath;

--- a/packages/web-app/src/pages/DocumentDetails/Section.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/Section.jsx
@@ -25,6 +25,7 @@ import {
   isImageFile
 } from '../../components/common/DocumentsList/utils/imageUtils';
 import { getFileIcon } from '../../components/common/DocumentsList/utils/fileIcons';
+import { ThumbnailsPropTypes } from '../../types/document.type';
 
 export const TextLink = ({ value, url }) =>
   url ? (
@@ -442,7 +443,8 @@ FilesSection.propTypes = {
     PropTypes.shape({
       fileName: PropTypes.string,
       completePath: PropTypes.string,
-      description: PropTypes.string
+      description: PropTypes.string,
+      thumbnails: ThumbnailsPropTypes
     })
   )
 };

--- a/packages/web-app/src/pages/DocumentDetails/Section.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/Section.jsx
@@ -21,6 +21,7 @@ import ImageThumbnail from '../../components/common/DocumentsList/ImageThumbnail
 import {
   decodeFileName,
   getFileExtension,
+  getThumbnailSources,
   isImageFile
 } from '../../components/common/DocumentsList/utils/imageUtils';
 import { getFileIcon } from '../../components/common/DocumentsList/utils/fileIcons';
@@ -331,14 +332,18 @@ export const FilesSection = ({ files }) => {
     <Stack spacing={3}>
       {images.length > 0 && (
         <ImageGallery>
-          {images.map((file, idx) => (
-            <ImageThumbnail
-              key={file.completePath}
-              src={file.completePath}
-              alt={decodeFileName(file.fileName)}
-              onClick={() => setLightboxIndex(idx)}
-            />
-          ))}
+          {images.map((file, idx) => {
+            const { src, srcSet } = getThumbnailSources(file);
+            return (
+              <ImageThumbnail
+                key={file.completePath}
+                src={src}
+                srcSet={srcSet}
+                alt={decodeFileName(file.fileName)}
+                onClick={() => setLightboxIndex(idx)}
+              />
+            );
+          })}
         </ImageGallery>
       )}
 

--- a/packages/web-app/src/types/document.type.js
+++ b/packages/web-app/src/types/document.type.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types';
 import authorType from './author.type';
 import idNameType from './idName.type';
 
+export const ThumbnailsPropTypes = PropTypes.shape({
+  small: PropTypes.string,
+  medium: PropTypes.string,
+  large: PropTypes.string
+});
+
 export const DocumentSimplePropTypes = PropTypes.shape({
   id: PropTypes.number.isRequired,
   title: PropTypes.string,
@@ -58,7 +64,8 @@ export const DocumentPropTypes = PropTypes.shape({
   files: PropTypes.arrayOf(
     PropTypes.shape({
       fileName: PropTypes.string,
-      completePath: PropTypes.string
+      completePath: PropTypes.string,
+      thumbnails: ThumbnailsPropTypes
     })
   )
 });


### PR DESCRIPTION
# feat(documents): use responsive image thumbnails from API

## 🤔 What

- Consume the new `thumbnails` object (`small`/`medium`/`large` WebP variants) returned by the API on document file resources, in addition to the existing `completePath`.
- Render responsive `srcSet`/`sizes` on thumbnail cards (`ImageThumbnail`) instead of always loading the full-resolution image.
- Use the `large` variant in the full-screen lightbox (`ImageLightbox`), while keeping `completePath` for downloads (always full resolution).
- Gracefully fall back to `completePath` whenever `thumbnails` or an individual variant is `null` (non-image files, failed generation, uploads predating the backfill, or images smaller than a given variant's target width).

Closes #1447

## 🤷‍♂️ Why

Document-heavy pages (document detail, cave/entrance/massif "associated documents" sections, document lists) were always loading full-resolution images even for small thumbnail cards, which is wasteful — especially on mobile. The API now generates responsive WebP variants specifically to fix this.

## 🔍 How

- `types/document.type.js`: added a shared `ThumbnailsPropTypes` shape (`{small, medium, large}`, all optional/nullable) and added `thumbnails` to the `files` prop type.
- `components/common/DocumentsList/utils/imageUtils.js`: two new pure helpers reused everywhere images are rendered:
  - `getThumbnailSources(file)` → `{src, srcSet}`, building `srcSet` only from non-null variants and falling back to `completePath`.
  - `getLightboxSrc(file)` → `large` variant, falling back to `completePath`.
- `components/common/DocumentsList/ImageThumbnail.jsx`: accepts optional `srcSet`/`sizes` props, with a `sizes` default that mirrors its own `ThumbnailCard` breakpoint (100vw below `sm`, fixed 240px from `sm` up) — so the value lives next to the CSS it describes instead of being duplicated by callers.
- `components/common/DocumentsList/ImageLightbox.jsx`: full-screen image now uses `getLightboxSrc`; the download button still uses `completePath`.
- `components/common/DocumentsList/Files.jsx` and `pages/DocumentDetails/Section.jsx`: both thumbnail grids now go through `getThumbnailSources`.

No Redux/action/reducer changes were needed — API responses are stored as-is, so `thumbnails` reaches components without any normalization step.

## 🔗 Related API PR

https://github.com/GrottoCenter/grottocenter-api/pull/1719

## 🧪 Testing

- `yarn lint` passes.
- Manually verified in the browser Network tab that thumbnail cards request `small`/`medium` WebP variants (not `completePath`) and that resizing the viewport changes which variant loads.
- Verified the lightbox loads the `large` variant and that the download button still fetches `completePath`.
- Verified fallback behavior with files where `thumbnails` is `null` and where only some variants are `null`.

## 📸 Previews

_N/A — no visual change at the rendered size/quality, only network payload size changes._
