### PR TITLE
fix(quick-search): do not propose single-entrance caves alongside their entrance

### DIFF
--- a/packages/web-app/src/components/appli/QuickSearch.jsx
+++ b/packages/web-app/src/components/appli/QuickSearch.jsx
@@ -26,8 +26,9 @@ const QuickSearch = ({ hasFixWidth, onClose }) => {
   const debouncedInput = useDebounce(input, AUTOCOMPLETE_DEBOUNCE_DELAY);
 
   // A single-entrance cavity would appear twice (once as its cave, once as its
-  // entrance). Keep only networks (caves with 2+ entrances) and entrances so the
-  // list shows networks or entrances, never a cave redundant with its entrance.
+  // entrance). Keep only networks (caves with 2+ entrances) and all other entity
+  // types (entrances, organizations, massifs) so the list never shows a cave
+  // redundant with its entrance.
   const filteredResults = useMemo(
     () =>
       results.filter(

--- a/packages/web-app/src/components/appli/QuickSearch.jsx
+++ b/packages/web-app/src/components/appli/QuickSearch.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
@@ -24,6 +24,17 @@ const QuickSearch = ({ hasFixWidth, onClose }) => {
   const [input, setInput] = useState('');
 
   const debouncedInput = useDebounce(input, AUTOCOMPLETE_DEBOUNCE_DELAY);
+
+  // A single-entrance cavity would appear twice (once as its cave, once as its
+  // entrance). Keep only networks (caves with 2+ entrances) and entrances so the
+  // list shows networks or entrances, never a cave redundant with its entrance.
+  const filteredResults = useMemo(
+    () =>
+      results.filter(
+        ({ _type, nbEntrances }) => _type !== 'caves' || (nbEntrances ?? 0) > 1
+      ),
+    [results]
+  );
 
   const handleSelection = selection => {
     if (!selection.id) return;
@@ -66,7 +77,7 @@ const QuickSearch = ({ hasFixWidth, onClose }) => {
       onInputChange={setInput}
       inputValue={input}
       label={formatMessage({ id: 'Quick search' })}
-      suggestions={results}
+      suggestions={filteredResults}
       onSelection={handleSelection}
       hasError={!!errors}
       isLoading={isLoading}


### PR DESCRIPTION
# fix(quick-search): do not propose single-entrance caves alongside their entrance

## 🤔 What

Filter the quick search results so a single-entrance cavity is no longer listed twice.

- Entrances are always kept.
- Caves are kept only when they are networks (`nbEntrances > 1`).
- Other entities (organizations, massifs) are untouched.

## 🤷‍♂️ Why

A cavity with a single entrance was showing up twice in the quick search dropdown: once as its cave and once as its entrance. Since the two entries point to the same physical cavity, this is redundant and confusing. We only want to propose networks or entrances.

## 🔍 How

Added a memoized `filteredResults` in `QuickSearch.jsx` that removes cave results whose `nbEntrances` is not greater than 1, before passing the suggestions to the autocomplete. The filter is recomputed only when the server results change.

## 🔗 Related API PR

_None._

## 🧪 Testing

1. Open the quick search.
2. Type the name of a cavity that has a single entrance (e.g. "Sarrasins (Sialet des)").
3. Verify only the entrance is proposed, not a duplicate cave entry.
4. Type the name of a network (2+ entrances) and verify it still appears as a network.

## 📸 Previews

Before (bug) 
<img width="663" height="182" alt="image" src="https://github.com/user-attachments/assets/2d268d54-a825-4cb6-aafe-92d9346ab4ca" />

After (fixed)
<img width="639" height="465" alt="image" src="https://github.com/user-attachments/assets/83d08848-e294-4c56-954a-29f08e052b77" />

