### PR TITLE
refactor(theme): migrate to standard MUI spacing scale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,12 +394,15 @@ cy.get('.MuiButton-root').click();
 // ✅
 cy.get('[data-testid="save-btn"]').click();
 
-// ❌ Non-integer values with theme.spacing (array-type spacing only accepts integer indices)
-sx={{ mt: theme.spacing(1.5), p: theme.spacing(0.5) }}
-// ✅ Use integer multiples only
-sx={{ mt: theme.spacing(1), p: theme.spacing(2) }}
-// ✅ Or use raw pixel values for non-standard spacing
+// ❌ Raw pixel values for ordinary spacing (bypasses the theme scale)
 sx={{ mt: '12px', p: '4px' }}
+// ✅ Use theme.spacing() factors — the theme uses the standard MUI scale
+// (spacing: 8), so theme.spacing(factor) = factor * 8px. Fractional factors
+// (0.25, 0.5, 1.5, ...) are valid and resolve correctly.
+sx={{ mt: theme.spacing(1.5), p: theme.spacing(0.5) }}
+// ✅ Shorthand props go through the same scale — prefer them over theme.spacing()
+// when there's no other computation involved
+sx={{ mt: 1.5, p: 0.5 }}
 ```
 
 ---

--- a/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/DocumentSearch.jsx
@@ -159,7 +159,7 @@ const DocumentSearch = () => {
           e.name,
           <Box
             key={e.name}
-            sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <Icon sx={{ fontSize: 18, color: 'text.secondary' }} />
             <Translate>{e.name}</Translate>
           </Box>
@@ -183,7 +183,7 @@ const DocumentSearch = () => {
         sx={{
           display: 'flex',
           flexDirection: { xs: 'column', sm: 'row' },
-          gap: 1,
+          gap: 0.5,
           alignItems: { sm: 'center' },
           width: '100%'
         }}>
@@ -201,11 +201,10 @@ const DocumentSearch = () => {
             options={docTypeOptions}
             onChange={e => updateFilter('type', e)}
             value={filterState.type}
-            sx={{ mx: { xs: 0, sm: '4px' } }}
+            sx={{ mx: { xs: 0.25, sm: '4px' } }}
           />
         </Box>
       </Box>
-
       <SearchFilterAccordion
         filterCount={advancedFilterCount}
         expanded={advancedExpanded}
@@ -368,7 +367,6 @@ const DocumentSearch = () => {
           onChange={e => setMatchAllFields(e)}
         />
       </SearchFilterAccordion>
-
       <SearchActionButtons
         showReset={query !== '' || countActiveFilters(filterState) > 0}
         onReset={() => {
@@ -382,7 +380,6 @@ const DocumentSearch = () => {
           startAdvancedsearch('', initialFilterState, true);
         }}
       />
-
       <ActiveFilterChips
         filterState={filterState}
         query={query}

--- a/packages/web-app/src/components/appli/AdvancedSearch/EntitySearchPage.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/EntitySearchPage.jsx
@@ -60,7 +60,7 @@ const EntitySearchPage = ({
       content={
         <>
           {children}
-          <Divider sx={{ my: 2 }} />
+          <Divider sx={{ my: 1 }} />
           <SearchResults entityType={entityType} />
         </>
       }

--- a/packages/web-app/src/components/appli/AdvancedSearch/PersonSearch.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/PersonSearch.jsx
@@ -57,13 +57,14 @@ const PersonSearch = () => {
         value={query}
         placeholder={formatMessage({ id: 'Search for a person...' })}
       />
-
       <SearchFilterAccordion
         filterCount={countActiveFilters({ personType }, ['personType'])}
         expanded={advancedExpanded}
         onExpandedChange={setAdvancedExpanded}>
         <SearchFieldset title="Type">
-          <Box sx={{ display: 'flex', gap: 0.75 }}>
+          <Box sx={{
+            display: 'flex'
+          }}>
             {TYPE_OPTIONS.map(opt => (
               <Chip
                 key={String(opt.value)}
@@ -79,7 +80,6 @@ const PersonSearch = () => {
           </Box>
         </SearchFieldset>
       </SearchFilterAccordion>
-
       <SearchActionButtons
         showReset={query !== '' || personType !== null}
         onReset={() => {

--- a/packages/web-app/src/components/appli/AdvancedSearch/SearchElements.jsx
+++ b/packages/web-app/src/components/appli/AdvancedSearch/SearchElements.jsx
@@ -43,7 +43,7 @@ const StyledForm = styled('form')`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
   margin-bottom: 0;
 `;
 
@@ -60,7 +60,7 @@ export const SearchForm = ({ children, onSubmit, title }) => (
       <Typography
         variant="overline"
         color="text.secondary"
-        sx={{ width: '100%', display: 'block', mb: -1 }}>
+        sx={{ width: '100%', display: 'block', mb: -0.5 }}>
         <Translate>{title}</Translate>
       </Typography>
     )}
@@ -78,7 +78,7 @@ export const SearchFormContainer = styled('div')`
   flex-wrap: wrap;
   align-items: center;
   width: 100%;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 
   @media (min-width: 550px) {
     > * {
@@ -400,16 +400,20 @@ export const SearchSlider = ({
 
   return (
     <FormControl
-      sx={{ flex: 1, minWidth: '200px', mx: 3, alignItems: 'center' }}>
+      sx={{ flex: 1, minWidth: '200px', mx: 2, alignItems: 'center' }}>
       <FormLabel
-        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: -2 }}>
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          mb: -2
+        }}>
         {icon}
         {label}
         <IconButton
           size="small"
           onClick={handleClear}
           aria-label={formatMessage({ id: 'clear filter' })}
-          sx={{ visibility: isDirty ? 'visible' : 'hidden', p: 0 }}>
+          sx={{ visibility: isDirty ? 'visible' : 'hidden', p: 0.25 }}>
           <ClearIcon fontSize="small" />
         </IconButton>
       </FormLabel>
@@ -476,13 +480,19 @@ SearchSlider.propTypes = {
 export const SearchBooleanToggle = ({ label, onChange, value, icon }) => {
   const { formatMessage } = useIntl();
   return (
-    <FormControl sx={{ alignItems: 'center', mx: 2 }}>
+    <FormControl sx={{ alignItems: 'center', mx: 1 }}>
       <FormLabel
-        sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        sx={{
+          mb: 0.5,
+          display: 'flex',
+          alignItems: 'center'
+        }}>
         {icon}
         <Translate>{label}</Translate>
       </FormLabel>
-      <Box sx={{ display: 'flex', gap: 0.75 }}>
+      <Box sx={{
+        display: 'flex'
+      }}>
         <Chip
           label={formatMessage({ id: 'Yes' })}
           size="small"
@@ -608,7 +618,10 @@ export const SearchMatchAllFieldsToogle = ({ isChecked, onChange }) => {
         />
       }
       label={
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'center'
+        }}>
           <Translate>Matching all fields</Translate>
           <Tooltip
             title={formatMessage({
@@ -695,7 +708,7 @@ export const ActiveFilterChips = ({
   if (chips.length === 0) return null;
 
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1, mb: 1 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5, mb: 0.5 }}>
       {chips.map(chip => (
         <Chip
           key={chip.key}
@@ -742,7 +755,7 @@ export const SearchFilterAccordion = ({
       '&:before': { display: 'none' }
     }}>
     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <FilterAltIcon color="primary" />
         <Typography variant="body1">
           <Translate>Advanced filters</Translate>
@@ -757,7 +770,7 @@ export const SearchFilterAccordion = ({
         )}
       </Box>
     </AccordionSummary>
-    <AccordionDetails sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <AccordionDetails sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       {children}
     </AccordionDetails>
   </Accordion>
@@ -770,7 +783,7 @@ SearchFilterAccordion.propTypes = {
 };
 
 export const SearchActionButtons = ({ onReset, showReset = true }) => (
-  <CardActions sx={{ padding: 0, justifyContent: 'flex-end', width: '100%' }}>
+  <CardActions sx={{ padding: 0.25, justifyContent: 'flex-end', width: '100%' }}>
     {showReset && (
       <Button
         type="button"

--- a/packages/web-app/src/components/appli/Api.jsx
+++ b/packages/web-app/src/components/appli/Api.jsx
@@ -32,7 +32,7 @@ const Api = () => {
     <Layout
       title={formatMessage({ id: 'Grottocenter API' })}
       content={
-        <Grid container justifyContent="center" spacing={2}>
+        <Grid container justifyContent="center" spacing={1}>
           <Grid size={{ xs: 12, md: 6 }} style={{ maxWidth: '400px' }}>
             <img
               style={{ width: '100%' }}

--- a/packages/web-app/src/components/appli/AuthChecker/index.jsx
+++ b/packages/web-app/src/components/appli/AuthChecker/index.jsx
@@ -14,7 +14,7 @@ import { usePermissions } from '../../../hooks';
 
 const SpacedButton = styled(Button)`
   ${({ theme }) => `
-    margin: ${theme.spacing(1)};
+    margin: ${theme.spacing(0.5)};
 `}
 `;
 
@@ -50,7 +50,7 @@ const AuthChecker = ({ errorMessageComponent, componentToDisplay }) => {
     <CenteredBlock>
       {errorMessageComponent || (
         <>
-          <Alert severity="error" sx={{ mb: 2 }}>
+          <Alert severity="error" sx={{ mb: 1 }}>
             {formatMessage({
               id: 'You must be authenticated in order to use this feature.'
             })}

--- a/packages/web-app/src/components/appli/Country/CountryList.jsx
+++ b/packages/web-app/src/components/appli/Country/CountryList.jsx
@@ -91,7 +91,7 @@ const CountryList = ({ countries = [] }) => {
       }
       content={
         <Box sx={{ maxWidth: 680 }}>
-          <SearchInput value={search} onChange={setSearch} sx={{ mb: 2 }} />
+          <SearchInput value={search} onChange={setSearch} sx={{ mb: 1 }} />
           <TableContainer
             component={Paper}
             sx={{ maxHeight: theme => `calc(100vh - ${theme.appBarHeight + 184}px)` }}>
@@ -124,7 +124,7 @@ const CountryList = ({ countries = [] }) => {
                     sx={{
                       '&:last-of-type td, &:last-of-type th': { border: 0 }
                     }}>
-                    <TableCell sx={{ pr: 0, width: 40 }}>
+                    <TableCell sx={{ pr: 0.25, width: 40 }}>
                       <FlagImage iso2={row.iso2} alt={row.localized} />
                     </TableCell>
                     <TableCell component="th" scope="row">

--- a/packages/web-app/src/components/appli/Country/RegionsList.jsx
+++ b/packages/web-app/src/components/appli/Country/RegionsList.jsx
@@ -102,16 +102,16 @@ const RegionsList = ({ countryId }) => {
   }
 
   return (
-    <Box sx={{ mt: -2 }}>
+    <Box sx={{ mt: -1 }}>
       {regions.length > 10 && (
-        <SearchInput value={search} onChange={setSearch} sx={{ mb: 1 }} />
+        <SearchInput value={search} onChange={setSearch} sx={{ mb: 0.5 }} />
       )}
       {filtered.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           {formatMessage({ id: 'No results' })}
         </Typography>
       ) : (
-        <Box sx={{ columnCount: { xs: 1, sm: 2, md: 3 }, columnGap: 6 }}>
+        <Box sx={{ columnCount: { xs: 1, sm: 2, md: 3 }, columnGap: 8 }}>
           {filtered.map(region => (
             <Box
               key={region.iso}
@@ -120,8 +120,8 @@ const RegionsList = ({ countryId }) => {
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                py: 1,
-                px: 1,
+                py: 0.5,
+                px: 0.5,
                 borderRadius: 1,
                 textDecoration: 'none',
                 color: 'text.primary',
@@ -132,7 +132,7 @@ const RegionsList = ({ countryId }) => {
                 label={region.iso.split('-')[1]}
                 color="primary"
                 size="small"
-                sx={{ mr: 1, flexShrink: 0 }}
+                sx={{ mr: 0.5, flexShrink: 0 }}
               />
               <Typography variant="body1">{region.name}</Typography>
             </Box>

--- a/packages/web-app/src/components/appli/Country/index.jsx
+++ b/packages/web-app/src/components/appli/Country/index.jsx
@@ -121,88 +121,88 @@ const Country = ({
 
   return (
     <PageContainer>
-    <div ref={componentRef}>
-      <PageHeader
-        title={title}
-        icon={<CustomIcon type="country" />}
-        subheader={subheader}
-        actions={actions}
-      />
-      {isLoading && (
-        <Card sx={{ m: 2, p: 3 }}>
-          <Skeleton height={300} />
-          <Skeleton height={100} />
-        </Card>
-      )}
-      {error && (
-        <Card sx={{ m: 2, p: 3 }}>
-          <Alert
-            title={formatMessage({
-              id: 'Error, the country data you are looking for is not available.'
-            })}
-            severity="error"
-          />
-        </Card>
-      )}
-      {country && (
-        <>
-          {!isEmpty(position) && (
+      <div ref={componentRef}>
+        <PageHeader
+          title={title}
+          icon={<CustomIcon type="country" />}
+          subheader={subheader}
+          actions={actions}
+        />
+        {isLoading && (
+          <Card sx={{ m: 1, p: 2 }}>
+            <Skeleton height={300} />
+            <Skeleton height={100} />
+          </Card>
+        )}
+        {error && (
+          <Card sx={{ m: 1, p: 2 }}>
+            <Alert
+              title={formatMessage({
+                id: 'Error, the country data you are looking for is not available.'
+              })}
+              severity="error"
+            />
+          </Card>
+        )}
+        {country && (
+          <>
+            {!isEmpty(position) && (
+              <ScrollableContent
+                content={
+                  <Box sx={{ minHeight: 200 }}>
+                    <CustomMapContainer
+                      center={position}
+                      dragging={!isMobile}
+                      forceCentering
+                      scrollWheelZoom={false}
+                      wholePage={false}
+                      shouldChangeControlInFullscreen={false}
+                      zoom={4}>
+                      <Marker icon={CoordinatesMarker} position={position} />
+                    </CustomMapContainer>
+                  </Box>
+                }
+              />
+            )}
+            <Box sx={{ mx: 1, mb: 0.5 }}>
+              <Button
+                fullWidth
+                variant="contained"
+                color="primary"
+                size="large"
+                startIcon={<CustomIcon type="entrance" size={24} />}
+                onClick={() => navigate(`/ui/countries/${country.id}/entrances`)}>
+                {formatMessage({ id: 'Entrances list' })}
+                {dataCountry?.nb_caves ? ` (${dataCountry.nb_caves})` : ''}
+              </Button>
+            </Box>
+            <StatisticsDataDashboard
+              countryId={country.id}
+              description={formatMessage({
+                id: 'Discover the numbers about this country and its massifs and caves.'
+              })}
+            />
+            {(country.guidelines?.length > 0 || permissions.isAuth) && (
+              <Guidelines
+                entityType="countries"
+                entityId={country.id}
+                guidelines={country.guidelines}
+              />
+            )}
+            <AssociationSection
+              organizations={country?.organizations}
+              entityType="country"
+              entityId={country?.id}
+              isLoading={isLoading}
+            />
             <ScrollableContent
-              content={
-                <Box sx={{ minHeight: 200 }}>
-                  <CustomMapContainer
-                    center={position}
-                    dragging={!isMobile}
-                    forceCentering
-                    scrollWheelZoom={false}
-                    wholePage={false}
-                    shouldChangeControlInFullscreen={false}
-                    zoom={4}>
-                    <Marker icon={CoordinatesMarker} position={position} />
-                  </CustomMapContainer>
-                </Box>
-              }
+              anchorId="regions"
+              title={formatMessage({ id: 'Regions' })}
+              content={<RegionsList countryId={country.id} />}
             />
-          )}
-          <Box sx={{ mx: 2, mb: 1 }}>
-            <Button
-              fullWidth
-              variant="contained"
-              color="primary"
-              size="large"
-              startIcon={<CustomIcon type="entrance" size={24} />}
-              onClick={() => navigate(`/ui/countries/${country.id}/entrances`)}>
-              {formatMessage({ id: 'Entrances list' })}
-              {dataCountry?.nb_caves ? ` (${dataCountry.nb_caves})` : ''}
-            </Button>
-          </Box>
-          <StatisticsDataDashboard
-            countryId={country.id}
-            description={formatMessage({
-              id: 'Discover the numbers about this country and its massifs and caves.'
-            })}
-          />
-          {(country.guidelines?.length > 0 || permissions.isAuth) && (
-            <Guidelines
-              entityType="countries"
-              entityId={country.id}
-              guidelines={country.guidelines}
-            />
-          )}
-          <AssociationSection
-            organizations={country?.organizations}
-            entityType="country"
-            entityId={country?.id}
-            isLoading={isLoading}
-          />
-          <ScrollableContent
-            anchorId="regions"
-            title={formatMessage({ id: 'Regions' })}
-            content={<RegionsList countryId={country.id} />}
-          />
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
     </PageContainer>
   );
 };

--- a/packages/web-app/src/components/appli/Descriptions/Description.jsx
+++ b/packages/web-app/src/components/appli/Descriptions/Description.jsx
@@ -17,8 +17,8 @@ import Contribution from '../../common/Contribution/Contribution';
 const ListItemStyled = styled(ListItem)`
   display: flow-root;
   border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  padding-top: ${({ theme }) => theme.spacing(1)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(0.5)};
+  padding-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 const Description = ({
   description,
@@ -66,7 +66,7 @@ const Description = ({
 
   return (
     <ListItemStyled disableGutters>
-      <Box sx={{ float: 'right', ml: 1 }}>
+      <Box sx={{ float: 'right', ml: 0.5 }}>
         <ActionButtons
           isLoading={isActionLoading}
           isUpdating={isUpdateFormVisible}

--- a/packages/web-app/src/components/appli/Descriptions/index.jsx
+++ b/packages/web-app/src/components/appli/Descriptions/index.jsx
@@ -91,8 +91,8 @@ const Descriptions = ({
         <>
           {hasNetworkDescriptions && (
             <>
-              <Divider sx={{ mb: 1 }} />
-              <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
+              <Divider sx={{ mb: 0.5 }} />
+              <Typography variant="body1" color="text.secondary" sx={{ mb: 0.5 }}>
                 <FormattedMessage
                   id="network.descriptions.callout"
                   values={{

--- a/packages/web-app/src/components/appli/Duplicates/TableActions.jsx
+++ b/packages/web-app/src/components/appli/Duplicates/TableActions.jsx
@@ -7,9 +7,9 @@ import ActionButton from '../../common/ActionButton';
 const Wrapper = styled('div')`
   display: flex;
   flex-direction: row;
-  margin-top: ${({ theme }) => theme.spacing(3)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
   & > button {
-    margin-right: ${({ theme }) => theme.spacing(2)};
+    margin-right: ${({ theme }) => theme.spacing(1)};
   }
 `;
 

--- a/packages/web-app/src/components/appli/EntitiesForm/Comment/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Comment/index.jsx
@@ -149,7 +149,7 @@ const CreateCommentForm = ({ closeForm, onSubmit, values, isNewComment }) => {
   });
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputText

--- a/packages/web-app/src/components/appli/EntitiesForm/Description/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Description/index.jsx
@@ -32,7 +32,7 @@ const CreateDescriptionForm = ({
   });
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputText

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/FormContent.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/FormContent.jsx
@@ -126,7 +126,7 @@ const FormContent = ({ onCancel }) => {
       <DocumentTypeSelect />
       {!isUnknown(docType) && simple && (
         /* Simplified layout for Image / Topographic Drawing — no sections */
-        (<Box sx={{ mt: 1 }}>
+        <Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -154,11 +154,11 @@ const FormContent = ({ onCancel }) => {
           />
           {filesIntro}
           <AddFileForm {...addFileFormProps} />
-        </Box>)
+        </Box>
       )}
       {!isUnknown(docType) && isEvent(docType) && (
         /* Event layout: Title, Language, Description (optional), Event date, ISO location */
-        (<Box sx={{ mt: 1 }}>
+        <Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -204,11 +204,11 @@ const FormContent = ({ onCancel }) => {
             labelName="ISO countries or regions"
             required={false}
           />
-        </Box>)
+        </Box>
       )}
       {!isUnknown(docType) && isAuthorizationToPublish(docType) && (
         /* Authorization To Publish layout: Title, Language, Description (optional), Date, Files (no license) */
-        (<Box sx={{ mt: 1 }}>
+        <Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -246,7 +246,7 @@ const FormContent = ({ onCancel }) => {
           </Suspense>
           {filesIntro}
           <AddFileForm {...addFileFormProps} showAuthorization={false} />
-        </Box>)
+        </Box>
       )}
       {!isUnknown(docType) &&
         !simple &&

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/FormContent.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/FormContent.jsx
@@ -97,7 +97,7 @@ const FormContent = ({ onCancel }) => {
   };
 
   const filesIntro = (
-    <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ mt: 1, mb: 0.5 }}>
       {formatMessage({
         id: 'You can create a document that contains one or several files at once.'
       })}
@@ -116,19 +116,17 @@ const FormContent = ({ onCancel }) => {
   return (
     <FormContainer>
       {linkedEntrance && (
-        <Alert severity="info" sx={{ mb: 3 }}>
+        <Alert severity="info" sx={{ mb: 2 }}>
           {formatMessage(
             { id: 'This document will be linked to entrance: {name}' },
             { name: <strong>{linkedEntrance.name}</strong> }
           )}
         </Alert>
       )}
-
       <DocumentTypeSelect />
-
       {!isUnknown(docType) && simple && (
         /* Simplified layout for Image / Topographic Drawing — no sections */
-        <Box sx={{ mt: 2 }}>
+        (<Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -147,7 +145,6 @@ const FormContent = ({ onCancel }) => {
               required
             />
           </FormRow>
-
           <StringInput
             multiline
             minRows={4}
@@ -155,15 +152,13 @@ const FormContent = ({ onCancel }) => {
             value={document.description}
             valueName={formatMessage({ id: 'Description' })}
           />
-
           {filesIntro}
           <AddFileForm {...addFileFormProps} />
-        </Box>
+        </Box>)
       )}
-
       {!isUnknown(docType) && isEvent(docType) && (
         /* Event layout: Title, Language, Description (optional), Event date, ISO location */
-        <Box sx={{ mt: 2 }}>
+        (<Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -209,12 +204,11 @@ const FormContent = ({ onCancel }) => {
             labelName="ISO countries or regions"
             required={false}
           />
-        </Box>
+        </Box>)
       )}
-
       {!isUnknown(docType) && isAuthorizationToPublish(docType) && (
         /* Authorization To Publish layout: Title, Language, Description (optional), Date, Files (no license) */
-        <Box sx={{ mt: 2 }}>
+        (<Box sx={{ mt: 1 }}>
           <FormRow>
             <StringInput
               onValueChange={value => updateAttribute('title', value)}
@@ -232,7 +226,6 @@ const FormContent = ({ onCancel }) => {
               label={formatMessage({ id: 'Document main language' })}
             />
           </FormRow>
-
           <StringInput
             multiline
             minRows={4}
@@ -240,7 +233,6 @@ const FormContent = ({ onCancel }) => {
             value={document.description}
             valueName={formatMessage({ id: 'Description' })}
           />
-
           <Suspense
             fallback={
               <>
@@ -252,17 +244,15 @@ const FormContent = ({ onCancel }) => {
               label={formatMessage({ id: 'Authorization date' })}
             />
           </Suspense>
-
           {filesIntro}
           <AddFileForm {...addFileFormProps} showAuthorization={false} />
-        </Box>
+        </Box>)
       )}
-
       {!isUnknown(docType) &&
         !simple &&
         !isEvent(docType) &&
         !isAuthorizationToPublish(docType) && (
-          <Box sx={{ mt: 2 }}>
+          <Box sx={{ mt: 1 }}>
             <FormRow>
               <StringInput
                 helperText={formatMessage({
@@ -325,9 +315,7 @@ const FormContent = ({ onCancel }) => {
             )}
           </Box>
         )}
-
       {!isUnknown(docType) && <AuthorsSection />}
-
       {!isUnknown(docType) &&
         !isEvent(docType) &&
         !isAuthorizationToPublish(docType) && (
@@ -335,7 +323,7 @@ const FormContent = ({ onCancel }) => {
             disableGutters
             elevation={0}
             sx={{
-              mt: 3,
+              mt: 2,
               border: '1px solid',
               borderColor: 'divider',
               borderRadius: 1,
@@ -346,7 +334,7 @@ const FormContent = ({ onCancel }) => {
                 {formatMessage({ id: 'Advanced metadata' })}
               </Typography>
             </AccordionSummary>
-            <AccordionDetails sx={{ pt: 0 }}>
+            <AccordionDetails sx={{ pt: 0.25 }}>
               {!isCollection(docType) && (
                 <Suspense
                   fallback={
@@ -448,7 +436,9 @@ const FormContent = ({ onCancel }) => {
                 variant="caption"
                 color="text.secondary"
                 display="block"
-                sx={{ mt: 1, mb: 0.5 }}>
+                sx={{
+                  mt: 0.5
+                }}>
                 <InternationalizedLink links={wikiBBSLinks}>
                   <Translate>
                     Speleological Abstracts (SA)/Bulletin bibliographique
@@ -485,7 +475,6 @@ const FormContent = ({ onCancel }) => {
             </AccordionDetails>
           </Accordion>
         )}
-
       {actionRow}
     </FormContainer>
   );

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AddFileForm/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AddFileForm/index.jsx
@@ -67,7 +67,6 @@ const AuthDocSelect = ({ value, onChange, disabled = false }) => {
           variant="filled"
           required={!disabled}
           label={formatMessage({ id: 'Authorization from authors' })}
-          sx={{}}
           InputProps={{
             ...params.InputProps,
             endAdornment: (

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AddFileForm/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AddFileForm/index.jsx
@@ -67,7 +67,7 @@ const AuthDocSelect = ({ value, onChange, disabled = false }) => {
           variant="filled"
           required={!disabled}
           label={formatMessage({ id: 'Authorization from authors' })}
-          sx={{ mt: 1.5 }}
+          sx={{}}
           InputProps={{
             ...params.InputProps,
             endAdornment: (
@@ -213,14 +213,16 @@ const AddFileForm = ({
         disabled={loading}
       />
       {showAuthorization && visibleFiles.length > 0 && (
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 1 }}>
           <FormControl
             component="fieldset"
             required
-            sx={{ display: 'block', mt: 2 }}>
+            sx={{ display: 'block', mt: 1 }}>
             <FormLabel
               component="legend"
-              sx={{ fontSize: '0.875rem', mb: 0.5 }}>
+              sx={{
+                fontSize: '0.875rem'
+              }}>
               {isAuthForced
                 ? formatMessage({
                     id: 'The licensing type of the document has been deduced from the parent document'
@@ -269,7 +271,7 @@ const AddFileForm = ({
                 fullWidth
                 required
                 disabled={isLicenseForced}
-                sx={{ mt: 2 }}>
+                sx={{ mt: 1 }}>
                 <InputLabel>
                   {isLicenseForced
                     ? formatMessage({

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/DocumentTypeSelect.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/DocumentTypeSelect.jsx
@@ -62,8 +62,8 @@ const FeaturedCard = ({ docType, selected, onClick }) => {
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-            gap: 1,
-            py: 3,
+            gap: 0.5,
+            py: 2,
             position: 'relative'
           }}>
           <Box
@@ -124,16 +124,15 @@ const SecondaryCard = ({ docType, selected, onClick }) => {
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1.5,
               py: 1.5,
-              '&:last-child': { pb: 1.5 }
+              '&:last-child': {}
             }}>
             <Box
               sx={{
                 color: selected ? 'primary.main' : 'text.secondary',
                 display: 'flex',
                 flexShrink: 0,
-                mr: 1,
+                mr: 0.5,
                 '& svg': { fontSize: 20 }
               }}>
               <Icon />
@@ -195,8 +194,8 @@ const DocumentTypeSelect = () => {
 
   if (!isLoaded) {
     return (
-      <Box sx={{ mt: 2 }}>
-        <Grid container spacing={2}>
+      <Box sx={{ mt: 1 }}>
+        <Grid container spacing={1}>
           {[0, 1].map(i => (
             <Grid size={6} key={i}>
               <Skeleton variant="rounded" height={110} />
@@ -208,17 +207,17 @@ const DocumentTypeSelect = () => {
   }
 
   return (
-    <Box sx={{ mt: 2 }}>
+    <Box sx={{ mt: 1 }}>
       <Typography
         variant="subtitle2"
         component="p"
-        sx={{ mb: 1, color: 'text.secondary' }}>
+        sx={{ mb: 0.5, color: 'text.secondary' }}>
         {formatMessage({ id: 'Document type' })}
         <Box component="span" sx={{ color: 'error.main', ml: '4px' }}>
           *
         </Box>
       </Typography>
-      <Grid container spacing={2} alignItems="stretch">
+      <Grid container spacing={1} alignItems="stretch">
         {featured.map(dt => (
           <Grid size={4} key={dt.id}>
             <FeaturedCard
@@ -229,22 +228,21 @@ const DocumentTypeSelect = () => {
           </Grid>
         ))}
       </Grid>
-
       {others.length > 0 && (
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 1 }}>
           {isMobile && (
             <Box
               onClick={() => setOthersOpen(o => !o)}
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: 1,
+                gap: 0.5,
                 cursor: 'pointer',
                 border: '1px solid',
                 borderColor: selectedOther ? 'primary.main' : 'divider',
                 borderRadius: 1,
-                px: 2,
-                py: 1,
+                px: 1,
+                py: 0.5,
                 bgcolor: selectedOther ? 'action.selected' : 'background.paper',
                 '&:hover': {
                   borderColor: selectedOther
@@ -253,7 +251,7 @@ const DocumentTypeSelect = () => {
                   bgcolor: 'action.hover'
                 },
                 userSelect: 'none',
-                mb: 1
+                mb: 0.5
               }}>
               {selectedOther && (
                 <Box
@@ -279,8 +277,7 @@ const DocumentTypeSelect = () => {
                 sx={{
                   bgcolor: 'action.selected',
                   borderRadius: 10,
-                  px: 1,
-                  py: 0.25,
+                  px: 0.5,
                   fontWeight: 600
                 }}>
                 {others.length}
@@ -300,7 +297,7 @@ const DocumentTypeSelect = () => {
           )}
 
           <Collapse in={isMobile ? othersOpen : true}>
-            <Grid container spacing={1}>
+            <Grid container spacing={0.5}>
               {others.map(dt => (
                 <Grid size={{ xs: 6, sm: 4, md: 3 }} key={dt.id}>
                   <SecondaryCard

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/IdentifierEditor.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/IdentifierEditor.jsx
@@ -104,7 +104,7 @@ const IdentifierEditor = () => {
         {shouldShowIdentifierTypeInput && (
           <Fade in={shouldShowIdentifierTypeInput}>
             <IdentifierTypeContainer>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
+              <Typography variant="caption" color="text.secondary" display="block">
                 <Translate>DOI, ISBN, ISSN, URL…</Translate>
               </Typography>
               <FormControl

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/IdentifierEditor.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/IdentifierEditor.jsx
@@ -104,7 +104,7 @@ const IdentifierEditor = () => {
         {shouldShowIdentifierTypeInput && (
           <Fade in={shouldShowIdentifierTypeInput}>
             <IdentifierTypeContainer>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+              <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
                 <Translate>DOI, ISBN, ISSN, URL…</Translate>
               </Typography>
               <FormControl

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelect.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelect.jsx
@@ -32,7 +32,7 @@ const Wrapper = styled('div')`
 `;
 
 const Collapse = styled(MuiCollapse)`
-  padding: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 // eslint-disable-next-line react/prop-types
@@ -114,7 +114,7 @@ const MultipleSelect = ({
           variant="caption"
           color={hasError ? 'error' : 'text.secondary'}
           display="block"
-          sx={{ mb: 0.5 }}>
+          sx={{}}>
           <Translate>{helperText}</Translate>
         </Typography>
       )}

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelect.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelect.jsx
@@ -113,8 +113,7 @@ const MultipleSelect = ({
         <Typography
           variant="caption"
           color={hasError ? 'error' : 'text.secondary'}
-          display="block"
-          sx={{}}>
+          display="block">
           <Translate>{helperText}</Translate>
         </Typography>
       )}

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelectWithOptions.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelectWithOptions.jsx
@@ -58,7 +58,7 @@ const MultipleSelectWithOptions = ({
   return (
     <>
       {helperText && (
-        <Typography variant="caption" color={hasError ? 'error' : 'text.secondary'} display="block" sx={{ mb: 0.5 }}>
+        <Typography variant="caption" color={hasError ? 'error' : 'text.secondary'} display="block" sx={{}}>
           <Translate>{helperText}</Translate>
         </Typography>
       )}

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelectWithOptions.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/MultipleSelectWithOptions.jsx
@@ -58,7 +58,7 @@ const MultipleSelectWithOptions = ({
   return (
     <>
       {helperText && (
-        <Typography variant="caption" color={hasError ? 'error' : 'text.secondary'} display="block" sx={{}}>
+        <Typography variant="caption" color={hasError ? 'error' : 'text.secondary'} display="block">
           <Translate>{helperText}</Translate>
         </Typography>
       )}

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PagesEditor.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PagesEditor.jsx
@@ -22,7 +22,7 @@ const PagesEditor = () => {
 
   return (
     <>
-      <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
+      <Typography variant="caption" color="text.secondary" display="block">
         <Translate>
           The page or the pages interval (using format: start-end, e.g: 10-12)
           where the article is.

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PagesEditor.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PagesEditor.jsx
@@ -22,7 +22,7 @@ const PagesEditor = () => {
 
   return (
     <>
-      <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+      <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
         <Translate>
           The page or the pages interval (using format: start-end, e.g: 10-12)
           where the article is.

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PublicationDatePicker.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/PublicationDatePicker.jsx
@@ -108,8 +108,8 @@ const PublicationDatePicker = ({ required = false, label = null }) => {
   ];
 
   return (
-    <Box sx={{ mt: 2 }}>
-      <Box sx={{ mb: 1 }}>
+    <Box sx={{ mt: 1 }}>
+      <Box sx={{ mb: 0.5 }}>
         <Typography variant="body2" color="text.secondary">
           {label ?? (
             <Translate>
@@ -118,7 +118,9 @@ const PublicationDatePicker = ({ required = false, label = null }) => {
             </Translate>
           )}
           {required && (
-            <Box component="span" aria-hidden sx={{ color: 'error.main', ml: 0.3 }}>
+            <Box component="span" aria-hidden sx={{
+              color: 'error.main'
+            }}>
               {'*'}
             </Box>
           )}
@@ -131,7 +133,7 @@ const PublicationDatePicker = ({ required = false, label = null }) => {
           onChange={handleGranularityChange}
           size="small"
           aria-label={formatMessage({ id: 'Date precision' })}
-          sx={{ display: 'flex', width: '100%', mb: 0 }}>
+          sx={{ display: 'flex', width: '100%', mb: 0.25 }}>
           {granularityOptions.map(opt => (
             <ToggleButton key={opt.value} value={opt.value} sx={{ flex: 1 }}>
               {opt.label}

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/index.jsx
@@ -37,7 +37,7 @@ import Translate from '../../../common/Translate';
 
 const SpacedButton = styled(Button)`
   ${({ theme }) => `
-    margin: ${theme.spacing(1)};
+    margin: ${theme.spacing(0.5)};
 `}
 `;
 
@@ -286,7 +286,7 @@ const DocumentSubmission = ({ onCancel }) => {
             <CenteredBlock>
               {documentState.errorMessages.map(error => (
                 <Fade in={documentState.errorMessages.length > 0} key={error}>
-                  <Alert severity="error" sx={{ mt: 1 }}>
+                  <Alert severity="error" sx={{ mt: 0.5 }}>
                     {formatMessage({ id: error })}
                   </Alert>
                 </Fade>

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/CaveDetail.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/CaveDetail.jsx
@@ -50,7 +50,7 @@ const CaveDetail = ({
   return (
     <FormSection title="Characteristics">
       {isShared && caveId && (
-        <Alert severity="info" sx={{ mb: 2 }}>
+        <Alert severity="info" sx={{ mb: 1 }}>
           <FormattedMessage
             id="Some of these characteristics are locked here because they belong to the network {networkLink} and are shared by all its entrances."
             values={{
@@ -64,7 +64,7 @@ const CaveDetail = ({
           />
         </Alert>
       )}
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
         <NumberField
           name="cave.depth"
           control={control}
@@ -107,7 +107,7 @@ const CaveDetail = ({
           inputProps={{ max: new Date().getFullYear() }}
         />
       </Box>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 2 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
         {/* Diving belongs to the cave (locked when shared); touristic site is
             an entrance-level attribute (always editable). */}
         <BoolToggleChip

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceAttributes.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceAttributes.jsx
@@ -9,7 +9,7 @@ import { ENTRANCE_HAZARD_FIELDS } from '../../../../conf/entranceCharacteristics
 // chips. Selected = the point of attention applies to this entrance.
 const EntranceAttributes = ({ control }) => (
   <FormSection title="Hazards & restrictions">
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
       {ENTRANCE_HAZARD_FIELDS.map(({ field, label, icon }) => (
         <BoolToggleChip
           key={field}

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceDetail.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/EntranceDetail.jsx
@@ -59,14 +59,13 @@ const EntranceDetail = ({
           onZoomChange={setMapZoom}
         />
       )}
-
       <Box
         sx={{
           display: 'flex',
           flexWrap: 'wrap',
           alignItems: 'center',
-          gap: 2,
-          mt: 2
+          gap: 1,
+          mt: 1
         }}
       >
         <NumberField

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/NameSuggestionDropdown.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/NameSuggestionDropdown.jsx
@@ -105,7 +105,7 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: 1,
+                    gap: 0.5,
                     p: '12px'
                   }}>
                   <CircularProgress size={18} />
@@ -118,7 +118,7 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
                   <Typography
                     variant="caption"
                     color="text.secondary"
-                    sx={{ display: 'block', px: '12px', pt: 1 }}>
+                    sx={{ display: 'block', px: '12px', pt: 0.5 }}>
                     {formatMessage({
                       id: 'Existing entrances with a similar name:'
                     })}
@@ -144,7 +144,7 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
                           <OpenInNewIcon
                             fontSize="small"
                             color="action"
-                            sx={{ ml: 1 }}
+                            sx={{ ml: 0.5 }}
                           />
                         </ListItemButton>
                       );
@@ -156,7 +156,6 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
           </Popper>
         </Box>
       </ClickAwayListener>
-
       <Dialog
         open={!!candidate}
         onClose={dismissConfirmation}
@@ -166,7 +165,7 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
           {formatMessage({ id: 'Is this the same cave?' })}
         </DialogTitle>
         <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
             {formatMessage({
               id: 'An entrance with a similar name already exists. Please check whether it is the same cave before creating a new one.'
             })}
@@ -187,7 +186,7 @@ const NameSuggestionDropdown = ({ control, formKey, enabled, children }) => {
                   display: 'inline-flex',
                   alignItems: 'center',
                   gap: '4px',
-                  mt: 1
+                  mt: 0.5
                 }}>
                 {formatMessage({ id: 'View full details' })}
                 <OpenInNewIcon fontSize="inherit" />

--- a/packages/web-app/src/components/appli/EntitiesForm/Entrance/NetworkMembershipSection.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Entrance/NetworkMembershipSection.jsx
@@ -52,8 +52,8 @@ const NetworkMembershipSection = ({
         sx={{
           display: 'flex',
           flexDirection: { xs: 'column', sm: 'row' },
-          gap: 2,
-          mt: 2
+          gap: 1,
+          mt: 1
         }}
       >
         <Button variant="outlined" onClick={() => navigate(movePath)}>

--- a/packages/web-app/src/components/appli/EntitiesForm/Guideline/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Guideline/index.jsx
@@ -44,7 +44,7 @@ const GuidelineForm = ({
   const isDescriptionLengthValid = value => !value || value.length <= 500;
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputText

--- a/packages/web-app/src/components/appli/EntitiesForm/History/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/History/index.jsx
@@ -26,7 +26,7 @@ const CreateHistoryForm = ({ closeForm, onSubmit, values, isNewHistory }) => {
   });
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputLanguage

--- a/packages/web-app/src/components/appli/EntitiesForm/Location/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Location/index.jsx
@@ -27,7 +27,7 @@ const CreateLocationForm = ({ closeForm, onSubmit, values, isNewLocation }) => {
   });
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputText

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifSensitivityControl.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/MassifSensitivityControl.jsx
@@ -110,7 +110,7 @@ const MassifSensitivityControl = ({ massif }) => {
   }
 
   return (
-    <Box sx={{ mt: 3, mb: 3, p: 2, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+    <Box sx={{ mt: 2, mb: 2, p: 1, border: 1, borderColor: 'divider', borderRadius: 1 }}>
       <Typography variant="h6" gutterBottom>
         {formatMessage({ id: 'Sensitivity Management' })}
       </Typography>
@@ -131,9 +131,7 @@ const MassifSensitivityControl = ({ massif }) => {
             : 'Enabling sensitivity will cascade to all entrances within the massif polygon. The designation must be based on applicable legislation.'
         })}
       </Typography>
-
-      {isPreviewLoading && <CircularProgress size={24} sx={{ ml: 2 }} />}
-
+      {isPreviewLoading && <CircularProgress size={24} sx={{ ml: 1 }} />}
       <StandardDialog
         open={isConfirmOpen}
         onClose={handleCancel}

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonLayersList.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonLayersList.jsx
@@ -62,35 +62,35 @@ const PolygonLayersList = ({
   return (
     <Paper sx={{ width: { xs: '100%', md: 250 }, maxHeight: { xs: 300, md: '70vh' }, overflow: 'auto' }}>
       {allHoles && (
-        <Alert severity="error" sx={{ py: 0 }}>
+        <Alert severity="error" sx={{ py: 0.25 }}>
           {formatMessage({
             id: 'At least one polygon must not be marked as a hole.'
           })}
         </Alert>
       )}
       {hasSelfIntersections && (
-        <Alert severity="error" sx={{ py: 0 }}>
+        <Alert severity="error" sx={{ py: 0.25 }}>
           {formatMessage({
             id: 'One or more polygons have self-intersecting edges. Fix them before saving.'
           })}
         </Alert>
       )}
       {hasInterPolygonIntersections && (
-        <Alert severity="error" sx={{ py: 0 }}>
+        <Alert severity="error" sx={{ py: 0.25 }}>
           {formatMessage({
             id: 'Polygons are crossing each other. Adjust them so they do not overlap.'
           })}
         </Alert>
       )}
       {hasTooFewPoints && (
-        <Alert severity="error" sx={{ py: 0 }}>
+        <Alert severity="error" sx={{ py: 0.25 }}>
           {formatMessage({
             id: 'One or more polygons have too few points. Add more vertices before saving.'
           })}
         </Alert>
       )}
       {areaExceeded && (
-        <Alert severity="error" sx={{ py: 0 }}>
+        <Alert severity="error" sx={{ py: 0.25 }}>
           {formatMessage(
             {
               id: 'Total area ({area} km²) exceeds the {limit} km² limit. Reduce the polygon size.'
@@ -100,7 +100,7 @@ const PolygonLayersList = ({
         </Alert>
       )}
       {hasNeedles && (
-        <Alert severity="warning" sx={{ py: 0 }}>
+        <Alert severity="warning" sx={{ py: 0.25 }}>
           {formatMessage({
             id: 'Some polygons are very thin or elongated. Check them before saving.'
           })}
@@ -151,7 +151,10 @@ const PolygonLayersList = ({
                 cursor: 'pointer'
               }}
               secondaryAction={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center'
+                }}>
                   <Tooltip
                     title={formatMessage({
                       id: 'Mark this polygon as a hole (inner ring) within another polygon'
@@ -165,7 +168,7 @@ const PolygonLayersList = ({
                         onLayerHoleToggle(layer.id);
                       }}
                       size="small"
-                      sx={{ p: 0 }}
+                      sx={{ p: 0.25 }}
                       inputProps={{
                         'aria-label': formatMessage({
                           id: 'Mark this polygon as a hole (inner ring) within another polygon'
@@ -189,7 +192,10 @@ const PolygonLayersList = ({
             >
               <ListItemText
                 primary={
-                  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box component="span" sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center'
+                  }}>
                     {(layer.hasSelfIntersection || layer.tooFewPoints) && (
                       <Tooltip
                         title={getErrorTooltip(layer)}

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/PolygonMap.jsx
@@ -224,10 +224,7 @@ const PolygonMap = ({ onChange, onValidationChange, data }) => {
 
   // Collect all kink points across all layers for rendering on the map
   const allKinkPoints = useMemo(
-    () => [
-      ...mapLayers.flatMap(l => l.kinkPoints || []),
-      ...interPolygonKinks
-    ],
+    () => [...mapLayers.flatMap(l => l.kinkPoints || []), ...interPolygonKinks],
     [mapLayers, interPolygonKinks]
   );
 
@@ -655,14 +652,13 @@ const PolygonMap = ({ onChange, onValidationChange, data }) => {
 
   return (
     <>
-      <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: 1 }}>
         <ShapefileImport onImport={handleShapefileImport} />
       </Box>
-
       <Box
         sx={{
           display: 'flex',
-          gap: 2,
+          gap: 1,
           flexDirection: { xs: 'column', md: 'row' }
         }}>
         <Box
@@ -689,12 +685,10 @@ const PolygonMap = ({ onChange, onValidationChange, data }) => {
               backgroundColor: 'rgba(255, 255, 255, 0.7)',
               zIndex: 1000,
               borderRadius: 1,
-              ...(validating
-                ? { display: 'flex' }
-                : { visibility: 'hidden' })
+              ...(validating ? { display: 'flex' } : { visibility: 'hidden' })
             }}>
             <CircularProgress size={40} />
-            <Typography variant="body2" sx={{ mt: 1 }}>
+            <Typography variant="body2" sx={{ mt: 0.5 }}>
               {formatMessage({ id: 'Validating polygons...' })}
             </Typography>
           </Box>

--- a/packages/web-app/src/components/appli/EntitiesForm/Massif/ShapefileImport.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Massif/ShapefileImport.jsx
@@ -380,7 +380,6 @@ const ShapefileImport = ({ onImport }) => {
         size="small">
         {formatMessage({ id: 'Import geometry' })}
       </Button>
-
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
         <DialogTitle>{formatMessage({ id: 'Import geometry' })}</DialogTitle>
         <DialogContent>
@@ -388,8 +387,8 @@ const ShapefileImport = ({ onImport }) => {
             sx={{
               display: 'flex',
               flexDirection: 'column',
-              gap: 2,
-              pt: 1,
+              gap: 1,
+              pt: 0.5,
               minHeight: 220
             }}>
             {parseError && (
@@ -417,8 +416,8 @@ const ShapefileImport = ({ onImport }) => {
             <Box
               sx={{
                 alignItems: 'center',
-                gap: 1,
-                py: 1,
+                gap: 0.5,
+                py: 0.5,
                 ...(analyzing
                   ? { display: 'flex' }
                   : { position: 'absolute', visibility: 'hidden' })
@@ -457,7 +456,7 @@ const ShapefileImport = ({ onImport }) => {
                     {formatMessage({ id: 'Vertex count' })}: {vertexCount}
                   </Typography>
                   {vertexWarning && (
-                    <Alert severity={vertexWarning.severity} sx={{ mt: 1 }}>
+                    <Alert severity={vertexWarning.severity} sx={{ mt: 0.5 }}>
                       {vertexWarning.message}
                     </Alert>
                   )}

--- a/packages/web-app/src/components/appli/EntitiesForm/Organization/OrganizationLogo.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Organization/OrganizationLogo.jsx
@@ -10,7 +10,7 @@ import 'react-phone-input-2/lib/style.css';
 import 'react-dropzone-uploader/dist/styles.css';
 
 const FormControl = styled(MuiFormControl)`
-  padding-bottom: ${({ theme }) => theme.spacing(4)};
+  padding-bottom: ${({ theme }) => theme.spacing(3)};
 `;
 
 const OrganizationLogo = ({ control, errors }) => {

--- a/packages/web-app/src/components/appli/EntitiesForm/Riggings/AnchorToolbar.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Riggings/AnchorToolbar.jsx
@@ -50,18 +50,17 @@ const AnchorToolbar = ({ onInsert }) => {
           <EditNoteIcon fontSize="small" />
         </IconButton>
       </Tooltip>
-
       <Popover
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        <Box sx={{ pt: 2, px: 2, pb: 2, minWidth: 200 }}>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+        <Box sx={{ pt: 1, px: 1, pb: 1, minWidth: 200 }}>
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
             {formatMessage({ id: 'Click to insert' })}
           </Typography>
-          <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+          <Box sx={{ display: 'flex', gap: 0.5, mb: 1 }}>
             {ARROWS.map(arrow => (
               <Tooltip key={arrow} title={`${formatMessage({ id: 'Click to insert' })} ${arrow}`}>
                 <IconButton
@@ -87,20 +86,25 @@ const AnchorToolbar = ({ onInsert }) => {
             ))}
           </Box>
           <Divider sx={{ mb: '12px' }} />
-          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1 }}>
+          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>
             {formatMessage({ id: 'Anchor notation legend' })}
           </Typography>
-          <Divider sx={{ mb: 1 }} />
-          <Table size="small" sx={{ mb: 0 }}>
+          <Divider sx={{ mb: 0.5 }} />
+          <Table size="small" sx={{ mb: 0.25 }}>
             <TableBody>
               {ANCHOR_LEGEND.map(({ abbrevKey, labelKey }) => (
                 <TableRow key={abbrevKey}>
-                  <TableCell sx={{ border: 0, py: 0.5, pr: 2 }}>
+                  <TableCell sx={{
+                    border: 0,
+                    pr: 2
+                  }}>
                     <Typography variant="body2" fontWeight="bold" component="span">
                       {formatMessage({ id: abbrevKey })}
                     </Typography>
                   </TableCell>
-                  <TableCell sx={{ border: 0, py: 0.5 }}>
+                  <TableCell sx={{
+                    border: 0
+                  }}>
                     <Typography variant="body2" component="span">
                       {formatMessage({ id: labelKey })}
                     </Typography>

--- a/packages/web-app/src/components/appli/EntitiesForm/Riggings/ObstacleCard.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Riggings/ObstacleCard.jsx
@@ -19,13 +19,15 @@ const ObstacleCard = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Card variant="outlined" sx={{ px: 1, py: 0.5 }}>
+    <Card variant="outlined" sx={{
+      px: 0.5
+    }}>
       <Box
         sx={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          mb: 0
+          mb: 0.25
         }}>
         <Typography variant="caption" fontWeight="medium">
           {`${formatMessage({ id: 'Obstacle' })} ${index + 1}`}
@@ -39,8 +41,8 @@ const ObstacleCard = ({
           orientation="horizontal"
         />
       </Box>
-      <Stack spacing={0}>
-        <Box sx={{ display: 'flex', gap: 1 }}>
+      <Stack spacing={0.25}>
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <ObstacleField
               control={control}

--- a/packages/web-app/src/components/appli/EntitiesForm/Riggings/ObstacleToolbar.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Riggings/ObstacleToolbar.jsx
@@ -47,28 +47,32 @@ const ObstacleToolbar = () => {
           <InfoOutlinedIcon fontSize="small" />
         </IconButton>
       </Tooltip>
-
       <Popover
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        <Box sx={{ pt: 2, px: 2, pb: 2, minWidth: 180 }}>
-          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1 }}>
+        <Box sx={{ pt: 1, px: 1, pb: 1, minWidth: 180 }}>
+          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>
             {formatMessage({ id: 'Obstacle notation legend' })}
           </Typography>
-          <Divider sx={{ mb: 1 }} />
-          <Table size="small" sx={{ mb: 0 }}>
+          <Divider sx={{ mb: 0.5 }} />
+          <Table size="small" sx={{ mb: 0.25 }}>
             <TableBody>
               {OBSTACLE_LEGEND.map(({ abbrevKey, labelKey }) => (
                 <TableRow key={abbrevKey}>
-                  <TableCell sx={{ border: 0, py: 0.5, pr: 2 }}>
+                  <TableCell sx={{
+                    border: 0,
+                    pr: 2
+                  }}>
                     <Typography variant="body2" fontWeight="bold" component="span">
                       {formatMessage({ id: abbrevKey })}
                     </Typography>
                   </TableCell>
-                  <TableCell sx={{ border: 0, py: 0.5 }}>
+                  <TableCell sx={{
+                    border: 0
+                  }}>
                     <Typography variant="body2" component="span">
                       {formatMessage({ id: labelKey })}
                     </Typography>

--- a/packages/web-app/src/components/appli/EntitiesForm/Riggings/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Riggings/index.jsx
@@ -108,7 +108,7 @@ const CreateRiggingsForm = ({
   );
 
   return (
-    <FormContainer sx={{ marginTop: 2 }}>
+    <FormContainer sx={{ marginTop: 1 }}>
       <form autoComplete="off" onSubmit={handleSubmit(onSubmit)}>
         <FormRow>
           <InputText
@@ -127,7 +127,7 @@ const CreateRiggingsForm = ({
         </FormRow>
         {fields.length > 0 &&
           (isMobile ? (
-            <Stack spacing={2} sx={{ mt: 2 }}>
+            <Stack spacing={1} sx={{ mt: 1 }}>
               {fields.map((item, index) => (
                 <ObstacleCard
                   key={item.id}
@@ -143,7 +143,7 @@ const CreateRiggingsForm = ({
               ))}
             </Stack>
           ) : (
-            <TableContainer sx={{ mt: 2 }}>
+            <TableContainer sx={{ mt: 1 }}>
               <Table
                 size="small"
                 aria-label={formatMessage({ id: 'riggings' })}>
@@ -185,7 +185,9 @@ const CreateRiggingsForm = ({
               </Table>
             </TableContainer>
           ))}
-        <Box sx={{ mt: 0.5, mb: 1 }}>
+        <Box sx={{
+          mb: 1
+        }}>
           <Button
             onClick={handleAppend}
             color="secondary"

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/BoolToggleChip.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/BoolToggleChip.jsx
@@ -24,7 +24,7 @@ const BoolToggleChip = ({ name, label, icon, control, disabled = false }) => (
         onChange={() => onChange(!value)}
         sx={{
           textTransform: 'none',
-          gap: 1,
+          gap: 0.5,
           borderRadius: 2,
           px: '12px',
           color: 'text.secondary',

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/BoolToggleChip.stories.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/BoolToggleChip.stories.js
@@ -13,7 +13,7 @@ const ChipsGroup = () => {
     )
   });
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
       {ENTRANCE_BOOLEAN_CHARACTERISTICS.map(({ field, label, icon }) => (
         <BoolToggleChip
           key={field}

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/CoordinateFormSection.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/CoordinateFormSection.jsx
@@ -275,9 +275,8 @@ const CoordinateFormSection = ({
         markerIcon={markerIcon}
         mapHeight={mapHeight}
       />
-
       {/* CRS selector + coordinate fields, below the map */}
-      <Box display="flex" alignItems="flex-start" gap={1} mt={1} mb={1}>
+      <Box display="flex" alignItems="flex-start" gap={0.5} mt={0.5} mb={0.5}>
         <Tooltip title={formatMessage({ id: 'Change coordinate system' })}>
           <Button
             variant="outlined"
@@ -307,7 +306,7 @@ const CoordinateFormSection = ({
             minWidth: 0,
             display: 'flex',
             flexDirection: { xs: 'column', sm: 'row' },
-            gap: 1
+            gap: 0.5
           }}
         >
           {isWGS84 ? (
@@ -365,10 +364,9 @@ const CoordinateFormSection = ({
           )}
         </Box>
       </Box>
-
       {/* UTM zone/hemisphere — separate row, only when needed */}
       {!isWGS84 && isUTM && (
-        <Box display="flex" gap={1} mb={1}>
+        <Box display="flex" gap={0.5} mb={0.5}>
           <TextField
             label={formatMessage({ id: 'Zone' })}
             type="number"
@@ -392,14 +390,13 @@ const CoordinateFormSection = ({
           </TextField>
         </Box>
       )}
-
       {!isWGS84 && conversionError && (
-        <Alert severity="error" sx={{ mb: 1 }}>
+        <Alert severity="error" sx={{ mb: 0.5 }}>
           {formatMessage({ id: 'Invalid coordinates' })}
         </Alert>
       )}
       {!isWGS84 && preview && (
-        <Box display="flex" alignItems="center" gap={1} mb={1}>
+        <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
           <Typography variant="caption" color="text.secondary">
             ≈ WGS84 :
           </Typography>
@@ -411,7 +408,6 @@ const CoordinateFormSection = ({
           />
         </Box>
       )}
-
       <CRSMenu
         anchorEl={crsMenuAnchor}
         onClose={() => setCrsMenuAnchor(null)}

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/FormContainers.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/FormContainers.jsx
@@ -28,7 +28,7 @@ export const FormRow = styled('div')(
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: ${theme.spacing(2)};
+    gap: ${theme.spacing(1)};
 
     ${theme.breakpoints.up('sm')} {
       flex-wrap: nowrap;
@@ -38,8 +38,8 @@ export const FormRow = styled('div')(
 
 const StyledFormLabel = styled(FormLabel)`
   display: block;
-  padding-top: ${({ theme }) => theme.spacing(4)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(3)};
+  padding-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 export const FormSectionLabel = ({ label }) => {
@@ -52,13 +52,15 @@ FormSectionLabel.propTypes = { label: PropTypes.string.isRequired };
 // creation form a clear visual hierarchy. Responsive: lighter top margin on
 // mobile.
 export const FormSection = ({ title, children }) => (
-  <Box component="section" sx={{ mt: { xs: 3, sm: 4 } }}>
+  <Box component="section" sx={{ mt: { xs: 2, sm: 3 } }}>
     {title && (
       <>
         <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
           <Translate>{title}</Translate>
         </Typography>
-        <Divider sx={{ mt: 0.5, mb: 2 }} />
+        <Divider sx={{
+          mb: 2
+        }} />
       </>
     )}
     {children}
@@ -84,8 +86,8 @@ export const FormActionRow = ({
         display: 'flex',
         flexDirection: { xs: 'column-reverse', sm: 'row' },
         justifyContent: isCenter ? 'center' : 'flex-end',
-        gap: 2,
-        mt: 3
+        gap: 1,
+        mt: 2
       }}>
       {onCancel && (
         <MuiButton

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/LicenseBox.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/LicenseBox.jsx
@@ -9,7 +9,7 @@ import { licensesODBLink } from '../../../../conf/externalLinks';
 // forms. Purposely low-key (small muted caption + inline text links) so it
 // informs without competing with the form itself.
 const LicenceBoxStyle = styled(Typography)`
-  margin-top: ${({ theme }) => theme.spacing(2)};
+  margin-top: ${({ theme }) => theme.spacing(1)};
   text-align: center;
   color: ${({ theme }) => theme.palette.text.secondary};
 

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/MapMarkerSelector.jsx
@@ -305,7 +305,7 @@ const MapMarkerSelector = ({ control, formLatitudeKey, formLongitudeKey, additio
               display: 'flex',
               alignItems: 'center',
               gap: '6px',
-              px: 1,
+              px: 0.5,
               py: '4px',
               borderRadius: 1,
               boxShadow: 1,

--- a/packages/web-app/src/components/appli/EntitiesForm/utils/NumberField.stories.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/utils/NumberField.stories.js
@@ -23,7 +23,7 @@ const NumberFieldsGroup = ({ disabled = false }) => {
     defaultValues: Object.fromEntries(FIELDS.map(({ name }) => [name, '']))
   });
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
       {FIELDS.map(({ name, label, icon, unit }) => (
         <NumberField
           key={name}

--- a/packages/web-app/src/components/appli/Entry/Comments/Comment.jsx
+++ b/packages/web-app/src/components/appli/Entry/Comments/Comment.jsx
@@ -29,7 +29,7 @@ const StyledListItemText = styled(ListItemText)`
 `;
 
 const StyledRatings = styled(Ratings)`
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const Comment = ({ comment, entranceId, isEditAllowed, isMoving, onMoveUp, onMoveDown, isFirst, isLast }) => {
@@ -81,7 +81,7 @@ const Comment = ({ comment, entranceId, isEditAllowed, isMoving, onMoveUp, onMov
 
   return (
     <ListItemStyled disableGutters>
-      <Box sx={{ float: 'right', ml: 1 }}>
+      <Box sx={{ float: 'right', ml: 0.5 }}>
         <ActionButtons
           isLoading={isActionLoading}
           isUpdating={isUpdateFormVisible}
@@ -141,9 +141,9 @@ const Comment = ({ comment, entranceId, isEditAllowed, isMoving, onMoveUp, onMov
           {(comment.aestheticism || comment.caving || comment.approach ||
             comment.eTTrail?.length > 0 ||
             comment.eTUnderground?.length > 0) && (
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1, pt: 1 }}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.5, pt: 0.5 }}>
               {(comment.eTTrail?.length > 0 || comment.eTUnderground?.length > 0) && (
-                <Box sx={{ display: 'flex', gap: 2 }}>
+                <Box sx={{ display: 'flex', gap: 1 }}>
                   {comment.eTTrail?.length > 0 && (
                     <Duration
                       image={timeToGoIcon}

--- a/packages/web-app/src/components/appli/Entry/Comments/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Comments/index.jsx
@@ -78,7 +78,7 @@ const Comments = ({ entranceId, comments, isEditAllowed }) => {
           )}
 
           {comments.length > 0 ? (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {(() => {
                 const sorted = sortByRelevance(comments);
                 const activeIds = sorted
@@ -88,7 +88,7 @@ const Comments = ({ entranceId, comments, isEditAllowed }) => {
                   <Paper
                     key={comment.id}
                     variant="outlined"
-                    sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+                    sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
                     <Comment
                       comment={comment}
                       entranceId={entranceId}

--- a/packages/web-app/src/components/appli/Entry/Documents/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Documents/index.jsx
@@ -49,7 +49,7 @@ const Documents = ({ documents, entranceId, isEditAllowed }) => {
         icon={
           permissions.isAuth &&
           isEditAllowed && (
-            <Box display="flex" gap={1}>
+            <Box display="flex" gap={0.5}>
               <Tooltip title={formatMessage({ id: 'Create a new document' })}>
                 <Button
                   color="secondary"
@@ -127,7 +127,6 @@ const Documents = ({ documents, entranceId, isEditAllowed }) => {
           </>
         }
       />
-
     </>
   );
 };

--- a/packages/web-app/src/components/appli/Entry/Histories/History.jsx
+++ b/packages/web-app/src/components/appli/Entry/Histories/History.jsx
@@ -18,8 +18,8 @@ const ListItemStyled = styled(ListItem)`
   flex-direction: row;
   align-items: flex-start;
   border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  padding-top: ${({ theme }) => theme.spacing(1)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(0.5)};
+  padding-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const History = ({ history, entranceId, isEditAllowed, isMoving, onMoveUp, onMoveDown, isFirst, isLast }) => {
@@ -82,7 +82,7 @@ const History = ({ history, entranceId, isEditAllowed, isMoving, onMoveUp, onMov
           />
         )}
       </Box>
-      <Box sx={{ flexShrink: 0, ml: 1 }}>
+      <Box sx={{ flexShrink: 0, ml: 0.5 }}>
         <ActionButtons
           isLoading={isActionLoading}
           isUpdating={isUpdateFormVisible}

--- a/packages/web-app/src/components/appli/Entry/Locations/Location.jsx
+++ b/packages/web-app/src/components/appli/Entry/Locations/Location.jsx
@@ -17,8 +17,8 @@ import { SnapshotButton } from '../Snapshots/UtilityFunction';
 const ListItemStyled = styled(ListItem)`
   display: flow-root;
   border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  padding-top: ${({ theme }) => theme.spacing(1)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(0.5)};
+  padding-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 const Location = ({
   location,
@@ -65,7 +65,7 @@ const Location = ({
 
   return (
     <ListItemStyled disableGutters>
-      <Box sx={{ float: 'right', ml: 1 }}>
+      <Box sx={{ float: 'right', ml: 0.5 }}>
         <ActionButtons
           isLoading={isActionLoading}
           isUpdating={isUpdateFormVisible}

--- a/packages/web-app/src/components/appli/Entry/Properties.jsx
+++ b/packages/web-app/src/components/appli/Entry/Properties.jsx
@@ -50,7 +50,7 @@ const GlobalWrapper = styled('div')`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledRatings = styled(Ratings)`
@@ -82,9 +82,9 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
     <GlobalWrapper>
       <Paper
         variant="outlined"
-        sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+        sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
         <InfoSection title={formatMessage({ id: 'Location' })}>
-          <Box display="flex" flexDirection="column" gap={1}>
+          <Box display="flex" flexDirection="column" gap={0.5}>
             {entrance.latitude && entrance.longitude && (
               <Property
                 loading={isLoading}
@@ -106,7 +106,7 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
               sx={{
                 display: 'grid',
                 gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: 1
+                gap: 0.5
               }}>
               {cityValue && (
                 <Property
@@ -128,7 +128,6 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
           </Box>
         </InfoSection>
       </Paper>
-
       {(entrance.cave?.depth ||
         entrance.cave?.length ||
         entrance.cave?.temperature ||
@@ -138,13 +137,13 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
         entrance.isTouristic) && (
         <Paper
           variant="outlined"
-          sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+          sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection title={formatMessage({ id: 'Characteristics' })}>
             <Box
               sx={{
                 display: 'grid',
                 gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: 1
+                gap: 0.5
               }}>
               <DepthProperty
                 depth={entrance.cave?.depth}
@@ -189,7 +188,6 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
           </InfoSection>
         </Paper>
       )}
-
       {(entrance.hasBat ||
         entrance.dangerFlooding ||
         entrance.dangerCo2 ||
@@ -201,12 +199,12 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
         <Paper
           variant="outlined"
           sx={{
-            p: 2,
+            p: 1,
             borderRadius: 2,
             bgcolor: 'secondary.veryLight',
             borderColor: 'secondary.light'
           }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
             <WarningAmber sx={{ color: 'secondary.main', fontSize: 20 }} />
             <Typography
               variant="subtitle1"
@@ -220,7 +218,7 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
             sx={{
               display: 'grid',
               gridTemplateColumns: 'repeat(2, 1fr)',
-              gap: 1
+              gap: 0.5
             }}>
             <HasBatProperty hasBat={entrance.hasBat} isLoading={isLoading} />
             <DangerFloodingProperty
@@ -254,11 +252,10 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
           </Box>
         </Paper>
       )}
-
       {entrance.cave?.exploringOrganizations?.length > 0 && (
         <Paper
           variant="outlined"
-          sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+          sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection title={formatMessage({ id: 'Exploring organizations' })}>
             <Box
               sx={{
@@ -280,10 +277,10 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
       {dataQuality?.total != null && (
         <Paper
           variant="outlined"
-          sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+          sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection title={formatMessage({ id: 'Data quality' })}>
-            <Box display="flex" flexDirection="column" gap={1.5}>
-              <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+            <Box display="flex" flexDirection="column">
+              <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
                 <DataQualityBadge value={dataQuality.total} size={32} />
                 <Typography variant="body2">
                   {formatMessage({ id: getDataQualityLabelKey(dataQuality.total) })}
@@ -304,7 +301,7 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
                     <Typography variant="caption">
                       {formatMessage({ id: 'Details by category' })}
                     </Typography>
-                    <IconButton size="small" sx={{ p: 0 }}>
+                    <IconButton size="small" sx={{ p: 0.25 }}>
                       {categoriesOpen ? (
                         <ExpandLess fontSize="small" />
                       ) : (
@@ -320,7 +317,7 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
                     sx={{
                       display: 'grid',
                       gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
-                      columnGap: 3,
+                      columnGap: 2,
                       rowGap: '4px',
                       pt: '4px'
                     }}>
@@ -338,7 +335,7 @@ const Properties = ({ isLoading = false, entrance, dataQuality }) => {
                           key={key}
                           display="flex"
                           alignItems="center"
-                          gap={1}>
+                          gap={0.5}>
                           <Typography
                             variant="caption"
                             noWrap

--- a/packages/web-app/src/components/appli/Entry/Riggings/ColumnLegend.jsx
+++ b/packages/web-app/src/components/appli/Entry/Riggings/ColumnLegend.jsx
@@ -27,7 +27,7 @@ const ColumnLegend = ({ titleKey, items }) => {
           onClick={e => setAnchorEl(e.currentTarget)}
           aria-label={formatMessage({ id: titleKey })}
           sx={{
-            ml: 1,
+            ml: 0.5,
             color: 'inherit',
             opacity: 0.8,
             verticalAlign: 'middle'
@@ -35,23 +35,25 @@ const ColumnLegend = ({ titleKey, items }) => {
           <InfoOutlinedIcon fontSize="small" />
         </IconButton>
       </Tooltip>
-
       <Popover
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}>
-        <Box sx={{ pt: 2, px: 2, pb: 2, minWidth: 160 }}>
-          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1 }}>
+        <Box sx={{ pt: 1, px: 1, pb: 1, minWidth: 160 }}>
+          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>
             {formatMessage({ id: titleKey })}
           </Typography>
-          <Divider sx={{ mb: 1 }} />
-          <Table size="small" sx={{ mb: 0 }}>
+          <Divider sx={{ mb: 0.5 }} />
+          <Table size="small" sx={{ mb: 0.25 }}>
             <TableBody>
               {items.map(({ abbrevKey, labelKey }) => (
                 <TableRow key={abbrevKey}>
-                  <TableCell sx={{ border: 0, py: 0.5, pr: 2 }}>
+                  <TableCell sx={{
+                    border: 0,
+                    pr: 2
+                  }}>
                     <Typography
                       variant="body2"
                       fontWeight="bold"
@@ -59,7 +61,9 @@ const ColumnLegend = ({ titleKey, items }) => {
                       {formatMessage({ id: abbrevKey })}
                     </Typography>
                   </TableCell>
-                  <TableCell sx={{ border: 0, py: 0.5 }}>
+                  <TableCell sx={{
+                    border: 0
+                  }}>
                     <Typography variant="body2" component="span">
                       {formatMessage({ id: labelKey })}
                     </Typography>

--- a/packages/web-app/src/components/appli/Entry/Riggings/Rigging.jsx
+++ b/packages/web-app/src/components/appli/Entry/Riggings/Rigging.jsx
@@ -66,10 +66,10 @@ const Rigging = ({ rigging, entranceId, isEditAllowed, isMoving, onMoveUp, onMov
         display: 'flow-root',
         borderTop: '1px solid',
         borderColor: 'divider',
-        pt: 1,
-        pb: 1
+        pt: 0.5,
+        pb: 0.5
       }}>
-      <Box sx={{ float: 'right', ml: 1 }}>
+      <Box sx={{ float: 'right', ml: 0.5 }}>
         <ActionButtons
           isLoading={isActionLoading}
           isUpdating={isUpdateFormVisible}

--- a/packages/web-app/src/components/appli/Entry/Riggings/RiggingSummary.jsx
+++ b/packages/web-app/src/components/appli/Entry/Riggings/RiggingSummary.jsx
@@ -11,7 +11,7 @@ const RiggingSummary = ({ obstacles }) => {
   const { total, unparsedCount } = parseRopeLengths(obstacles.map(o => o.rope));
 
   return (
-    <Stack direction="row" spacing={1}>
+    <Stack direction="row" spacing={0.5}>
       <Chip
         size="small"
         variant="outlined"

--- a/packages/web-app/src/components/appli/Entry/Riggings/RiggingTable.jsx
+++ b/packages/web-app/src/components/appli/Entry/Riggings/RiggingTable.jsx
@@ -91,7 +91,7 @@ const RiggingTable = ({ id, obstacles, title, previous, isDeleted }) => {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1, mb: 1 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
         {titleEl}
         {previous === undefined && <RiggingSummary obstacles={obstacles} />}
       </Box>

--- a/packages/web-app/src/components/appli/Entry/Science/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Science/index.jsx
@@ -65,7 +65,7 @@ const Science = ({ caveId }) => {
             })}
           />
 
-          <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
+          <Box sx={{ mt: 1, display: 'flex', gap: 0.5 }}>
             <Button
               variant="outlined"
               color="secondary"
@@ -76,11 +76,11 @@ const Science = ({ caveId }) => {
             </Button>
           </Box>
 
-          <Box sx={{ mt: 2 }}>
+          <Box sx={{ mt: 1 }}>
             <Typography
               variant="subtitle1"
               fontWeight="bold"
-              sx={{ px: 1, mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}
+              sx={{ px: 0.5, mb: 0.5, display: 'flex', alignItems: 'center', gap: 0.5 }}
             >
               <PestControlIcon fontSize="small" />
               {formatMessage({ id: 'Bat counting' })}

--- a/packages/web-app/src/components/appli/Entry/SectionTitle.jsx
+++ b/packages/web-app/src/components/appli/Entry/SectionTitle.jsx
@@ -25,7 +25,7 @@ const SectionTitle = ({ title, anchorId, isDeleted = false, marginBottom = 2 }) 
 
   if (!isDeleted)
     return title ? (
-      <AnchorBox id={anchorId} mt={1} mb={marginBottom}>
+      <AnchorBox id={anchorId} mt={0.5} mb={marginBottom}>
         <Typography variant="h4">{heading}</Typography>
       </AnchorBox>
     ) : (
@@ -33,7 +33,7 @@ const SectionTitle = ({ title, anchorId, isDeleted = false, marginBottom = 2 }) 
     );
 
   return (
-    <AnchorBox id={anchorId} mb={2}>
+    <AnchorBox id={anchorId} mb={1}>
       <Typography
         variant="h4"
         noWrap

--- a/packages/web-app/src/components/appli/Entry/SensitiveLocationPlaceholder.jsx
+++ b/packages/web-app/src/components/appli/Entry/SensitiveLocationPlaceholder.jsx
@@ -15,8 +15,8 @@ const SensitiveLocationPlaceholder = () => {
         flex: 1,
         bgcolor: 'secondary.veryLight',
         borderRadius: 1,
-        p: 3,
-        gap: 1
+        p: 2,
+        gap: 0.5
       }}>
       <LockOutlinedIcon sx={{ fontSize: 48, color: 'secondary.main' }} />
       <Typography variant="h6" color="secondary.main">

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -60,7 +60,7 @@ const AccordionSnapshot = ({
   const displayDate = rawDate ? new Date(rawDate) : null;
 
   return (
-    <TimelineItem sx={{ '&::before': { flex: 0, padding: 0 } }}>
+    <TimelineItem sx={{ '&::before': { flex: 0, padding: 0.25 } }}>
       <TimelineSeparator>
         <TimelineDot
           color={isNameChange ? 'secondary' : isCurrent ? 'primary' : 'grey'}
@@ -69,7 +69,7 @@ const AccordionSnapshot = ({
         />
         <TimelineConnector />
       </TimelineSeparator>
-      <TimelineContent sx={{ pb: 2, pt: 0, pr: 0 }}>
+      <TimelineContent sx={{ pb: 1, pt: 0.25, pr: 0.25 }}>
         <Box
           sx={{
             borderRadius: 1,
@@ -84,9 +84,9 @@ const AccordionSnapshot = ({
               cursor: isNameChange ? 'default' : 'pointer',
               display: 'flex',
               alignItems: 'flex-start',
-              gap: 1,
-              px: 1,
-              py: 1,
+              gap: 0.5,
+              px: 0.5,
+              py: 0.5,
               ...(isNameChange
                 ? {}
                 : { '&:hover': { bgcolor: 'action.hover' } })
@@ -98,7 +98,7 @@ const AccordionSnapshot = ({
                 display: 'flex',
                 flexDirection: { xs: 'column', sm: 'row' },
                 alignItems: { xs: 'stretch', sm: 'flex-start' },
-                gap: 1
+                gap: 0.5
               }}>
               <Box sx={{ flex: '0 0 auto' }}>
                 {all && (
@@ -147,7 +147,7 @@ const AccordionSnapshot = ({
                   minWidth: 0,
                   display: 'flex',
                   alignItems: 'center',
-                  gap: 1,
+                  gap: 0.5,
                   flexWrap: 'wrap'
                 }}>
                 <Typography
@@ -160,7 +160,7 @@ const AccordionSnapshot = ({
                     // Rename snapshot: the name IS the change — show old → new.
                     // snapshotTitle holds the OLD name (raw h_name value);
                     // newName is resolved from the next real snapshot.
-                    <HighLightsChar oldText={snapshotTitle} newText={newName} />
+                    (<HighLightsChar oldText={snapshotTitle} newText={newName} />)
                   ) : isEntranceSnapshot ? (
                     // Regular entrance snapshot: name/caveName are contextual
                     // labels resolved across tables, not diffable fields. Renames
@@ -218,9 +218,9 @@ const AccordionSnapshot = ({
           <Collapse in={open && !isNameChange}>
             <Box
               sx={{
-                px: 2,
-                pt: 1,
-                pb: 1,
+                px: 1,
+                pt: 0.5,
+                pb: 0.5,
                 borderTop: '1px solid',
                 borderColor: 'grey.200'
               }}>
@@ -232,7 +232,7 @@ const AccordionSnapshot = ({
               )}
             </Box>
             {!isCurrent && snapshotType !== 'documents' && !isNameChange && (
-              <Box sx={{ px: 2, pb: 2 }}>
+              <Box sx={{ px: 1, pb: 1 }}>
                 <RestoreSnapshot
                   snapshot={snapshot}
                   snapshotType={snapshotType}

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshot.jsx
@@ -160,7 +160,7 @@ const AccordionSnapshot = ({
                     // Rename snapshot: the name IS the change — show old → new.
                     // snapshotTitle holds the OLD name (raw h_name value);
                     // newName is resolved from the next real snapshot.
-                    (<HighLightsChar oldText={snapshotTitle} newText={newName} />)
+                    <HighLightsChar oldText={snapshotTitle} newText={newName} />
                   ) : isEntranceSnapshot ? (
                     // Regular entrance snapshot: name/caveName are contextual
                     // labels resolved across tables, not diffable fields. Renames

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotList.jsx
@@ -106,9 +106,9 @@ const AccordionSnapshotList = ({
   const hasItems = hasCurrentItem || hasRevisions;
 
   return (
-    <Box sx={{ px: 2 }}>
+    <Box sx={{ px: 1 }}>
       {isCurrentItemLoading && (
-        <Skeleton height={80} variant="rectangular" sx={{ borderRadius: 1, mb: 1 }} />
+        <Skeleton height={80} variant="rectangular" sx={{ borderRadius: 1, mb: 0.5 }} />
       )}
       {hasItems ? (
         <>

--- a/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotListPage.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/AccordionSnapshotListPage.jsx
@@ -147,15 +147,15 @@ const AccordionSnapshotListPage = ({
   const hasItems = timelineItems.length > 0;
 
   return (
-    <Box sx={{ px: 2 }}>
+    <Box sx={{ px: 1 }}>
       {isCurrentItemLoading && (
-        <Skeleton height={80} variant="rectangular" sx={{ borderRadius: 1, mb: 1 }} />
+        <Skeleton height={80} variant="rectangular" sx={{ borderRadius: 1, mb: 0.5 }} />
       )}
       {hasItems ? (
         <Timeline
           sx={{
-            p: 0,
-            m: 0,
+            p: 0.25,
+            m: 0.25,
             '& .MuiTimelineItem-root:last-child .MuiTimelineConnector-root': {
               display: 'none'
             }

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/DocumentSnapshots.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/DocumentSnapshots.jsx
@@ -56,7 +56,7 @@ const DocumentSnapshots = ({ document, previous }) => {
         display: 'grid',
         gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
         width: '100%',
-        rowGap: 1
+        rowGap: 0.5
       }}>
       {isValidated != null && (
         <Box sx={{ gridColumn: '1 / -1' }}>
@@ -69,21 +69,18 @@ const DocumentSnapshots = ({ document, previous }) => {
           />
         </Box>
       )}
-
       {show(creatorLabel, null) && (
         <Property
           label={formatMessage({ id: 'Created by' })}
           value={creatorLabel}
         />
       )}
-
       {show(validatorLabel, null) && (
         <Property
           label={formatMessage({ id: 'Validator' })}
           value={validatorLabel}
         />
       )}
-
       {show(type, previous?.type) && (
         <Property
           label={formatMessage({ id: 'Document type' })}
@@ -97,7 +94,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(license, previous?.license) && (
         <Property
           label={formatMessage({ id: 'License' })}
@@ -109,7 +105,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(desc.language?.refName, prevDesc.language?.refName) && (
         <Property
           label={formatMessage({ id: 'Title and description language' })}
@@ -121,14 +116,12 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {dateInscription && (
         <Property
           label={formatMessage({ id: 'Creation date' })}
           value={`${new Date(dateInscription).toLocaleDateString()} - ${new Date(dateInscription).toLocaleTimeString()}`}
         />
       )}
-
       {show(dateValidation, previous?.dateValidation) && (
         <Property
           label={formatMessage({ id: 'Validation date' })}
@@ -148,7 +141,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(datePublication, previous?.datePublication) && (
         <Property
           label={formatMessage({ id: 'Publication Date' })}
@@ -160,7 +152,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(editorLabel, prevEditorLabel) && (
         <Property
           label={formatMessage({ id: 'Editor' })}
@@ -172,7 +163,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(identifier, previous?.identifier) && (
         <Property
           label={formatMessage({ id: 'Identifier' })}
@@ -184,7 +174,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(desc.title, prevDesc.title) && (
         <Property
           flexBasis="100%"
@@ -197,7 +186,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(desc.body ?? desc.text, prevDesc.body ?? prevDesc.text) && (
         <Property
           flexBasis="100%"
@@ -210,7 +198,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(parentId, prevParentId) && (
         <Property
           flexBasis="100%"
@@ -232,7 +219,6 @@ const DocumentSnapshots = ({ document, previous }) => {
           }
         />
       )}
-
       {show(validatorComment, previous?.validatorComment) && (
         <Property
           flexBasis="100%"

--- a/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCharacteristicsSnapshot.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/component/EntranceCharacteristicsSnapshot.jsx
@@ -24,9 +24,15 @@ const EntranceCharacteristicsSnapshot = ({ entrance, previous }) => {
         key={field}
         sx={
           isAdded
-            ? { bgcolor: 'rgba(70, 149, 74, 0.2)', borderRadius: 1, px: 0.5 }
+            ? {
+            bgcolor: 'rgba(70, 149, 74, 0.2)',
+            borderRadius: 1
+          }
             : isRemoved
-            ? { bgcolor: 'rgba(229, 83, 74, 0.2)', borderRadius: 1, px: 0.5 }
+            ? {
+            bgcolor: 'rgba(229, 83, 74, 0.2)',
+            borderRadius: 1
+          }
             : undefined
         }>
         <Property

--- a/packages/web-app/src/components/appli/Entry/Snapshots/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/Snapshots/index.jsx
@@ -190,9 +190,8 @@ const SnapshotPage = () => {
         subheader={backLink}
       />
       {isSensitive && <SensitiveCaveWarning />}
-
-      <Card sx={{ mx: 2, mt: 1 }}>
-        <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+      <Card sx={{ mx: 1, mt: 0.5 }}>
+        <CardContent sx={{ p: 0.25, '&:last-child': { pb: 0.25 } }}>
           {is403 && <Alert403 type={type} />}
           {is404 && <Alert404 type={type} />}
           {isLoading && <Skeleton height={300} />}

--- a/packages/web-app/src/components/appli/Entry/index.jsx
+++ b/packages/web-app/src/components/appli/Entry/index.jsx
@@ -67,12 +67,12 @@ import {
 const HalfSplitContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 
   ${({ theme }) => theme.breakpoints.up('sm')} {
     flex-direction: row;
     align-items: stretch;
-    gap: ${({ theme }) => theme.spacing(3)};
+    gap: ${({ theme }) => theme.spacing(2)};
   }
 `;
 
@@ -319,7 +319,7 @@ export const Entry = ({
           {/* Tab Information */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={300} />
                 <Skeleton height={80} />
                 <Skeleton height={100} />
@@ -328,7 +328,7 @@ export const Entry = ({
               </Card>
             )}
             {error && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Alert
                   title={formatMessage({
                     id: 'Error, the entrance data you are looking for is not available.'
@@ -340,7 +340,7 @@ export const Entry = ({
             {entrance && (
               <>
                 {entrance.isDeleted && (
-                  <Box sx={{ m: 2 }}>
+                  <Box sx={{ m: 1 }}>
                     <DeletedCard
                       entityType={DELETED_ENTITIES.entrance}
                       entity={entrance}
@@ -364,7 +364,7 @@ export const Entry = ({
                   }}
                 />
                 {entrance.isSensitive && isAdmin && (
-                  <Box sx={{ mx: 2, mt: 2 }}>
+                  <Box sx={{ mx: 1, mt: 1 }}>
                     <SensitiveCaveWarning />
                   </Box>
                 )}
@@ -393,7 +393,7 @@ export const Entry = ({
                           component="div"
                           variant="caption"
                           color="text.secondary"
-                          sx={{ mt: 2 }}>
+                          sx={{ mt: 1 }}>
                           {entrance.author && (
                             <AuthorAndDate
                               author={entrance.author}
@@ -457,7 +457,7 @@ export const Entry = ({
           {/* Tab 1 — Documents */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={40} width="100%" />
                 <Skeleton height={60} />
                 <Skeleton height={60} />
@@ -485,7 +485,7 @@ export const Entry = ({
           {/* Tab 3 — Comments */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={40} width="100%" />
                 <Skeleton height={80} />
                 <Skeleton height={80} />

--- a/packages/web-app/src/components/appli/Faq.jsx
+++ b/packages/web-app/src/components/appli/Faq.jsx
@@ -59,7 +59,7 @@ const StyledSummary = styled(AccordionSummary)(({ theme }) => ({
 }));
 
 const StyledDetails = styled(AccordionDetails)(({ theme }) => ({
-  padding: theme.spacing(3),
+  padding: theme.spacing(2),
   '& a': {
     color: theme.palette.primary.main,
     textDecoration: 'underline'
@@ -113,7 +113,7 @@ const Faq = () => {
               </Typography>
             </StyledSummary>
             <StyledDetails>
-              <Typography variant="body2" sx={{ mb: 2 }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
                 {formatMessage({
                   id: 'Cave protection is a priority. A procedure has been defined for sensitive locations.'
                 })}
@@ -152,7 +152,7 @@ const Faq = () => {
               </Typography>
             </StyledSummary>
             <StyledDetails>
-              <Typography variant="body2" sx={{ mb: 2 }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
                 {formatMessage({
                   id: 'You can help as an active member, translator, developer, or partner organisation.'
                 })}
@@ -191,7 +191,7 @@ const Faq = () => {
               </Typography>
             </StyledSummary>
             <StyledDetails>
-              <Typography variant="body2" sx={{ mb: 2 }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
                 {formatMessage({
                   id: 'GrottoCenter is built and maintained by the Wikicaves association and a community of volunteer contributors.'
                 })}

--- a/packages/web-app/src/components/appli/Form/SearchCaveForm/index.jsx
+++ b/packages/web-app/src/components/appli/Form/SearchCaveForm/index.jsx
@@ -48,7 +48,7 @@ const SearchCaveForm = ({ onSubmit, submitLabel = null }) => {
         resetResults={resetAdvancedSearch}
       />
       <SearchResults onSelected={handleSelection} hideExport compact entityType={ADVANCED_SEARCH_TYPES.ENTRANCES} />
-      <Box sx={{ mt: 2, mb: 3, textAlign: 'center' }}>
+      <Box sx={{ mt: 1, mb: 2, textAlign: 'center' }}>
         <Button
           disabled={selectedEntrances.length === 0}
           color="primary"

--- a/packages/web-app/src/components/appli/Form/SearchOrganizationForm/index.jsx
+++ b/packages/web-app/src/components/appli/Form/SearchOrganizationForm/index.jsx
@@ -47,7 +47,7 @@ const SearchOrganizationForm = ({ onSubmit }) => {
         resetResults={resetAdvancedSearch}
       />
       <SearchResults onSelected={handleSelection} hideExport compact entityType={ADVANCED_SEARCH_TYPES.ORGANIZATIONS} />
-      <Box sx={{ mt: 2, mb: 3, textAlign: 'center' }}>
+      <Box sx={{ mt: 1, mb: 2, textAlign: 'center' }}>
         <Button
           disabled={selectedOrganizations.length === 0}
           color="primary"

--- a/packages/web-app/src/components/appli/Guidelines/Guideline.jsx
+++ b/packages/web-app/src/components/appli/Guidelines/Guideline.jsx
@@ -18,8 +18,8 @@ import Contribution from '../../common/Contribution/Contribution';
 const ListItemStyled = styled(ListItem)`
   display: flow-root;
   border-top: 1px solid ${({ theme }) => theme.palette.divider};
-  padding-top: ${({ theme }) => theme.spacing(1)};
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(0.5)};
+  padding-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const Guideline = ({
@@ -84,7 +84,7 @@ const Guideline = ({
   return (
     <ListItemStyled disableGutters>
       {isEditAllowed && (
-        <Box sx={{ float: 'right', ml: 1 }}>
+        <Box sx={{ float: 'right', ml: 0.5 }}>
           <ActionButtons
             isLoading={isActionLoading}
             isUpdating={isUpdateFormVisible}

--- a/packages/web-app/src/components/appli/Guidelines/GuidelinesGrouped.jsx
+++ b/packages/web-app/src/components/appli/Guidelines/GuidelinesGrouped.jsx
@@ -24,9 +24,9 @@ const GuidelinesGrouped = ({ guidelines }) => {
       title={<FormattedMessage id="Guidelines" />}
       anchorId="guidelines"
     >
-      <Box p={2}>
+      <Box p={1}>
         {groups.map((group, index) => (
-          <Box key={group.key} mt={index > 0 ? 3 : 0}>
+          <Box key={group.key} mt={index > 0 ? 2 : 0.25}>
             <Typography variant="h6" gutterBottom>
               <FormattedMessage id={group.titleId} />
             </Typography>

--- a/packages/web-app/src/components/appli/Guidelines/index.jsx
+++ b/packages/web-app/src/components/appli/Guidelines/index.jsx
@@ -159,10 +159,10 @@ const Guidelines = ({ entityType, entityId, guidelines }) => {
     switch (mode) {
       case MODE_CREATE:
         return (
-          <Box mb={2}>
+          <Box mb={1}>
             <ButtonGroup
               size="small"
-              sx={{ mb: 2 }}
+              sx={{ mb: 1 }}
               data-testid="guideline-mode-toggle">
               <Button
                 variant="outlined"
@@ -188,10 +188,10 @@ const Guidelines = ({ entityType, entityId, guidelines }) => {
 
       case MODE_ATTACH:
         return (
-          <Box mb={2}>
+          <Box mb={1}>
             <ButtonGroup
               size="small"
-              sx={{ mb: 2 }}
+              sx={{ mb: 1 }}
               data-testid="guideline-mode-toggle">
               <Button variant="contained" startIcon={<LinkIcon />}>
                 <FormattedMessage id="guidelines.attach_existing" />
@@ -207,14 +207,13 @@ const Guidelines = ({ entityType, entityId, guidelines }) => {
                 <FormattedMessage id="guidelines.create_new" />
               </Button>
             </ButtonGroup>
-
             <form autoComplete="off" onSubmit={handleAttachGuideline}>
               {isLoadingGuidelines ? (
                 <Box
                   sx={{
                     display: 'flex',
                     justifyContent: 'center',
-                    py: 3
+                    py: 2
                   }}>
                   <CircularProgress size={28} />
                 </Box>

--- a/packages/web-app/src/components/appli/ImportCSV/ImportContainer.jsx
+++ b/packages/web-app/src/components/appli/ImportCSV/ImportContainer.jsx
@@ -35,7 +35,7 @@ const LinearProgress = styled(MuiLinearProgress, {
 }));
 
 const StyledDivider = styled(Divider)`
-  margin: ${({ theme }) => theme.spacing(3)};
+  margin: ${({ theme }) => theme.spacing(2)};
 `;
 
 const ImportContainer = () => {

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/index.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/index.jsx
@@ -181,11 +181,11 @@ const ImportObservationsWizard = ({ initialCaveId, caveIdLocked }) => {
   return (
     <Card sx={{ minWidth: 275 }}>
       <CardContent>
-        <Typography color="secondary" variant="h1" sx={{ mb: 2 }}>
+        <Typography color="secondary" variant="h1" sx={{ mb: 1 }}>
           {formatMessage({ id: 'Import observations' })}
         </Typography>
 
-        <Stepper activeStep={currentStep} sx={{ mb: 4 }}>
+        <Stepper activeStep={currentStep} sx={{ mb: 3 }}>
           {stepLabels.map(label => (
             <Step key={label}>
               <StepLabel>{label}</StepLabel>
@@ -193,11 +193,11 @@ const ImportObservationsWizard = ({ initialCaveId, caveIdLocked }) => {
           ))}
         </Stepper>
 
-        <Box sx={{ mb: 4 }}>
+        <Box sx={{ mb: 3 }}>
           {renderStep(currentStep, initialCaveId, caveIdLocked)}
         </Box>
 
-        <Box sx={{ display: 'flex', gap: 2 }}>
+        <Box sx={{ display: 'flex', gap: 1 }}>
           <Button
             data-testid="back-button"
             disabled={isBackDisabled}

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/ContextStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/ContextStep.jsx
@@ -420,9 +420,8 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
 
   return (
     <Box
-      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
       data-testid="context-step">
-
       {/* Location mode toggle */}
       <Box>
         <Typography variant="subtitle2" gutterBottom>
@@ -459,10 +458,9 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           />
         </RadioGroup>
       </Box>
-
       {/* Cave selection */}
       {showCave && (
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
           <Box sx={{ flex: 1, maxWidth: 480 }}>
             <Typography variant="subtitle2" gutterBottom>
               {formatMessage({ id: 'ImportObservationsWizard.ContextStep.caveLabel' })}
@@ -478,7 +476,7 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
             <IconButton
               onClick={handleClearCave}
               size="small"
-              sx={{ mt: 4 }}
+              sx={{ mt: 3 }}
               data-testid="clear-cave-button"
               aria-label={formatMessage({
                 id: 'ImportObservationsWizard.ContextStep.clearCave'
@@ -488,10 +486,9 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           )}
         </Box>
       )}
-
       {/* Point label + location */}
       {showPoint && (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
           <TextField
             required
             variant="filled"
@@ -534,9 +531,8 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           )}
         </Box>
       )}
-
       {/* Observation name + language */}
-      <Box sx={{ display: 'flex', gap: 2, maxWidth: 480, alignItems: 'flex-start' }}>
+      <Box sx={{ display: 'flex', gap: 1, maxWidth: 480, alignItems: 'flex-start' }}>
         <TextField
           variant="filled"
           label={formatMessage({
@@ -560,7 +556,6 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           />
         </Box>
       </Box>
-
       {/* Authors */}
       <Box sx={{ maxWidth: 480 }}>
         <AuthorsSelect
@@ -572,7 +567,6 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           })}
         />
       </Box>
-
       {/* License selector */}
       <FormControl size="small" sx={{ minWidth: 240, maxWidth: 320 }} required>
         <InputLabel id="license-label">
@@ -597,9 +591,8 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           </FormHelperText>
         )}
       </FormControl>
-
       {/* Sampling interval — with tooltip */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <TextField
           variant="filled"
           label={formatMessage({
@@ -621,14 +614,13 @@ const ContextStep = ({ initialCaveId, caveIdLocked }) => {
           <HelpOutlineIcon fontSize="small" color="action" />
         </Tooltip>
       </Box>
-
       {/* Optional fields */}
       <Box>
         <Typography variant="subtitle2" gutterBottom>
           {formatMessage({ id: 'ImportObservationsWizard.ContextStep.optionalFieldsTitle' })}
         </Typography>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 480 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxWidth: 480 }}>
           {/* Data quality */}
           <FormControl size="small" sx={{ minWidth: 200, maxWidth: 240 }}>
             <InputLabel id="data-quality-label">

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/DeviceSensorsStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/DeviceSensorsStep.jsx
@@ -144,7 +144,7 @@ const DeviceSelector = ({ disabled, onCreateNew, onSelect }) => {
   );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
       <FormControlLabel
         control={
           <Checkbox
@@ -179,7 +179,7 @@ const DeviceSelector = ({ disabled, onCreateNew, onSelect }) => {
           if (option.__isCreateNew) {
             return (
               <li key="create-new" {...rest}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   <AddIcon fontSize="small" color="primary" />
                   <Typography color="primary">{option.name}</Typography>
                 </Box>
@@ -191,7 +191,7 @@ const DeviceSelector = ({ disabled, onCreateNew, onSelect }) => {
               <Box>
                 <Typography variant="body2">{option.name}</Typography>
                 <Box
-                  sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                  sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
                   {option.brandName && (
                     <Typography variant="caption" color="text.secondary">
                       {option.brandName}
@@ -300,15 +300,14 @@ const DeviceCreator = ({ onCancel, onSuccess }) => {
   return (
     <Paper
       variant="outlined"
-      sx={{ p: 2, mt: 2 }}
+      sx={{ p: 1, mt: 1 }}
       data-testid="create-device-form">
-      <Typography variant="subtitle2" sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
         {formatMessage({
           id: 'ImportObservationsWizard.DeviceSensorsStep.newDeviceTitle'
         })}
       </Typography>
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <TextField
           label={formatMessage({
             id: 'ImportObservationsWizard.DeviceSensorsStep.deviceName'
@@ -363,14 +362,12 @@ const DeviceCreator = ({ onCancel, onSuccess }) => {
           data-testid="new-device-manufacturer-url"
         />
       </Box>
-
       {createError && (
-        <Alert severity="error" sx={{ mt: 2 }} data-testid="create-device-error">
+        <Alert severity="error" sx={{ mt: 1 }} data-testid="create-device-error">
           {createError}
         </Alert>
       )}
-
-      <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+      <Box sx={{ display: 'flex', gap: 0.5, mt: 1 }}>
         <Button
           variant="contained"
           onClick={handleSubmit}
@@ -529,20 +526,18 @@ const DeviceSensorsStep = () => {
 
   return (
     <Box
-      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
       data-testid="device-sensors-step">
       <Typography variant="h6">
         {formatMessage({
           id: 'ImportObservationsWizard.DeviceSensorsStep.title'
         })}
       </Typography>
-
       <Typography variant="body2" color="text.secondary">
         {formatMessage({
           id: 'ImportObservationsWizard.DeviceSensorsStep.description'
         })}
       </Typography>
-
       {/* Phase 1: Device selection/creation */}
       <Box data-testid="device-phase">
         {confirmedDevice ? (
@@ -566,17 +561,16 @@ const DeviceSensorsStep = () => {
           </>
         )}
       </Box>
-
       {/* Phase 2: Sensor configurations (only when device is confirmed) */}
       {confirmedDevice && (
         <Box data-testid="sensor-config-phase">
-          <Typography variant="subtitle1" sx={{ mb: 2 }}>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>
             {formatMessage({
               id: 'ImportObservationsWizard.DeviceSensorsStep.sensorConfigPhaseTitle'
             })}
           </Typography>
           <SensorConfigList deviceId={confirmedDevice.id} />
-          <Box sx={{ mt: 2 }}>
+          <Box sx={{ mt: 1 }}>
             <SensorConfigForm deviceId={confirmedDevice.id} />
           </Box>
         </Box>

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/MapColumnsStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/MapColumnsStep.jsx
@@ -184,7 +184,7 @@ const TimestampConfig = ({ mapping, columnMappings, sampleValues, onUpdate }) =>
 
   return (
     <Box
-      sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, py: 1 }}
+      sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, py: 0.5 }}
       data-testid={`timestamp-config-${mapping.columnIndex}`}>
       {/* Timestamp type selector */}
       <FormControl size="small" sx={{ minWidth: 160 }}>
@@ -210,7 +210,6 @@ const TimestampConfig = ({ mapping, columnMappings, sampleValues, onUpdate }) =>
           ))}
         </Select>
       </FormControl>
-
       {/* TimestampFormatInput for datetime/dateOnly/timeOnly */}
       {showPillBuilder && (
         <TimestampFormatInput
@@ -220,7 +219,6 @@ const TimestampConfig = ({ mapping, columnMappings, sampleValues, onUpdate }) =>
           onChange={handleFormatChange}
         />
       )}
-
     </Box>
   );
 };
@@ -260,7 +258,7 @@ const MeasurementConfig = ({ mapping, sensorConfigs, onUpdate }) => {
 
   return (
     <Box
-      sx={{ pl: 4, py: 1, display: 'flex', gap: 2, flexWrap: 'wrap' }}
+      sx={{ pl: 3, py: 0.5, display: 'flex', gap: 1, flexWrap: 'wrap' }}
       data-testid={`measurement-config-${mapping.columnIndex}`}>
       <FormControl size="small" sx={{ minWidth: 300 }}>
         <InputLabel id={`sensor-label-${mapping.columnIndex}`}>
@@ -292,7 +290,6 @@ const MeasurementConfig = ({ mapping, sensorConfigs, onUpdate }) => {
           ))}
         </Select>
       </FormControl>
-
       <FormControl size="small" sx={{ minWidth: 160 }}>
         <InputLabel id={`medium-label-${mapping.columnIndex}`}>
           {formatMessage({
@@ -462,7 +459,7 @@ const ColumnRoleTable = ({
                     </Tooltip>
                   </TableCell>
                   <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5, flexWrap: 'wrap' }}>
                       <FormControl size="small" sx={{ minWidth: 140 }}>
                         <Select
                           value={mapping.role || ''}
@@ -528,23 +525,21 @@ const ColumnRoleTable = ({
                     {decimalPartError && (
                       <Alert
                         severity="error"
-                        sx={{ mt: 1, py: 0, px: 1 }}
+                        sx={{ mt: 0.5, py: 0.25, px: 0.5 }}
                         data-testid={`decimal-part-error-${colIndex}`}>
                         {decimalPartError}
                       </Alert>
                     )}
                   </TableCell>
                 </TableRow>
-
               </React.Fragment>
             );
           })}
         </TableBody>
       </Table>
-
       {/* Timezone selector — shown once when any column has timestamp role */}
       {columnMappings.some(m => m.role === 'timestamp') && (
-        <Box sx={{ mt: 2, maxWidth: 320 }}>
+        <Box sx={{ mt: 1, maxWidth: 320 }}>
           <Autocomplete
             size="small"
             options={sortedTimezones}
@@ -824,20 +819,18 @@ const MapColumnsStep = () => {
 
   return (
     <Box
-      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
       data-testid="map-columns-step">
       <Typography variant="h6">
         {formatMessage({
           id: 'ImportObservationsWizard.MapColumnsStep.title'
         })}
       </Typography>
-
       <Typography variant="body2" color="text.secondary">
         {formatMessage({
           id: 'ImportObservationsWizard.MapColumnsStep.description'
         })}
       </Typography>
-
       {columnHeaders.length > 0 && (
         <ColumnRoleTable
           columnHeaders={columnHeaders}
@@ -847,7 +840,6 @@ const MapColumnsStep = () => {
           onUpdateMapping={handleUpdateMapping}
         />
       )}
-
       {columnHeaders.length === 0 && (
         <Alert severity="info" data-testid="no-columns-alert">
           {formatMessage({

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SensorConfigForm.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SensorConfigForm.jsx
@@ -217,22 +217,20 @@ const SensorConfigForm = ({ deviceId }) => {
 
   return (
     <Box data-testid="sensor-config-form">
-      <Typography variant="subtitle2" sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
         {formatMessage({
           id: 'ImportObservationsWizard.DeviceSensorsStep.addSensorTitle'
         })}
       </Typography>
-
       {submitError && (
         <Alert
           severity="error"
-          sx={{ mb: 2 }}
+          sx={{ mb: 1 }}
           data-testid="sensor-config-form-error">
           {submitError}
         </Alert>
       )}
-
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 480 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxWidth: 480 }}>
         {/* Label — optional human-readable name */}
         <TextField
           label={formatMessage({
@@ -246,7 +244,7 @@ const SensorConfigForm = ({ deviceId }) => {
         />
 
         {/* Quantity Kind and Unit dropdowns — side by side */}
-        <Box sx={{ display: 'flex', gap: 2 }}>
+        <Box sx={{ display: 'flex', gap: 1 }}>
           <TextField
             select
             label={formatMessage({
@@ -308,9 +306,9 @@ const SensorConfigForm = ({ deviceId }) => {
           </AccordionSummary>
           <AccordionDetails>
             <Box
-              sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {/* Precision: lower first, side by side */}
-              <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ display: 'flex', gap: 1 }}>
                 <TextField
                   label={formatMessage({
                     id: 'ImportObservationsWizard.DeviceSensorsStep.precisionLower'
@@ -354,7 +352,7 @@ const SensorConfigForm = ({ deviceId }) => {
                 />
               </Box>
               {/* Detection limits: min first, side by side */}
-              <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ display: 'flex', gap: 1 }}>
                 <TextField
                   label={formatMessage({
                     id: 'ImportObservationsWizard.DeviceSensorsStep.detectionLimitMin'

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SensorConfigList.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SensorConfigList.jsx
@@ -34,8 +34,8 @@ const SensorConfigList = ({ deviceId }) => {
   if (loading) {
     return (
       <Box data-testid="sensor-config-list-loading">
-        <Skeleton variant="rectangular" height={48} sx={{ mb: 1 }} />
-        <Skeleton variant="rectangular" height={48} sx={{ mb: 1 }} />
+        <Skeleton variant="rectangular" height={48} sx={{ mb: 0.5 }} />
+        <Skeleton variant="rectangular" height={48} sx={{ mb: 0.5 }} />
         <Skeleton variant="rectangular" height={48} />
       </Box>
     );

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SubmitStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/SubmitStep.jsx
@@ -99,7 +99,7 @@ const SubmitStep = () => {
 
   return (
     <Box
-      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
       data-testid="submit-step">
       {/* Summary section */}
       <Box>
@@ -113,11 +113,11 @@ const SubmitStep = () => {
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            gap: 1,
-            pl: 1
+            gap: 0.5,
+            pl: 0.5
           }}>
           {/* File name */}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
             <Typography
               variant="body2"
               color="text.secondary"
@@ -132,7 +132,7 @@ const SubmitStep = () => {
           </Box>
 
           {/* Cave ID */}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
             <Typography
               variant="body2"
               color="text.secondary"
@@ -151,7 +151,7 @@ const SubmitStep = () => {
           </Box>
 
           {/* Point label */}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
             <Typography
               variant="body2"
               color="text.secondary"
@@ -169,7 +169,7 @@ const SubmitStep = () => {
           </Box>
 
           {/* Sensor configs count */}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
             <Typography
               variant="body2"
               color="text.secondary"
@@ -185,7 +185,7 @@ const SubmitStep = () => {
 
           {/* Valid row count */}
           {validRowCount !== null && (
-            <Box sx={{ display: 'flex', gap: 1 }}>
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
               <Typography
                 variant="body2"
                 color="text.secondary"
@@ -201,9 +201,7 @@ const SubmitStep = () => {
           )}
         </Box>
       </Box>
-
       <Divider />
-
       {/* Error display — inline message and details */}
       {isFailed && submission.error && (
         <Alert severity="error" data-testid="submit-error-details">
@@ -223,12 +221,12 @@ const SubmitStep = () => {
                   <Typography
                     variant="body2"
                     fontWeight="bold"
-                    sx={{ mb: showRaw || errorDetails.length > 0 ? 1 : 0 }}>
+                    sx={{ mb: showRaw || errorDetails.length > 0 ? 0.5 : 0.25 }}>
                     {translatedMessage}
                   </Typography>
                 )}
                 {showRaw && (
-                  <Typography variant="body2" sx={{ mb: errorDetails.length > 0 ? 1 : 0 }}>
+                  <Typography variant="body2" sx={{ mb: errorDetails.length > 0 ? 0.5 : 0.25 }}>
                     {rawMessage}
                   </Typography>
                 )}
@@ -240,7 +238,7 @@ const SubmitStep = () => {
               {/* Error details have no stable unique ID — field may repeat */}
               {/* eslint-disable-next-line react/no-array-index-key */}
               {errorDetails.map((detail, index) => (
-                <ListItem key={detail.field ? `${detail.field}-${index}` : index} disableGutters sx={{ py: 0 }}>
+                <ListItem key={detail.field ? `${detail.field}-${index}` : index} disableGutters sx={{ py: 0.25 }}>
                   <ListItemText
                     primary={
                       detail.field
@@ -264,7 +262,7 @@ const SubmitStep = () => {
             <Typography
               variant="caption"
               color="text.secondary"
-              sx={{ mt: 1, display: 'block' }}>
+              sx={{ mt: 0.5, display: 'block' }}>
               {formatMessage(
                 { id: 'ImportObservationsWizard.SubmitStep.referenceId' },
                 { id: submission.error.referenceId }
@@ -273,9 +271,8 @@ const SubmitStep = () => {
           )}
         </Alert>
       )}
-
       {/* Action buttons */}
-      <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
         <Button
           variant="contained"
           color="primary"

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/TimestampFormatInput.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/TimestampFormatInput.jsx
@@ -119,9 +119,11 @@ const ParsedPreview = ({ sampleValue, parsedDate, timestampType }) => {
     <Typography
       variant="caption"
       color="text.secondary"
-      sx={{ mt: 0.5, display: 'block' }}
+      sx={{
+        display: 'block'
+      }}
       data-testid="parsed-preview">
-      {sampleValue} → {formatted}
+      {sampleValue}→ {formatted}
     </Typography>
   );
 };
@@ -138,8 +140,8 @@ const TokenReferenceContent = ({ tokens }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Box sx={{ p: 1, minWidth: 420 }} data-testid="token-reference-popover">
-      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+    <Box sx={{ p: 0.5, minWidth: 420 }} data-testid="token-reference-popover">
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
         {formatMessage({
           id: 'ImportObservationsWizard.FormatInput.tokensTitle'
         })}
@@ -147,17 +149,23 @@ const TokenReferenceContent = ({ tokens }) => {
       <Table size="small">
         <TableHead>
           <TableRow>
-            <TableCell sx={{ fontWeight: 'bold', py: 0.5 }}>
+            <TableCell sx={{
+              fontWeight: 'bold'
+            }}>
               {formatMessage({
                 id: 'ImportObservationsWizard.FormatInput.tokenColumn'
               })}
             </TableCell>
-            <TableCell sx={{ fontWeight: 'bold', py: 0.5 }}>
+            <TableCell sx={{
+              fontWeight: 'bold'
+            }}>
               {formatMessage({
                 id: 'ImportObservationsWizard.FormatInput.meaningColumn'
               })}
             </TableCell>
-            <TableCell sx={{ fontWeight: 'bold', py: 0.5 }}>
+            <TableCell sx={{
+              fontWeight: 'bold'
+            }}>
               {formatMessage({
                 id: 'ImportObservationsWizard.FormatInput.exampleColumn'
               })}
@@ -167,15 +175,19 @@ const TokenReferenceContent = ({ tokens }) => {
         <TableBody>
           {tokens.map(token => (
             <TableRow key={token}>
-              <TableCell sx={{ fontFamily: 'monospace', py: 0.5 }}>
+              <TableCell sx={{
+                fontFamily: 'monospace'
+              }}>
                 {token}
               </TableCell>
-              <TableCell sx={{ py: 0.5 }}>
+              <TableCell sx={{}}>
                 {formatMessage({
                   id: `ImportObservationsWizard.FormatInput.token.${token}`
                 })}
               </TableCell>
-              <TableCell sx={{ fontFamily: 'monospace', py: 0.5 }}>
+              <TableCell sx={{
+                fontFamily: 'monospace'
+              }}>
                 {TOKEN_DESCRIPTIONS[token]?.example || ''}
               </TableCell>
             </TableRow>
@@ -185,7 +197,7 @@ const TokenReferenceContent = ({ tokens }) => {
       <Typography
         variant="caption"
         color="text.secondary"
-        sx={{ mt: 1, display: 'block' }}>
+        sx={{ mt: 0.5, display: 'block' }}>
         {formatMessage(
           { id: 'ImportObservationsWizard.FormatInput.separatorsHint' },
           {
@@ -240,7 +252,7 @@ const TimestampFormatInput = ({
 
   return (
     <Box data-testid="format-pill-builder">
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <TextField
           size="small"
           value={currentFormat}

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/TimestampFormatInput.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/TimestampFormatInput.jsx
@@ -123,7 +123,7 @@ const ParsedPreview = ({ sampleValue, parsedDate, timestampType }) => {
         display: 'block'
       }}
       data-testid="parsed-preview">
-      {sampleValue}→ {formatted}
+      {sampleValue} → {formatted}
     </Typography>
   );
 };
@@ -180,7 +180,7 @@ const TokenReferenceContent = ({ tokens }) => {
               }}>
                 {token}
               </TableCell>
-              <TableCell sx={{}}>
+              <TableCell>
                 {formatMessage({
                   id: `ImportObservationsWizard.FormatInput.token.${token}`
                 })}

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/UploadStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/UploadStep.jsx
@@ -83,7 +83,7 @@ const FilePreviewTable = ({ rawRows, headerRow, skipFirstRows, skipLastRows }) =
 
   if (dataRows.length === 0) {
     return (
-      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
         {formatMessage({
           id: 'ImportObservationsWizard.UploadStep.noDataRows'
         })}
@@ -92,7 +92,7 @@ const FilePreviewTable = ({ rawRows, headerRow, skipFirstRows, skipLastRows }) =
   }
 
   return (
-    <Box sx={{ overflowX: 'auto', mt: 2 }}>
+    <Box sx={{ overflowX: 'auto', mt: 1 }}>
       <Table
         size="small"
         data-testid="file-preview-table"
@@ -376,7 +376,7 @@ const UploadStep = () => {
   }));
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       {/* File picker */}
       <Box>
         <Typography variant="subtitle1" gutterBottom>
@@ -398,7 +398,7 @@ const UploadStep = () => {
           data-testid="profile-input"
           onChange={handleProfileFileChange}
         />
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Button
             variant="outlined"
             startIcon={<UploadFileIcon />}
@@ -424,7 +424,7 @@ const UploadStep = () => {
             </Typography>
           )}
         </Box>
-        <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ mt: 0.5, display: 'flex', alignItems: 'center', gap: 1 }}>
           <Button
             variant="outlined"
             startIcon={<FileOpenIcon />}
@@ -445,11 +445,10 @@ const UploadStep = () => {
           )}
         </Box>
       </Box>
-
       {rawRows.length > 0 && (
         <>
           {/* Encoding + Number format (side by side) */}
-          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
             <FormControl size="small" sx={{ minWidth: 200 }}>
               <InputLabel id="encoding-label">
                 {formatMessage({
@@ -501,7 +500,7 @@ const UploadStep = () => {
           </Box>
 
           {/* Header row + Skip first rows + Skip last rows (side by side) */}
-          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
             <FormControl size="small" sx={{ minWidth: 300, maxWidth: 400 }}>
               <InputLabel id="header-row-label">
                 {formatMessage({
@@ -575,7 +574,6 @@ const UploadStep = () => {
           </Box>
         </>
       )}
-
       {/* File preview table */}
       {rawRows.length > 0 && (
         <Box>

--- a/packages/web-app/src/components/appli/ImportObservationsWizard/steps/ValidateStep.jsx
+++ b/packages/web-app/src/components/appli/ImportObservationsWizard/steps/ValidateStep.jsx
@@ -36,7 +36,7 @@ const InvalidRowsTable = ({ invalidRowDetails }) => {
   const rows = invalidRowDetails.slice(0, MAX_INVALID_ROWS_DISPLAY);
 
   return (
-    <Box sx={{ overflowX: 'auto', mt: 1 }} data-testid="invalid-rows-table">
+    <Box sx={{ overflowX: 'auto', mt: 0.5 }} data-testid="invalid-rows-table">
       <Table size="small">
         <TableHead>
           <TableRow>
@@ -299,7 +299,7 @@ const ValidateStep = () => {
   if (isValidating || !validationResult) {
     return (
       <Box
-        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
         data-testid="validate-step-loading">
         <Typography variant="body2" color="text.secondary">
           {formatMessage({
@@ -321,7 +321,7 @@ const ValidateStep = () => {
 
   return (
     <Box
-      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+      sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
       data-testid="validate-step">
       {/* Blocking errors */}
       {blockingErrors.map((error, idx) => (
@@ -333,11 +333,10 @@ const ValidateStep = () => {
           {error}
         </Alert>
       ))}
-
       {/* Warning: some rows are invalid but no blocking errors */}
       {blockingErrors.length === 0 && invalidRows > 0 && (
         <Box data-testid="invalid-rows-warning">
-          <Alert severity="warning" sx={{ mb: 1 }}>
+          <Alert severity="warning" sx={{ mb: 0.5 }}>
             {formatMessage(
               {
                 id: 'ImportObservationsWizard.ValidateStep.invalidRowsWarning'
@@ -348,7 +347,6 @@ const ValidateStep = () => {
           <InvalidRowsTable invalidRowDetails={invalidRowDetails} />
         </Box>
       )}
-
       {/* Success: all rows valid */}
       {blockingErrors.length === 0 && invalidRows === 0 && (
         <Alert severity="success" data-testid="validation-success">
@@ -358,7 +356,6 @@ const ValidateStep = () => {
           )}
         </Alert>
       )}
-
       {/* Summary when there are blocking errors — still show row counts if we
           have rows at all so the user has some context */}
       {blockingErrors.length > 0 && totalRows > 0 && (

--- a/packages/web-app/src/components/appli/Login.jsx
+++ b/packages/web-app/src/components/appli/Login.jsx
@@ -193,7 +193,7 @@ const Login = () => {
         isSubmitting ||
         (resendTimeout > 0 && authState.isNotVerifiedMessageDisplayed)
       }
-      sx={{ mt: 2 }}>
+      sx={{ mt: 1 }}>
       {isSubmitting ? (
         <CircularProgress size="2.8rem" color="inherit" />
       ) : (
@@ -280,7 +280,7 @@ const Login = () => {
         <b>{email || authState.notVerifiedEmail}</b>
       </Typography>
       {serverError && (
-        <Alert severity="error" sx={{ mt: 2 }}>
+        <Alert severity="error" sx={{ mt: 1 }}>
           {serverError}
         </Alert>
       )}
@@ -320,7 +320,7 @@ const Login = () => {
         <b>{email || authState.notVerifiedEmail}</b>
       </Typography>
       {serverError && (
-        <Alert severity="error" sx={{ mt: 2 }}>
+        <Alert severity="error" sx={{ mt: 1 }}>
           {serverError}
         </Alert>
       )}
@@ -337,7 +337,7 @@ const Login = () => {
         passwordError={fieldErrors.password}
         serverError={serverError}
       />
-      <Box display="flex" justifyContent="flex-end" mt={1}>
+      <Box display="flex" justifyContent="flex-end" mt={0.5}>
         <Button
           type="button"
           size="small"
@@ -348,8 +348,8 @@ const Login = () => {
         </Button>
       </Box>
       {LoginButton}
-      <Divider sx={{ my: 2 }} />
-      <Box display="flex" flexDirection="column" alignItems="center" gap={1}>
+      <Divider sx={{ my: 1 }} />
+      <Box display="flex" flexDirection="column" alignItems="center" gap={0.5}>
         <Typography variant="body2" color="text.secondary">
           <Translate>No account yet?</Translate>
         </Typography>

--- a/packages/web-app/src/components/appli/Massif/Massif.jsx
+++ b/packages/web-app/src/components/appli/Massif/Massif.jsx
@@ -193,7 +193,7 @@ const Massif = ({ isLoading, error, massif }) => {
           {/* Tab Information */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={300} width="100%" />
                 <Skeleton height={100} />
                 <Skeleton height={100} />
@@ -201,7 +201,7 @@ const Massif = ({ isLoading, error, massif }) => {
               </Card>
             )}
             {error && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Alert
                   title={formatMessage({
                     id: 'Error, the massif data you are looking for is not available.'
@@ -213,7 +213,7 @@ const Massif = ({ isLoading, error, massif }) => {
             {massif && (
               <>
                 {massif.isDeleted && (
-                  <Box sx={{ m: 2 }}>
+                  <Box sx={{ m: 1 }}>
                     <DeletedCard
                       entityType={DELETED_ENTITIES.massif}
                       entity={massif}
@@ -271,7 +271,7 @@ const Massif = ({ isLoading, error, massif }) => {
                             component="div"
                             variant="caption"
                             color="text.secondary"
-                            sx={{ mt: massif?.geogPolygon ? 2 : 0 }}>
+                            sx={{ mt: massif?.geogPolygon ? 1 : 0.25 }}>
                             {massif.author && (
                               <AuthorAndDate
                                 author={massif.author}
@@ -301,7 +301,7 @@ const Massif = ({ isLoading, error, massif }) => {
                     }
                   />
                 )}
-                <Box sx={{ mx: 2, mb: 1 }}>
+                <Box sx={{ mx: 1, mb: 0.5 }}>
                   <Button
                     fullWidth
                     variant="contained"
@@ -359,7 +359,7 @@ const Massif = ({ isLoading, error, massif }) => {
           {/* Tab Documents */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={40} width="100%" />
                 <Skeleton height={60} />
                 <Skeleton height={60} />

--- a/packages/web-app/src/components/appli/MfaEnrollment/index.jsx
+++ b/packages/web-app/src/components/appli/MfaEnrollment/index.jsx
@@ -29,7 +29,7 @@ import { normalizeOtp } from '../../../utils/otpHelpers';
 const StepInstall = ({ onContinue, isLoading, error }) => {
   const { formatMessage } = useIntl();
   return (
-    <Box display="flex" flexDirection="column" gap={3}>
+    <Box display="flex" flexDirection="column" gap={2}>
       <Typography variant="body1">
         {formatMessage({ id: 'mfaEnrollmentStep1Body' })}
       </Typography>
@@ -78,13 +78,13 @@ const StepScanQr = ({ otpauthUri, secret, onContinue, onBack }) => {
   };
 
   return (
-    <Box display="flex" flexDirection="column" gap={3} alignItems="center">
+    <Box display="flex" flexDirection="column" gap={2} alignItems="center">
       <Typography variant="body2" color="text.secondary" textAlign="center">
         {formatMessage({ id: 'mfaEnrollmentStep2Body' })}
       </Typography>
       <Box
         sx={{
-          p: 2,
+          p: 1,
           border: '1px solid',
           borderColor: 'divider',
           borderRadius: 1,
@@ -93,18 +93,20 @@ const StepScanQr = ({ otpauthUri, secret, onContinue, onBack }) => {
         <QRCodeSVG value={otpauthUri} size={180} />
       </Box>
       <Box sx={{ width: '100%' }}>
-        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
+        <Typography variant="caption" color="text.secondary" sx={{
+          display: 'block'
+        }}>
           {formatMessage({ id: 'mfaSecretLabel' })}
         </Typography>
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
-            gap: 1,
+            gap: 0.5,
             bgcolor: 'action.hover',
             borderRadius: 1,
-            px: 2,
-            py: 1
+            px: 1,
+            py: 0.5
           }}>
           <Typography
             variant="caption"
@@ -173,7 +175,7 @@ const StepVerify = ({ onSubmit, isLoading, error, isEnrollmentTokenExpired, onBa
   const msg = errorMessage();
 
   return (
-    <Box display="flex" flexDirection="column" gap={2}>
+    <Box display="flex" flexDirection="column" gap={1}>
       <Typography variant="body2" color="text.secondary">
         {formatMessage({ id: 'mfaEnrollmentStep3Body' })}
       </Typography>
@@ -301,7 +303,7 @@ const MfaEnrollment = ({ onBack }) => {
   ];
 
   return (
-    <Box display="flex" flexDirection="column" gap={3}>
+    <Box display="flex" flexDirection="column" gap={2}>
       <Stepper activeStep={activeStep} alternativeLabel>
         {steps.map(label => (
           <Step key={label}>

--- a/packages/web-app/src/components/appli/MoveEntranceToCave/DetachEntranceSection.jsx
+++ b/packages/web-app/src/components/appli/MoveEntranceToCave/DetachEntranceSection.jsx
@@ -39,10 +39,9 @@ const DetachEntranceSection = ({ entrance }) => {
 
   return (
     <Box>
-      <Box mb={4}>
+      <Box mb={3}>
         <OperationSummary entrance={entrance} variant="detach" />
       </Box>
-
       {error && (
         <Alert
           severity="error"
@@ -51,7 +50,6 @@ const DetachEntranceSection = ({ entrance }) => {
           })}
         />
       )}
-
       <FormActions
         confirmLabel={formatMessage({ id: 'Detach entrance' })}
         onConfirm={handleDetach}

--- a/packages/web-app/src/components/appli/MoveEntranceToCave/FormActions.jsx
+++ b/packages/web-app/src/components/appli/MoveEntranceToCave/FormActions.jsx
@@ -31,12 +31,12 @@ const FormActions = ({
 
   return (
     <Box
-      mt={4}
+      mt={3}
       sx={{
         display: 'flex',
         flexDirection: { xs: 'column-reverse', sm: 'row' },
         justifyContent: { sm: 'flex-end' },
-        gap: 2
+        gap: 1
       }}
     >
       <Button
@@ -47,7 +47,6 @@ const FormActions = ({
       >
         {formatMessage({ id: 'Cancel' })}
       </Button>
-
       {confirmTooltip ? (
         <Tooltip title={confirmTooltip}>
           <Box component="span" sx={{ width: { xs: '100%', sm: 'auto' } }}>

--- a/packages/web-app/src/components/appli/MoveEntranceToCave/MoveEntranceToCaveForm.jsx
+++ b/packages/web-app/src/components/appli/MoveEntranceToCave/MoveEntranceToCaveForm.jsx
@@ -91,7 +91,7 @@ const MoveEntranceToCaveForm = ({ entrance }) => {
         {/* Discreet switch to the other operation, offered right under the
             subject. Detaching only makes sense for a networked entrance. */}
         {(mode === MODE_DETACH || sourceInNetwork) && (
-          <Box mt={1}>
+          <Box mt={0.5}>
             <Link
               component="button"
               type="button"
@@ -110,7 +110,6 @@ const MoveEntranceToCaveForm = ({ entrance }) => {
           </Box>
         )}
       </Box>
-
       {mode === MODE_MOVE ? (
         <Box>
           <CaveAutoCompleteSearch

--- a/packages/web-app/src/components/appli/MoveEntranceToCave/OperationSummary.jsx
+++ b/packages/web-app/src/components/appli/MoveEntranceToCave/OperationSummary.jsx
@@ -115,7 +115,7 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
   const renderItem = (item, index) => (
     <Box
       key={`${item.icon}-${item.name ?? ''}-${index}`}
-      sx={{ p: 1, borderRadius: 1, bgcolor: 'action.hover', minWidth: 0 }}
+      sx={{ p: 0.5, borderRadius: 1, bgcolor: 'action.hover', minWidth: 0 }}
     >
       {item.icon === 'network' ? (
         <Box
@@ -161,7 +161,7 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
           variant="caption"
           color="text.secondary"
           display="block"
-          sx={{ mt: 0.5 }}
+          sx={{}}
         >
           {item.note}
         </Typography>
@@ -175,12 +175,12 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
         variant="overline"
         color="text.secondary"
         display="block"
-        sx={{ mb: 1 }}
+        sx={{ mb: 0.5 }}
       >
         {label}
       </Typography>
       {items.length > 0 ? (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           {items.map(renderItem)}
         </Box>
       ) : (
@@ -197,11 +197,10 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
         display: 'flex',
         flexDirection: { xs: 'column', sm: 'row' },
         alignItems: { xs: 'stretch', sm: 'center' },
-        gap: 2
+        gap: 1
       }}
     >
       {column(formatMessage({ id: 'Now' }), before)}
-
       <KeyboardArrowRightIcon
         fontSize="large"
         sx={{
@@ -210,7 +209,6 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
           transform: { xs: 'rotate(90deg)', sm: 'none' }
         }}
       />
-
       {column(formatMessage({ id: 'After' }), after)}
     </Box>
   );

--- a/packages/web-app/src/components/appli/MoveEntranceToCave/OperationSummary.jsx
+++ b/packages/web-app/src/components/appli/MoveEntranceToCave/OperationSummary.jsx
@@ -161,7 +161,6 @@ const OperationSummary = ({ entrance, newCave, variant = 'link' }) => {
           variant="caption"
           color="text.secondary"
           display="block"
-          sx={{}}
         >
           {item.note}
         </Typography>

--- a/packages/web-app/src/components/appli/Network/EntrancesList.jsx
+++ b/packages/web-app/src/components/appli/Network/EntrancesList.jsx
@@ -44,7 +44,7 @@ const EntrancesList = ({
       dense
       disablePadding
       sx={{
-        '& .MuiListItemButton-root': { py: 0, pl: 0, minHeight: 0 },
+        '& .MuiListItemButton-root': { py: 0.25, pl: 0.25, minHeight: 0 },
         '& .MuiListItemIcon-root': { minWidth: 32 }
       }}>
       {isLoading && <LoadingList />}
@@ -116,7 +116,7 @@ const EntrancesList = ({
   if (inline) {
     return (
       <Box sx={{ height: '100%', overflow: 'auto' }}>
-        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+        <Paper variant="outlined" sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection
             title={formatMessage({ id: 'Entrances' })}>
 

--- a/packages/web-app/src/components/appli/Network/Properties.jsx
+++ b/packages/web-app/src/components/appli/Network/Properties.jsx
@@ -17,7 +17,7 @@ const GlobalWrapper = styled('div')`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const Properties = ({ isLoading, cave }) => {
@@ -32,13 +32,13 @@ const Properties = ({ isLoading, cave }) => {
   return (
     <GlobalWrapper>
       {hasCharacteristics && (
-        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+        <Paper variant="outlined" sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection title={formatMessage({ id: 'Characteristics' })}>
             <Box
               sx={{
                 display: 'grid',
                 gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: 1
+                gap: 0.5
               }}>
               <DepthProperty depth={cave?.depth} isLoading={isLoading} />
               <LengthProperty length={cave?.length} isLoading={isLoading} />
@@ -52,7 +52,7 @@ const Properties = ({ isLoading, cave }) => {
         </Paper>
       )}
       {cave?.exploringOrganizations?.length > 0 && (
-        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+        <Paper variant="outlined" sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
           <InfoSection title={formatMessage({ id: 'Exploring organizations' })}>
             <Box
               sx={{

--- a/packages/web-app/src/components/appli/Network/Science/index.jsx
+++ b/packages/web-app/src/components/appli/Network/Science/index.jsx
@@ -31,7 +31,7 @@ const Science = ({ caveId }) => {
             })}
           />
 
-          <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
+          <Box sx={{ mt: 1, display: 'flex', gap: 0.5 }}>
             <Button
               variant="outlined"
               color="secondary"

--- a/packages/web-app/src/components/appli/Network/index.jsx
+++ b/packages/web-app/src/components/appli/Network/index.jsx
@@ -43,12 +43,12 @@ import {
 const HalfSplitContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 
   ${({ theme }) => theme.breakpoints.up('sm')} {
     flex-direction: row;
     align-items: stretch;
-    gap: ${({ theme }) => theme.spacing(3)};
+    gap: ${({ theme }) => theme.spacing(2)};
   }
 `;
 
@@ -221,7 +221,7 @@ export const Network = ({ isLoading, error, cave }) => {
           {/* Tab 0 — Information */}
           <div>
             {isLoading && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Skeleton height={300} />
                 <Skeleton height={100} />
                 <Skeleton height={100} />
@@ -229,7 +229,7 @@ export const Network = ({ isLoading, error, cave }) => {
               </Card>
             )}
             {error && (
-              <Card sx={{ m: 2, p: 3 }}>
+              <Card sx={{ m: 1, p: 2 }}>
                 <Alert
                   title={formatMessage({
                     id: 'Error, the network data you are looking for is not available.'
@@ -241,7 +241,7 @@ export const Network = ({ isLoading, error, cave }) => {
             {cave && (
               <>
                 {cave.isDeleted && (
-                  <Box sx={{ m: 2 }}>
+                  <Box sx={{ m: 1 }}>
                     <DeletedCard
                       entityType={DELETED_ENTITIES.network}
                       entity={cave}
@@ -277,7 +277,7 @@ export const Network = ({ isLoading, error, cave }) => {
                             flex: 1,
                             display: 'flex',
                             flexDirection: 'column',
-                            gap: 2
+                            gap: 1
                           }}>
                           <Box sx={{ minHeight: 200 }}>
                             <EntrancesMap
@@ -303,7 +303,7 @@ export const Network = ({ isLoading, error, cave }) => {
                           component="div"
                           variant="caption"
                           color="text.secondary"
-                          sx={{ mt: 2 }}>
+                          sx={{ mt: 1 }}>
                           {cave.author && (
                             <AuthorAndDate
                               author={cave.author}

--- a/packages/web-app/src/components/appli/NotificationMenu/index.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/index.jsx
@@ -32,16 +32,16 @@ const SeeAllMenuItem = styled(MenuItem)(({ theme }) => ({
   color: theme.palette.primary.main,
   fontWeight: 'bold',
   justifyContent: 'center',
-  padding: theme.spacing(2)
+  padding: theme.spacing(1)
 }));
 
 const createSkeletons = n =>
   [...Array(n)].map((e, i) => (
     // Dummy skeletons which will disappear: we can ignore the eslint rule
     // eslint-disable-next-line react/no-array-index-key
-    <MenuItem key={i} style={{ width: NOTIFICATION_WIDTH }}>
+    (<MenuItem key={i} style={{ width: NOTIFICATION_WIDTH }}>
       <Skeleton width={NOTIFICATION_WIDTH} />
-    </MenuItem>
+    </MenuItem>)
   ));
 
 const NotificationMenu = () => {
@@ -143,8 +143,8 @@ const NotificationMenu = () => {
         {/* Header */}
         <Box
           sx={{
-            px: 2,
-            py: 2,
+            px: 1,
+            py: 1,
             bgcolor: 'action.hover',
             display: 'flex',
             alignItems: 'center',
@@ -154,7 +154,7 @@ const NotificationMenu = () => {
           <Typography variant="body2" color="text.primary">
             {formatMessage({ id: 'Notifications' })}
           </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             {nbNotifications > 0 && (
               <Chip label={nbNotifications} color="secondary" size="small" />
             )}
@@ -202,12 +202,12 @@ const NotificationMenu = () => {
           {notifications && notifications.length === 0 && (
             <Box
               sx={{
-                px: 2,
-                py: 3,
+                px: 1,
+                py: 2,
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
-                gap: 1,
+                gap: 0.5,
                 color: 'action.active'
               }}>
               <NotificationsOffIcon />

--- a/packages/web-app/src/components/appli/NotificationMenu/index.jsx
+++ b/packages/web-app/src/components/appli/NotificationMenu/index.jsx
@@ -39,9 +39,9 @@ const createSkeletons = n =>
   [...Array(n)].map((e, i) => (
     // Dummy skeletons which will disappear: we can ignore the eslint rule
     // eslint-disable-next-line react/no-array-index-key
-    (<MenuItem key={i} style={{ width: NOTIFICATION_WIDTH }}>
+    <MenuItem key={i} style={{ width: NOTIFICATION_WIDTH }}>
       <Skeleton width={NOTIFICATION_WIDTH} />
-    </MenuItem>)
+    </MenuItem>
   ));
 
 const NotificationMenu = () => {

--- a/packages/web-app/src/components/appli/Organization/BadgesSection.jsx
+++ b/packages/web-app/src/components/appli/Organization/BadgesSection.jsx
@@ -20,7 +20,7 @@ const EntranceIcon = styled('img')`
 `;
 
 const StyledBadge = styled(Badge)`
-  margin: ${({ theme }) => theme.spacing(1)};
+  margin: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const BadgesSection = ({

--- a/packages/web-app/src/components/appli/Organization/Details.jsx
+++ b/packages/web-app/src/components/appli/Organization/Details.jsx
@@ -27,24 +27,24 @@ import {
 const HalfSplitContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 
   ${({ theme }) => theme.breakpoints.up('sm')} {
     flex-direction: row;
     align-items: stretch;
-    gap: ${({ theme }) => theme.spacing(3)};
+    gap: ${({ theme }) => theme.spacing(2)};
   }
 `;
 
 const InfoRow = styled('div')`
   display: flex;
   align-items: flex-start;
-  gap: ${({ theme }) => theme.spacing(1)};
+  gap: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const SectionPaper = styled(Paper)`
-  padding: ${({ theme }) => theme.spacing(2)};
-  border-radius: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(1)};
+  border-radius: ${({ theme }) => theme.spacing(0.5)};
   background-color: ${({ theme }) => theme.palette.grey[50]};
 `;
 
@@ -123,7 +123,6 @@ const Details = ({ organization }) => {
           </CustomMapContainer>
         </Box>
       )}
-
       {/* RIGHT: Stats + Info Papers */}
       <Box
         sx={{
@@ -131,7 +130,7 @@ const Details = ({ organization }) => {
           minWidth: 0,
           display: 'flex',
           flexDirection: 'column',
-          gap: 2
+          gap: 1
         }}>
         {/* Stats — prominent */}
         <SectionPaper variant="outlined">

--- a/packages/web-app/src/components/appli/Organization/ManagedEntitiesSection.jsx
+++ b/packages/web-app/src/components/appli/Organization/ManagedEntitiesSection.jsx
@@ -24,7 +24,9 @@ const ManagedEntitiesSection = ({ organization }) => {
   const renderList = (items, getLink) => (
     <List dense disablePadding>
       {items.map(item => (
-        <ListItem key={item.id} sx={{ px: 0, py: 0.5 }}>
+        <ListItem key={item.id} sx={{
+          px: 0.25
+        }}>
           <ListItemText
             primary={
               <Link component={RouterLink} to={getLink(item)}>
@@ -38,19 +40,18 @@ const ManagedEntitiesSection = ({ organization }) => {
   );
 
   return (
-    <Box sx={{ my: 2 }}>
+    <Box sx={{ my: 1 }}>
       {sortedCountries.length > 0 && (
-        <Box sx={{ mb: 2 }}>
-          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 1 }}>
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 0.5 }}>
             {formatMessage({ id: 'Countries' })}
           </Typography>
           {renderList(sortedCountries, country => `/ui/countries/${country.id}`)}
         </Box>
       )}
-
       {sortedRegions.length > 0 && (
-        <Box sx={{ mb: 2 }}>
-          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 1 }}>
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 0.5 }}>
             {formatMessage({ id: 'Regions' })}
           </Typography>
           {renderList(sortedRegions, region => {
@@ -80,10 +81,9 @@ const ManagedEntitiesSection = ({ organization }) => {
           })}
         </Box>
       )}
-
       {sortedMassifs.length > 0 && (
-        <Box sx={{ mb: 2 }}>
-          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 1 }}>
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', mb: 0.5 }}>
             {formatMessage({ id: 'Massifs' })}
           </Typography>
           {renderList(sortedMassifs, massif => `/ui/massifs/${massif.id}`)}

--- a/packages/web-app/src/components/appli/Organization/index.jsx
+++ b/packages/web-app/src/components/appli/Organization/index.jsx
@@ -180,7 +180,7 @@ const Organization = ({ error, isLoading, organization }) => {
       <Stack
         direction="row"
         divider={
-          <Typography component="span" color="text.secondary" sx={{ mx: 1 }}>
+          <Typography component="span" color="text.secondary" sx={{ mx: 0.5 }}>
             ·
           </Typography>
         }
@@ -227,7 +227,7 @@ const Organization = ({ error, isLoading, organization }) => {
         actions={actions}
       />
       {isLoading && (
-        <Card sx={{ m: 2, p: 3 }}>
+        <Card sx={{ m: 1, p: 2 }}>
           <Skeleton height={150} />
           <Skeleton height={100} />
           <Skeleton height={100} />
@@ -235,7 +235,7 @@ const Organization = ({ error, isLoading, organization }) => {
         </Card>
       )}
       {error && (
-        <Card sx={{ m: 2, p: 3 }}>
+        <Card sx={{ m: 1, p: 2 }}>
           <Alert
             title={formatMessage({
               id: 'Error, the organization data you are looking for is not available.'
@@ -247,7 +247,7 @@ const Organization = ({ error, isLoading, organization }) => {
       {organization && (
         <>
           {organization.isDeleted && (
-            <Box sx={{ m: 2 }}>
+            <Box sx={{ m: 1 }}>
               <DeletedCard
                 entityType={DELETED_ENTITIES.organization}
                 entity={organization}

--- a/packages/web-app/src/components/appli/OrganizationAssociation/AssociationForm.jsx
+++ b/packages/web-app/src/components/appli/OrganizationAssociation/AssociationForm.jsx
@@ -62,7 +62,7 @@ const AssociationForm = ({ open, onClose, onSubmit, status, error }) => {
       </DialogTitle>
       <DialogContent>
         {status === REDUCER_STATUS.FAILED && (
-          <Alert severity="error" sx={{ mb: 2 }}>
+          <Alert severity="error" sx={{ mb: 1 }}>
             {error?.message ||
               formatMessage({ id: 'An error occurred while saving.' })}
           </Alert>
@@ -114,7 +114,7 @@ const AssociationForm = ({ open, onClose, onSubmit, status, error }) => {
           inputValue.trim().length > 0 &&
           results.length === 0 &&
           !isLoading && (
-            <Alert severity="info" sx={{ mt: 2 }}>
+            <Alert severity="info" sx={{ mt: 1 }}>
               {formatMessage(
                 {
                   id: 'Select an existing organization from the list, or a new one named "{name}" will be created.'

--- a/packages/web-app/src/components/appli/OrganizationAssociation/index.jsx
+++ b/packages/web-app/src/components/appli/OrganizationAssociation/index.jsx
@@ -156,9 +156,9 @@ const AssociationSection = ({
       icon={associateButton}
       content={
         isLoading ? (
-          <Skeleton variant="rectangular" height={60} sx={{ my: 1, borderRadius: 1 }} />
+          <Skeleton variant="rectangular" height={60} sx={{ my: 0.5, borderRadius: 1 }} />
         ) : (
-          <Box sx={{ my: 1 }}>
+          <Box sx={{ my: 0.5 }}>
             <EntitiesList
               type="organization"
               entities={organizations}

--- a/packages/web-app/src/components/appli/Person/Person.jsx
+++ b/packages/web-app/src/components/appli/Person/Person.jsx
@@ -126,7 +126,7 @@ const Person = ({ isLoading, person, error }) => {
       label={formatMessage({ id: 'You' }).toUpperCase()}
       color="secondary"
       sx={{
-        ml: 3,
+        ml: 2,
         fontSize: '1.4rem',
         letterSpacing: 1.5,
         verticalAlign: 'middle',
@@ -211,7 +211,7 @@ const Person = ({ isLoading, person, error }) => {
         {/* Tab Profil */}
         <div>
           {isLoading && (
-            <Card sx={{ m: 2, p: 3 }}>
+            <Card sx={{ m: 1, p: 2 }}>
               <Skeleton />
               <Skeleton height={200} />
               <Skeleton height={100} />
@@ -221,7 +221,7 @@ const Person = ({ isLoading, person, error }) => {
             </Card>
           )}
           {!!error && (
-            <Card sx={{ m: 2, p: 3 }}>
+            <Card sx={{ m: 1, p: 2 }}>
               <Alert
                 title={formatMessage({
                   id: 'Error, the person you are looking for is not available.'
@@ -250,7 +250,7 @@ const Person = ({ isLoading, person, error }) => {
         {/* Tab Activités */}
         <div>
           {isLoading && (
-            <Card sx={{ m: 2, p: 3 }}>
+            <Card sx={{ m: 1, p: 2 }}>
               <Skeleton height={100} />
               <Skeleton height={100} />
             </Card>
@@ -300,7 +300,7 @@ const Person = ({ isLoading, person, error }) => {
         {/* Tab Documents */}
         <div>
           {isLoading && (
-            <Card sx={{ m: 2, p: 3 }}>
+            <Card sx={{ m: 1, p: 2 }}>
               <Skeleton height={40} width="100%" />
               <Skeleton height={60} />
               <Skeleton height={60} />

--- a/packages/web-app/src/components/appli/Region/index.jsx
+++ b/packages/web-app/src/components/appli/Region/index.jsx
@@ -126,87 +126,87 @@ const Region = ({
 
   return (
     <PageContainer>
-    <div ref={componentRef}>
-      <PageHeader
-        title={region?.name ?? (isLoading ? undefined : '')}
-        subheader={subheader}
-        actions={actions}
-      />
-      {region && (
-        <Box sx={{ mx: 2, mb: 1 }}>
-          <Button
-            fullWidth
-            variant="contained"
-            color="primary"
-            size="large"
-            startIcon={<CustomIcon type="entrance" size={24} />}
-            onClick={() =>
-              navigate(
-                `/ui/countries/${countryId}/regions/${regionId}/entrances`
-              )
-            }>
-            {formatMessage({ id: 'Entrances list' })}
-            {dataRegion?.nb_caves ? ` (${dataRegion.nb_caves})` : ''}
-          </Button>
-        </Box>
-      )}
-      {isLoading && (
-        <Card sx={{ m: 2, p: 3 }}>
-          <Skeleton height={150} />
-        </Card>
-      )}
-      {error && (
-        <Card sx={{ m: 2, p: 3 }}>
-          <Alert
-            title={formatMessage({
-              id: 'Error, the region data you are looking for is not available.'
-            })}
-            severity="error"
-          />
-        </Card>
-      )}
-      {region && (
-        <>
-          {position && (
-            <ScrollableContent
-              content={
-                <CustomMapContainer
-                  center={position}
-                  dragging={!isMobile}
-                  forceCentering
-                  scrollWheelZoom={false}
-                  wholePage={false}
-                  shouldChangeControlInFullscreen={false}
-                  zoom={6}>
-                  <Marker icon={CoordinatesMarker} position={position} />
-                </CustomMapContainer>
-              }
+      <div ref={componentRef}>
+        <PageHeader
+          title={region?.name ?? (isLoading ? undefined : '')}
+          subheader={subheader}
+          actions={actions}
+        />
+        {region && (
+          <Box sx={{ mx: 1, mb: 0.5 }}>
+            <Button
+              fullWidth
+              variant="contained"
+              color="primary"
+              size="large"
+              startIcon={<CustomIcon type="entrance" size={24} />}
+              onClick={() =>
+                navigate(
+                  `/ui/countries/${countryId}/regions/${regionId}/entrances`
+                )
+              }>
+              {formatMessage({ id: 'Entrances list' })}
+              {dataRegion?.nb_caves ? ` (${dataRegion.nb_caves})` : ''}
+            </Button>
+          </Box>
+        )}
+        {isLoading && (
+          <Card sx={{ m: 1, p: 2 }}>
+            <Skeleton height={150} />
+          </Card>
+        )}
+        {error && (
+          <Card sx={{ m: 1, p: 2 }}>
+            <Alert
+              title={formatMessage({
+                id: 'Error, the region data you are looking for is not available.'
+              })}
+              severity="error"
             />
-          )}
-          <StatisticsDataDashboard
-            regionId={regionId}
-            countryId={countryId}
-            description={formatMessage({
-              id: 'Discover the numbers about this region and its caves.'
-            })}
-          />
-          {(region.guidelines?.length > 0 || permissions.isAuth) && (
-            <Guidelines
-              entityType="regions"
-              entityId={region.id}
-              guidelines={region.guidelines}
+          </Card>
+        )}
+        {region && (
+          <>
+            {position && (
+              <ScrollableContent
+                content={
+                  <CustomMapContainer
+                    center={position}
+                    dragging={!isMobile}
+                    forceCentering
+                    scrollWheelZoom={false}
+                    wholePage={false}
+                    shouldChangeControlInFullscreen={false}
+                    zoom={6}>
+                    <Marker icon={CoordinatesMarker} position={position} />
+                  </CustomMapContainer>
+                }
+              />
+            )}
+            <StatisticsDataDashboard
+              regionId={regionId}
+              countryId={countryId}
+              description={formatMessage({
+                id: 'Discover the numbers about this region and its caves.'
+              })}
             />
-          )}
-          <AssociationSection
-            organizations={region?.organizations}
-            entityType="region"
-            entityId={regionId}
-            parentEntityId={countryId}
-            isLoading={isLoading}
-          />
-        </>
-      )}
-    </div>
+            {(region.guidelines?.length > 0 || permissions.isAuth) && (
+              <Guidelines
+                entityType="regions"
+                entityId={region.id}
+                guidelines={region.guidelines}
+              />
+            )}
+            <AssociationSection
+              organizations={region?.organizations}
+              entityType="region"
+              entityId={regionId}
+              parentEntityId={countryId}
+              isLoading={isLoading}
+            />
+          </>
+        )}
+      </div>
     </PageContainer>
   );
 };

--- a/packages/web-app/src/components/appli/SearchDocumentForm/index.jsx
+++ b/packages/web-app/src/components/appli/SearchDocumentForm/index.jsx
@@ -12,7 +12,7 @@ import Alert from '../../common/Alert';
 
 const SpacedButton = styled(Button)`
   ${({ theme }) => `
-  margin: 0 ${theme.spacing(1)};`}
+  margin: 0 ${theme.spacing(0.5)};`}
 `;
 
 const SearchDocumentForm = ({ closeForm, onSubmit }) => {
@@ -60,7 +60,6 @@ const SearchDocumentForm = ({ closeForm, onSubmit }) => {
           ]);
         }}
       />
-
       {selectedDocuments.length === 0 && (
         <Alert
           severity="info"
@@ -69,8 +68,7 @@ const SearchDocumentForm = ({ closeForm, onSubmit }) => {
           })}
         />
       )}
-
-      <Box my={4}>
+      <Box my={3}>
         {closeForm && (
           <SpacedButton onClick={closeForm}>
             {formatMessage({ id: 'Cancel' })}

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesData/InlineData.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesData/InlineData.jsx
@@ -31,7 +31,7 @@ const InlineData = ({ icon, numberData, text }) => {
           variant="h3"
           color="secondary"
           fontWeight={700}
-          sx={{ pl: 1 }}>
+          sx={{ pl: 0.5 }}>
           {numberData.toLocaleString(locale)}
         </Typography>
       </StyledLine>

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesData/index.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesData/index.jsx
@@ -10,10 +10,10 @@ const CavesData = ({ title, nbMassifs, nbCaves, nbDivingCaves, nbNetworks }) => 
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      <Typography variant="h4" textAlign="center" pb={2}>
+      <Typography variant="h4" textAlign="center" pb={1}>
         {title}
       </Typography>
-      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 3 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
         {nbMassifs !== undefined && nbMassifs !== null && (
           <InlineData
             icon={<CustomIcon type="massif" size={40} />}

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesStatistics/InfoBlock.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesStatistics/InfoBlock.jsx
@@ -14,8 +14,8 @@ const InfoBlock = ({ icon, numberData, text }) => {
   const locale = useSelector(state => state.intl);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <StyledIcon>{icon}</StyledIcon>
         <Typography variant="h3" color="secondary" fontWeight={700}>
           {(Math.round(numberData * 10) / 10).toLocaleString(locale)} m

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesStatistics/index.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/CavesStatistics/index.jsx
@@ -10,7 +10,7 @@ import { depthIcon, lengthIcon } from '../../../../../assets/icons';
 const StyledBox = styled(Box)(({ theme }) => ({
   display: 'grid',
   alignItems: 'center',
-  gap: theme.spacing(2),
+  gap: theme.spacing(1),
   [theme.breakpoints.down('sm')]: {
     gridTemplateColumns: '1fr !important',
     '& hr': { display: 'none' },
@@ -62,7 +62,7 @@ const CavesStatistics = ({ avgDepth, avgLength, totalLength }) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      <Typography variant="h4" textAlign="center" pb={2}>
+      <Typography variant="h4" textAlign="center" pb={1}>
         {formatMessage({ id: 'Caves statistics' })}
       </Typography>
       <StyledBox sx={{ gridTemplateColumns: cols.join(' ') }}>

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/SpecificsCaves/CaveCard.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/SpecificsCaves/CaveCard.jsx
@@ -29,7 +29,7 @@ const CaveCard = ({ idCave, nameCave, numberData, text, backgroundColor }) => {
       style={{ backgroundColor: alpha(backgroundColor, 0.75) }}
       to={`/ui/caves/${idCave}`}
       openInNewTabDesktop>
-      <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 0.5 }}>
         <Typography variant="h4" fontWeight={700} noWrap>
           {numberData.toLocaleString(locale)} m
         </Typography>

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/components/SpecificsCaves/index.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/components/SpecificsCaves/index.jsx
@@ -8,7 +8,7 @@ import CaveCard from './CaveCard';
 const StyledBox = styled(Box)`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const SpecificsCaves = ({ maxDepthCave, maxLengthCave, parentEntity }) => {
@@ -17,7 +17,7 @@ const SpecificsCaves = ({ maxDepthCave, maxLengthCave, parentEntity }) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      <Typography variant="h4" textAlign="center" pb={2}>
+      <Typography variant="h4" textAlign="center" pb={1}>
         {formatMessage({ id: 'Specifics caves' })}
       </Typography>
       <StyledBox>

--- a/packages/web-app/src/components/appli/StatisticsDataDashboard/index.jsx
+++ b/packages/web-app/src/components/appli/StatisticsDataDashboard/index.jsx
@@ -85,11 +85,11 @@ const StatisticsDataDashboard = ({
         <>
           {isLoading && <Skeleton height={200} width="100%" />}
           {hasData && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               {/* KPI banner: 3 key metrics full width */}
               <Paper
                 variant="outlined"
-                sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+                sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
                 <CavesStatistics
                   avgDepth={data.avg.avg_depth}
                   avgLength={data.avg.avg_length}
@@ -101,11 +101,11 @@ const StatisticsDataDashboard = ({
                 sx={{
                   display: 'grid',
                   gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
-                  gap: 2
+                  gap: 1
                 }}>
                 <Paper
                   variant="outlined"
-                  sx={{ p: 1, px: 4, borderRadius: 2, bgcolor: 'grey.50' }}>
+                  sx={{ p: 0.5, px: 3, borderRadius: 2, bgcolor: 'grey.50' }}>
                   <CavesData
                     title={
                       entityType === 'country'
@@ -120,7 +120,7 @@ const StatisticsDataDashboard = ({
                 </Paper>
                 <Paper
                   variant="outlined"
-                  sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+                  sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
                   <SpecificsCaves
                     maxDepthCave={data.cave_with_max_depth}
                     maxLengthCave={data.cave_with_max_length}

--- a/packages/web-app/src/components/common/Alert.jsx
+++ b/packages/web-app/src/components/common/Alert.jsx
@@ -7,9 +7,9 @@ const StyledAlert = styled(MuiAlert, {
   shouldForwardProp: prop => prop[0] !== '$'
 })`
   margin-top: ${({ theme, $disablemargins }) =>
-    !$disablemargins && theme.spacing(2)};
+    !$disablemargins && theme.spacing(1)};
   margin-bottom: ${({ theme, $disablemargins }) =>
-    !$disablemargins && theme.spacing(2)};
+    !$disablemargins && theme.spacing(1)};
 `;
 
 const Alert = ({

--- a/packages/web-app/src/components/common/AppBar/User.jsx
+++ b/packages/web-app/src/components/common/AppBar/User.jsx
@@ -110,8 +110,8 @@ const UserMenu = ({
         {/* Primary content: User info */}
         <Box
           sx={{
-            px: 2,
-            py: 2,
+            px: 1,
+            py: 1,
             bgcolor: 'action.hover',
             display: 'flex',
             flexDirection: 'column'
@@ -157,7 +157,7 @@ const UserMenu = ({
 
         {/* Session expired warning */}
         {isSessionExpired && (
-          <Box sx={{ px: 2, py: '12px' }}>
+          <Box sx={{ px: 1, py: '12px' }}>
             <Alert severity="error">
               {formatMessage({
                 id: 'Your session has expired: please log in again.'

--- a/packages/web-app/src/components/common/AppBar/index.jsx
+++ b/packages/web-app/src/components/common/AppBar/index.jsx
@@ -50,10 +50,10 @@ const StyledMuiAppBar = styled(MuiAppBar, {
 const NavigationGroup = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(1),
-  marginRight: theme.spacing(2),
+  gap: theme.spacing(0.5),
+  marginRight: theme.spacing(1),
   [theme.breakpoints.down('sm')]: {
-    marginRight: theme.spacing(1)
+    marginRight: theme.spacing(0.5)
   }
 }));
 
@@ -67,7 +67,7 @@ const ToolsGroup = styled('div')(({ theme }) => ({
   flexGrow: 1,
   gap: 12,
   alignItems: 'center',
-  padding: theme.spacing(2),
+  padding: theme.spacing(1),
   [theme.breakpoints.down('sm')]: {
     display: 'none'
   }
@@ -75,7 +75,7 @@ const ToolsGroup = styled('div')(({ theme }) => ({
 
 const LogoImage = styled('img')(({ theme }) => ({
   height: 34,
-  marginRight: theme.spacing(2),
+  marginRight: theme.spacing(1),
   [theme.breakpoints.down('sm')]: {
     height: 32
   }
@@ -99,10 +99,10 @@ export const StyledLink = styled(Link)`
 
 const ActionsGroup = styled('div')(({ theme }) => ({
   display: 'flex',
-  gap: theme.spacing(1),
-  marginLeft: theme.spacing(2),
+  gap: theme.spacing(0.5),
+  marginLeft: theme.spacing(1),
   [theme.breakpoints.down('sm')]: {
-    marginLeft: theme.spacing(1)
+    marginLeft: theme.spacing(0.5)
   }
 }));
 

--- a/packages/web-app/src/components/common/AuthorsSelect/index.jsx
+++ b/packages/web-app/src/components/common/AuthorsSelect/index.jsx
@@ -92,7 +92,6 @@ const AuthorsSelect = ({
         variant="caption"
         color="text.secondary"
         display="block"
-        sx={{}}
       >
         {formatMessage({ id: HELPER_TEXT_KEY })}
       </Typography>

--- a/packages/web-app/src/components/common/AuthorsSelect/index.jsx
+++ b/packages/web-app/src/components/common/AuthorsSelect/index.jsx
@@ -92,7 +92,7 @@ const AuthorsSelect = ({
         variant="caption"
         color="text.secondary"
         display="block"
-        sx={{ mb: 0.5 }}
+        sx={{}}
       >
         {formatMessage({ id: HELPER_TEXT_KEY })}
       </Typography>
@@ -151,7 +151,7 @@ const AuthorsSelect = ({
               />
             )}
           />
-          <Collapse in={isCreateOpen} sx={{ p: 1 }}>
+          <Collapse in={isCreateOpen} sx={{ p: 0.5 }}>
             <CreateCaverPanel
               enabled={isCreateOpen}
               onCreateSuccess={handleCreateSuccess}

--- a/packages/web-app/src/components/common/AutoCompleteSearch/index.jsx
+++ b/packages/web-app/src/components/common/AutoCompleteSearch/index.jsx
@@ -41,14 +41,14 @@ const InputWrapper = styled('div', {
 `;
 
 const SearchIconWrapper = styled('div')`
-  padding: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(0.5)};
   display: flex;
   align-items: center;
   justify-content: center;
 `;
 
 const StyledInputBase = styled(InputBase)`
-  padding: ${({ theme }) => theme.spacing(1, 1, 1, 0)};
+  padding: ${({ theme }) => theme.spacing(0.5, 0.5, 0.5, 0.25)};
   width: 100%;
 `;
 
@@ -79,7 +79,7 @@ const InputAdornments = ({ isLoading, hasError }) =>
   ) : null;
 
 const StyledPopper = hasFixWidth =>
-  function (props) {
+  (function(props) {
     return (
       <ResultsPopper
         {...props}
@@ -87,7 +87,7 @@ const StyledPopper = hasFixWidth =>
         placement="bottom-end"
       />
     );
-  };
+  });
 const AutoCompleteSearch = ({
   suggestions,
   renderOption,

--- a/packages/web-app/src/components/common/CRSMenu/index.jsx
+++ b/packages/web-app/src/components/common/CRSMenu/index.jsx
@@ -101,10 +101,10 @@ const CRSMenu = ({ anchorEl = null, onClose, preferred, projections = [], onSele
           overflow: 'hidden'
         }
       }}>
-      <Box sx={{ p: 1, borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{ p: 0.5, borderBottom: 1, borderColor: 'divider' }}>
         <ListSubheader
           disableSticky
-          sx={{ lineHeight: '28px', fontWeight: 'bold', px: 0 }}>
+          sx={{ lineHeight: '28px', fontWeight: 'bold', px: 0.25 }}>
           <Translate>Coordinate system</Translate>
         </ListSubheader>
         <SearchInput
@@ -113,10 +113,13 @@ const CRSMenu = ({ anchorEl = null, onClose, preferred, projections = [], onSele
           sx={{ '& input': { fontSize: '1.4rem' } }}
         />
       </Box>
-
       <MenuList
         dense
-        sx={{ overflowY: 'auto', overflowX: 'hidden', flex: 1, py: 0.5 }}>
+        sx={{
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          flex: 1
+        }}>
         {showWGS84 && (
           <MenuItem onClick={() => onSelect(WGS84_DD)}>
             <ListItemIcon>

--- a/packages/web-app/src/components/common/Contribution/Contribution.jsx
+++ b/packages/web-app/src/components/common/Contribution/Contribution.jsx
@@ -42,7 +42,7 @@ const Contribution = ({
         </MultilinesTypography>
       )}
       {!hideAttribution && (author || reviewer || language) && (
-        <Typography component="div" variant="caption" color="text.secondary" sx={{ mt: 3 }}>
+        <Typography component="div" variant="caption" color="text.secondary" sx={{ mt: 2 }}>
           {author && (
             <AuthorAndDate
               author={author}

--- a/packages/web-app/src/components/common/CoordinateDisplay/index.jsx
+++ b/packages/web-app/src/components/common/CoordinateDisplay/index.jsx
@@ -119,7 +119,7 @@ const CoordinateDisplay = ({
 
   if (compact) {
     return (
-      <Box display="flex" alignItems="center" gap={0.5}>
+      <Box display="flex" alignItems="center">
         <Typography variant="body2">{displayValue}</Typography>
         <Tooltip title={formatMessage({ id: 'Copy coordinates' })}>
           <IconButton
@@ -151,7 +151,7 @@ const CoordinateDisplay = ({
   }
 
   return (
-    <Box display="flex" alignItems="center" flexWrap="wrap" gap={1}>
+    <Box display="flex" alignItems="center" flexWrap="wrap" gap={0.5}>
       <Typography variant="body1">{displayValue}</Typography>
       {precisionText && (
         <Chip

--- a/packages/web-app/src/components/common/DataQualityBadge/DataQualityComputeDetails.jsx
+++ b/packages/web-app/src/components/common/DataQualityBadge/DataQualityComputeDetails.jsx
@@ -9,13 +9,12 @@ const DataQualityComputeDetails = () => {
   const theme = useTheme();
 
   return (
-    <Box display="flex" flexDirection="column" gap={2} p={2}>
+    <Box display="flex" flexDirection="column" gap={1} p={1}>
       <Typography variant="body2">
         {formatMessage({
           id: 'The quality of the data is calculated from the information available on the cave, the number of people who provided information and the date of the last contributions. This allows us to build a value between 3 and 100.'
         })}
       </Typography>
-
       <Box>
         <Typography variant="body2" gutterBottom>
           {formatMessage({ id: 'The chosen color code is as follows:' })}
@@ -37,7 +36,6 @@ const DataQualityComputeDetails = () => {
           {` — ${formatMessage({ id: 'The data provided is of high quality, a verification would guarantee the quality level of this data.' })}`}
         </Typography>
       </Box>
-
       <Box sx={{ overflowX: 'auto' }}>
         <DataQualityComputeTable />
       </Box>

--- a/packages/web-app/src/components/common/DataQualityBadge/DataQualityHelpButton.jsx
+++ b/packages/web-app/src/components/common/DataQualityBadge/DataQualityHelpButton.jsx
@@ -22,7 +22,7 @@ const DataQualityHelpButton = () => {
         onClose={() => setAnchor(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         slotProps={{ paper: { sx: { maxWidth: 700, width: '90vw' } } }}>
-        <Box px={2} pt={2}>
+        <Box px={1} pt={1}>
           <Typography variant="h6">
             {formatMessage({ id: 'Data quality computation' })}
           </Typography>

--- a/packages/web-app/src/components/common/DocumentsList/Document.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/Document.jsx
@@ -48,24 +48,26 @@ const Document = ({
   }, [document.description, isMobileView]);
 
   return (
-    <ListItem disableGutters sx={{ display: 'block', py: 0.5 }}>
+    <ListItem disableGutters sx={{
+      display: 'block'
+    }}>
       <Paper
         variant="outlined"
-        sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+        sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
         {/* Header row: title + chip + actions */}
         <Box
           sx={{
             display: 'flex',
             alignItems: 'flex-start',
             justifyContent: 'space-between',
-            gap: 1
+            gap: 0.5
           }}>
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
               flexWrap: 'wrap',
-              gap: 1,
+              gap: 0.5,
               flex: 1,
               minWidth: 0
             }}>
@@ -118,7 +120,7 @@ const Document = ({
 
         {/* Description with truncation */}
         {document.description && (
-          <Box mt={1}>
+          <Box mt={0.5}>
             <Typography
               ref={descriptionRef}
               variant="body2"
@@ -142,7 +144,11 @@ const Document = ({
                 endIcon={
                   descriptionExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />
                 }
-                sx={{ p: 0, minWidth: 0, mt: 0.5, textTransform: 'none' }}
+                sx={{
+                  p: 0.25,
+                  minWidth: 0,
+                  textTransform: 'none'
+                }}
                 onClick={() => setDescriptionExpanded(e => !e)}>
                 {formatMessage({
                   id: descriptionExpanded ? 'Show less' : 'Read more'
@@ -154,7 +160,7 @@ const Document = ({
 
         {/* Files */}
         {document.files && (
-          <Box mt={1}>
+          <Box mt={0.5}>
             <Files
               files={document.files}
               description={document.description}
@@ -164,7 +170,6 @@ const Document = ({
           </Box>
         )}
       </Paper>
-
       {onUnlink && (
         <StandardDialog
           open={isUnlinkDialogOpen}

--- a/packages/web-app/src/components/common/DocumentsList/DocumentsList.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/DocumentsList.jsx
@@ -14,11 +14,13 @@ import ImageLightbox from './ImageLightbox';
 import { isImageFile } from './utils/imageUtils';
 
 const DocumentSkeleton = () => (
-  <ListItem disableGutters sx={{ display: 'block', py: 0.5 }}>
+  <ListItem disableGutters sx={{
+    display: 'block'
+  }}>
     <Paper
       variant="outlined"
-      sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+      sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
         <Skeleton variant="text" width="55%" height={28} />
         <Skeleton variant="rounded" width={90} height={24} />
       </Box>
@@ -111,7 +113,7 @@ const DocumentsList = ({
       </List>
       {totalPages > 1 && (
         <Box
-          mt={2}
+          mt={1}
           display="flex"
           justifyContent="center"
           sx={{ '@media print': { display: 'none' } }}>

--- a/packages/web-app/src/components/common/DocumentsList/Files.jsx
+++ b/packages/web-app/src/components/common/DocumentsList/Files.jsx
@@ -45,7 +45,7 @@ const Files = ({ files = [], description, onImageClick, imageIndexOffset = 0 }) 
     <>
       {/* Image thumbnails section */}
       {imageFiles.length > 0 && (
-        <Grid container rowSpacing={2} columnSpacing={{ xs: 0, sm: 2 }} sx={{ mb: 2 }}>
+        <Grid container rowSpacing={1} columnSpacing={{ xs: 0.25, sm: 1 }} sx={{ mb: 1 }}>
           {imageFiles.map((file, index) => {
             const { src, srcSet } = getThumbnailSources(file);
             return (
@@ -61,7 +61,6 @@ const Files = ({ files = [], description, onImageClick, imageIndexOffset = 0 }) 
           })}
         </Grid>
       )}
-
       {/* Non-image files section (existing logic) */}
       {otherFiles.map(file => (
         <FileListItem key={`${file.fileName}`} dense component="div">
@@ -76,7 +75,6 @@ const Files = ({ files = [], description, onImageClick, imageIndexOffset = 0 }) 
           </Button>
         </FileListItem>
       ))}
-
       {/*
         Fallback lightbox when not managed by a parent component.
 

--- a/packages/web-app/src/components/common/DuplicatesHandler/Common/ActionLine.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/Common/ActionLine.jsx
@@ -7,8 +7,8 @@ import PublishIcon from '@mui/icons-material/Publish';
 import ActionButton from '../../ActionButton';
 
 const StyledGrid = styled(Grid)`
-  margin-top: ${({ theme }) => theme.spacing(2)};
-  margin-bottom: ${({ theme }) => theme.spacing(2)};
+  margin-top: ${({ theme }) => theme.spacing(1)};
+  margin-bottom: ${({ theme }) => theme.spacing(1)};
 `;
 
 const ActionLine = ({

--- a/packages/web-app/src/components/common/DuplicatesHandler/Common/LabelAdornment.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/Common/LabelAdornment.jsx
@@ -11,8 +11,8 @@ import { useIntl } from 'react-intl';
 import { styled } from '@mui/material/styles';
 
 const Wrapper = styled('div')`
-  margin-top: ${({ theme }) => theme.spacing(1)};
-  margin-bot: ${({ theme }) => theme.spacing(1)};
+  margin-top: ${({ theme }) => theme.spacing(0.5)};
+  margin-bot: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const LabelAdornment = () => {

--- a/packages/web-app/src/components/common/DuplicatesHandler/Common/TitleLine.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/Common/TitleLine.jsx
@@ -15,8 +15,8 @@ const Title = ({ children }) => (
 );
 
 const StyledGrid = styled(Grid)`
-  margin-top: ${({ theme }) => theme.spacing(2)};
-  margin-bottom: ${({ theme }) => theme.spacing(2)};
+  margin-top: ${({ theme }) => theme.spacing(1)};
+  margin-bottom: ${({ theme }) => theme.spacing(1)};
 `;
 
 const TitleLine = ({ title1, title2, handleAllClick1, handleAllClick2 }) => {

--- a/packages/web-app/src/components/common/DuplicatesHandler/Common/WrapperUtilities.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/Common/WrapperUtilities.jsx
@@ -1,9 +1,9 @@
 import { styled } from '@mui/material/styles';
 
 export const MarginLeftDiv = styled('div')`
-  margin-left: ${({ theme }) => theme.spacing(2)};
+  margin-left: ${({ theme }) => theme.spacing(1)};
 `;
 
 export const MarginRightDiv = styled('div')`
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-right: ${({ theme }) => theme.spacing(1)};
 `;

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
@@ -105,7 +105,6 @@ const EmptyState = () => (
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      py: 8,
       gap: '12px',
       color: 'text.disabled'
     }}>
@@ -142,7 +141,7 @@ const JumpToPage = ({ page, count, rowsPerPage, onPageChange }) => {
   };
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 2 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, px: 1 }}>
       <Typography variant="body2" noWrap>
         <Translate>Go to page</Translate>
       </Typography>
@@ -311,7 +310,7 @@ const DesktopEntityTable = ({
   const TableContent =
     pageRows.length === 0 ? (
       <TableRow>
-        <TableCell colSpan={colSpan} sx={{ border: 0, p: 0 }}>
+        <TableCell colSpan={colSpan} sx={{ border: 0, p: 0.25 }}>
           <EmptyState />
         </TableCell>
       </TableRow>
@@ -356,7 +355,6 @@ const DesktopEntityTable = ({
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 0.5,
               minHeight: 48,
               overflow: 'hidden'
             }}>
@@ -378,7 +376,7 @@ const DesktopEntityTable = ({
               sx={{
                 minWidth: 0,
                 display: 'flex',
-                gap: 1,
+                gap: 0.5,
                 alignItems: 'center'
               }}>
               {onExport &&

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
@@ -102,7 +102,7 @@ const MobileEntityCard = React.memo(
                 />
               )}
             </Box>
-            <Divider sx={{}} />
+            <Divider />
             {bodyColumns.length > 0 && (
               <Box sx={{
                 display: 'flex',

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
@@ -55,15 +55,21 @@ const MobileEntityCard = React.memo(
           {...(!onToggle
             ? { component: AppLink, to: link(doc), openInNewTabDesktop: true }
             : {})}>
-          <CardContent sx={{ py: 1, px: 1.5, '&:last-child': { pb: 1 } }}>
+          <CardContent
+            sx={{
+              py: 0.5,
+              '&:last-child': { pb: 1 }
+            }}>
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'space-between',
-                mb: 0.5
+                justifyContent: 'space-between'
               }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Box sx={{
+                display: 'flex',
+                alignItems: 'center'
+              }}>
                 {onToggle && (
                   <Checkbox
                     checked={selected}
@@ -71,7 +77,10 @@ const MobileEntityCard = React.memo(
                     color="primary"
                     onClick={e => e.stopPropagation()}
                     onChange={() => onToggle(doc.id)}
-                    sx={{ p: 0, mr: 0.5, flexShrink: 0 }}
+                    sx={{
+                      p: 0.25,
+                      flexShrink: 0
+                    }}
                   />
                 )}
                 {icon}
@@ -86,20 +95,26 @@ const MobileEntityCard = React.memo(
               {!onToggle && (
                 <ChevronRightIcon
                   fontSize="small"
-                  sx={{ color: 'text.disabled', flexShrink: 0, ml: 0.5 }}
+                  sx={{
+                    color: 'text.disabled',
+                    flexShrink: 0
+                  }}
                 />
               )}
             </Box>
-            <Divider sx={{ mb: 0.5 }} />
+            <Divider sx={{}} />
             {bodyColumns.length > 0 && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+              <Box sx={{
+                display: 'flex',
+                flexDirection: 'column'
+              }}>
                 {bodyColumns.map(col => {
                   const value = renderCellFn(doc, col.field, col.render);
                   const isMissing = value === '-';
                   return (
                     <Box
                       key={col.field}
-                      sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                       <Typography
                         variant="caption"
                         color="text.secondary"
@@ -219,8 +234,8 @@ const MobileEntityList = ({
 
   if (allRows.length === 0 && !isLoading) {
     return (
-      <Box sx={{ py: 4, textAlign: 'center', color: 'text.disabled' }}>
-        <SearchOffIcon sx={{ fontSize: 48, mb: 1 }} />
+      <Box sx={{ py: 3, textAlign: 'center', color: 'text.disabled' }}>
+        <SearchOffIcon sx={{ fontSize: 48, mb: 0.5 }} />
         <Typography variant="body2" color="text.secondary">
           <Translate>No results</Translate>
         </Typography>
@@ -233,7 +248,7 @@ const MobileEntityList = ({
 
   return (
     <Box>
-      <Stack spacing={2} sx={{ mb: 1 }}>
+      <Stack spacing={1} sx={{ mb: 0.5 }}>
         {allRows.map(doc => (
           <MobileEntityCard
             key={doc.id}
@@ -249,7 +264,7 @@ const MobileEntityList = ({
         ))}
       </Stack>
       {(hasMore || isLoading) && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
           {isLoading ? (
             <CircularProgress size={24} color="secondary" />
           ) : (
@@ -264,7 +279,7 @@ const MobileEntityList = ({
         <Typography
           variant="caption"
           color="text.secondary"
-          sx={{ display: 'block', textAlign: 'center', py: 1 }}>
+          sx={{ display: 'block', textAlign: 'center', py: 0.5 }}>
           <Translate>Refine your search to see more results</Translate>
         </Typography>
       )}

--- a/packages/web-app/src/components/common/EntityTable/MobileToolbar.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileToolbar.jsx
@@ -138,7 +138,7 @@ const MobileToolbar = ({
     <Toolbar
       disableGutters
       variant="dense"
-      sx={{ display: 'flex', alignItems: 'center', gap: 1, minHeight: 48 }}>
+      sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 48 }}>
       {sortableColumns.length > 0 && (
         <SortMenu
           sortableColumns={sortableColumns}

--- a/packages/web-app/src/components/common/EntityTable/entitiesConfig.jsx
+++ b/packages/web-app/src/components/common/EntityTable/entitiesConfig.jsx
@@ -51,7 +51,7 @@ const cellsRender = {
       <UnreadNotificationIcon color="secondary" fontSize="small" />
     ),
   notificationEntityType: (value, doc) => (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
       <img src={doc.iconPath} alt="icon" style={{ width: '24px' }} />
       <span>
         <Translate>{value}</Translate>

--- a/packages/web-app/src/components/common/FeedbackButton/index.jsx
+++ b/packages/web-app/src/components/common/FeedbackButton/index.jsx
@@ -7,17 +7,17 @@ import { contactLinks } from '../../../conf/externalLinks';
 
 const FloatingAnchor = styled('a')(({ theme }) => ({
   position: 'fixed',
-  bottom: theme.spacing(4),
-  right: theme.spacing(4),
+  bottom: theme.spacing(3),
+  right: theme.spacing(3),
   zIndex: 1200,
   display: 'inline-flex',
   width: 'fit-content',
   alignItems: 'center',
-  gap: theme.spacing(2),
+  gap: theme.spacing(1),
   backgroundColor: theme.palette.secondary.main,
   color: '#fff',
   borderRadius: '50px',
-  padding: `${theme.spacing(2)} ${theme.spacing(3)}`,
+  padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
   boxShadow: '0 4px 20px rgba(0,0,0,0.35)',
   textDecoration: 'none',
   transition: 'box-shadow 0.2s ease, transform 0.2s ease',
@@ -27,9 +27,9 @@ const FloatingAnchor = styled('a')(({ theme }) => ({
     transform: 'translateY(-3px)'
   },
   [theme.breakpoints.down('sm')]: {
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-    padding: `${theme.spacing(1)} ${theme.spacing(2)}`
+    bottom: theme.spacing(1),
+    right: theme.spacing(1),
+    padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
   }
 }));
 

--- a/packages/web-app/src/components/common/FileSelectorInput/index.jsx
+++ b/packages/web-app/src/components/common/FileSelectorInput/index.jsx
@@ -20,7 +20,7 @@ const DropZone = styled(Box, {
     $isDragging ? theme.palette.primary.main : theme.palette.divider
   }`,
   borderRadius: theme.shape.borderRadius * 2,
-  padding: theme.spacing(4, 2),
+  padding: theme.spacing(3, 1),
   textAlign: 'center',
   cursor: 'pointer',
   background: $isDragging ? theme.palette.action.hover : 'transparent',
@@ -81,7 +81,6 @@ const FileSelectorInput = ({
       variant="caption"
       color="text.disabled"
       display="block"
-      mt={1.5}
       onClick={e => e.stopPropagation()}>
       {[...extensions].sort().join(', ')}
     </Typography>
@@ -91,8 +90,8 @@ const FileSelectorInput = ({
     <Box
       display="flex"
       flexWrap="wrap"
-      gap={1}
-      mt={2}
+      gap={0.5}
+      mt={1}
       onClick={e => e.stopPropagation()}>
       {files.map(f => (
         <Chip
@@ -118,7 +117,7 @@ const FileSelectorInput = ({
         disabled={disabled}
       />
       {isMobile ? (
-        <Stack spacing={1.5}>
+        <Stack>
           <Button
             variant="contained"
             color="primary"
@@ -150,7 +149,7 @@ const FileSelectorInput = ({
             sx={{
               fontSize: 40,
               color: isDragging ? 'primary.main' : 'text.disabled',
-              mb: 1
+              mb: 0.5
             }}
           />
           <Typography
@@ -159,11 +158,7 @@ const FileSelectorInput = ({
             fontWeight={500}>
             {t('Drag and drop files here', 'Drag and drop a file here')}
           </Typography>
-          <Typography
-            variant="caption"
-            color="text.disabled"
-            mt={0.5}
-            display="block">
+          <Typography variant="caption" color="text.disabled" display="block">
             {formatMessage({ id: 'or' })}
           </Typography>
           <Button
@@ -172,7 +167,7 @@ const FileSelectorInput = ({
             disabled={disabled}
             aria-hidden="true"
             tabIndex={-1}
-            sx={{ mt: 1, pointerEvents: 'none' }}>
+            sx={{ mt: 0.5, pointerEvents: 'none' }}>
             {t('Choose files', 'Choose a file')}
           </Button>
           {extensionsLabel}

--- a/packages/web-app/src/components/common/Form/FormAutoComplete.jsx
+++ b/packages/web-app/src/components/common/Form/FormAutoComplete.jsx
@@ -58,7 +58,7 @@ const FormAutoComplete = ({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
       {helperContent && (
-        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+        <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
           {helperContent}
         </Typography>
       )}

--- a/packages/web-app/src/components/common/Form/FormAutoComplete.jsx
+++ b/packages/web-app/src/components/common/Form/FormAutoComplete.jsx
@@ -58,7 +58,7 @@ const FormAutoComplete = ({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
       {helperContent && (
-        <Typography variant="caption" color="text.secondary" display="block" sx={{}}>
+        <Typography variant="caption" color="text.secondary" display="block">
           {helperContent}
         </Typography>
       )}

--- a/packages/web-app/src/components/common/Form/PasswordRules.jsx
+++ b/packages/web-app/src/components/common/Form/PasswordRules.jsx
@@ -8,7 +8,7 @@ import { checkPasswordRules, PASSWORD_MIN_LENGTH } from '../../../conf/config';
 const RuleItem = ({ satisfied, labelId, labelValues = undefined }) => {
   const { formatMessage } = useIntl();
   return (
-    <Box display="flex" alignItems="center" gap={1}>
+    <Box display="flex" alignItems="center" gap={0.5}>
       <BoolIcon value={satisfied} />
       <Typography
         variant="caption"
@@ -31,7 +31,7 @@ const PasswordRules = ({ password }) => {
   const rules = checkPasswordRules(password);
 
   return (
-    <Box display="flex" flexDirection="column" gap={0.25} mt={0.5} mb={1}>
+    <Box display="flex" flexDirection="column" mb={0.5}>
       <RuleItem
         satisfied={rules.minLength}
         labelId="password.rule.minLength"

--- a/packages/web-app/src/components/common/Form/StringInput.jsx
+++ b/packages/web-app/src/components/common/Form/StringInput.jsx
@@ -28,7 +28,7 @@ const StringInput = ({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', width: fullWidth ? '100%' : undefined }}>
       {helperText && (
-        <Typography variant="caption" color="text.secondary" sx={{}}>
+        <Typography variant="caption" color="text.secondary">
           {helperText}
         </Typography>
       )}

--- a/packages/web-app/src/components/common/Form/StringInput.jsx
+++ b/packages/web-app/src/components/common/Form/StringInput.jsx
@@ -28,7 +28,7 @@ const StringInput = ({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', width: fullWidth ? '100%' : undefined }}>
       {helperText && (
-        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
+        <Typography variant="caption" color="text.secondary" sx={{}}>
           {helperText}
         </Typography>
       )}

--- a/packages/web-app/src/components/common/InfoSection.jsx
+++ b/packages/web-app/src/components/common/InfoSection.jsx
@@ -6,7 +6,7 @@ import { Box, Typography } from '@mui/material';
 const SectionWrapper = styled(Box)`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(1)};
+  gap: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const SectionTitle = styled(Typography)`

--- a/packages/web-app/src/components/common/Layouts/Fixed/FixedContent.jsx
+++ b/packages/web-app/src/components/common/Layouts/Fixed/FixedContent.jsx
@@ -14,7 +14,7 @@ import { styled } from '@mui/material/styles';
 import PageContainer from '../PageContainer';
 
 const Card = styled(MuiCard)`
-  margin: ${({ theme }) => theme.spacing(2)};
+  margin: ${({ theme }) => theme.spacing(1)};
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -48,7 +48,7 @@ const FixedContent = ({ subheader, title, icon, action, content }) => (
             display: 'flex',
             alignItems: 'flex-start',
             justifyContent: 'space-between',
-            gap: 1
+            gap: 0.5
           }}>
           <Box sx={{ flex: 1, minWidth: 0 }}>
             {title !== undefined && title !== null ? (

--- a/packages/web-app/src/components/common/Layouts/Fixed/ScrollableContent.jsx
+++ b/packages/web-app/src/components/common/Layouts/Fixed/ScrollableContent.jsx
@@ -17,7 +17,7 @@ import { useAnchorScroll } from '../../../../hooks';
 
 const Card = styled(MuiCard)`
   overflow: inherit;
-  margin: ${({ theme }) => theme.spacing(1)} ${({ theme }) => theme.spacing(2)};
+  margin: ${({ theme }) => theme.spacing(0.5)} ${({ theme }) => theme.spacing(1)};
   scroll-margin-top: ${({ theme }) => theme.appBarHeight}px;
 `;
 
@@ -37,7 +37,7 @@ const StyledCardContent = styled(CardContent, {
 })`
   ${({ $dense, $collapsible }) => $dense && $collapsible && `padding-top: 0;`}
   &:last-child {
-    padding-bottom: ${({ theme }) => theme.spacing(2)};
+    padding-bottom: ${({ theme }) => theme.spacing(1)};
   }
 `;
 
@@ -46,7 +46,7 @@ const CountBadge = ({ count }) => (
     label={count}
     size="small"
     sx={{
-      ml: 1,
+      ml: 0.5,
       fontWeight: 600,
       verticalAlign: 'middle'
     }}

--- a/packages/web-app/src/components/common/Layouts/PageContainer.jsx
+++ b/packages/web-app/src/components/common/Layouts/PageContainer.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Container } from '@mui/material';
 
 const PageContainer = ({ children }) => (
-  <Container maxWidth={false} disableGutters sx={{ pb: 1 }}>
+  <Container maxWidth={false} disableGutters sx={{ pb: 0.5 }}>
     {children}
   </Container>
 );

--- a/packages/web-app/src/components/common/Layouts/PageHeader.jsx
+++ b/packages/web-app/src/components/common/Layouts/PageHeader.jsx
@@ -18,14 +18,14 @@ const TitleIcon = styled('span')`
 `;
 
 const PageHeader = ({ title, icon, titleAdornment, subheader, actions }) => (
-  <Card sx={{ mx: 2, mt: 1, mb: 1, p: { xs: 2, md: 3 } }}>
+  <Card sx={{ mx: 1, mt: 0.5, mb: 0.5, p: { xs: 1, md: 2 } }}>
     <Box>
       <Box
         sx={{
           display: 'flex',
           alignItems: 'flex-start',
           justifyContent: 'space-between',
-          gap: 1
+          gap: 0.5
         }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           {isString(title) ? (
@@ -42,7 +42,7 @@ const PageHeader = ({ title, icon, titleAdornment, subheader, actions }) => (
         </Box>
         {actions && <Box sx={{ flexShrink: 0 }}>{actions}</Box>}
       </Box>
-      {subheader && <Box sx={{ mt: 0.75 }}>{subheader}</Box>}
+      {subheader && <Box sx={{}}>{subheader}</Box>}
     </Box>
   </Card>
 );

--- a/packages/web-app/src/components/common/Layouts/PageHeader.jsx
+++ b/packages/web-app/src/components/common/Layouts/PageHeader.jsx
@@ -42,7 +42,7 @@ const PageHeader = ({ title, icon, titleAdornment, subheader, actions }) => (
         </Box>
         {actions && <Box sx={{ flexShrink: 0 }}>{actions}</Box>}
       </Box>
-      {subheader && <Box sx={{}}>{subheader}</Box>}
+      {subheader && <Box>{subheader}</Box>}
     </Box>
   </Card>
 );

--- a/packages/web-app/src/components/common/Layouts/PageTabs.jsx
+++ b/packages/web-app/src/components/common/Layouts/PageTabs.jsx
@@ -26,7 +26,7 @@ const StickyTabsBar = styled(Card, {
   transition: 'margin 150ms ease, border-radius 150ms ease',
   ...(isStuck
     ? { margin: 0, borderRadius: 0 }
-    : { margin: theme.spacing(1, 2, 0) }),
+    : { margin: theme.spacing(0.5, 1, 0.25) }),
   '@media print': { display: 'none' }
 }));
 
@@ -106,7 +106,7 @@ const PageTabs = ({ tabs, children }) => {
             fontSize: '1rem',
             minWidth: 18,
             height: 18,
-            padding: 0
+            padding: 0.25
           }
         }}>
         {tab.icon}
@@ -132,7 +132,7 @@ const PageTabs = ({ tabs, children }) => {
                 id={`page-tab-${i}`}
                 aria-controls={`page-tabpanel-${i}`}
                 label={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     {tab.label}
                     {tab.count != null && (
                       <Chip
@@ -150,7 +150,9 @@ const PageTabs = ({ tabs, children }) => {
                 icon={tab.icon}
                 disabled={tab.disabled}
                 iconPosition="start"
-                sx={{ minHeight: 36, py: 0.5 }}
+                sx={{
+                  minHeight: 36
+                }}
               />
             ))}
           </Tabs>
@@ -166,7 +168,7 @@ const PageTabs = ({ tabs, children }) => {
             display: activeTab !== i ? 'none' : 'block',
             pb: isMobile
               ? `calc(${BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom) + 8px)`
-              : 1
+              : 0.5
           }}>
           {child}
         </TabPanel>

--- a/packages/web-app/src/components/common/LoginForm/index.jsx
+++ b/packages/web-app/src/components/common/LoginForm/index.jsx
@@ -69,11 +69,10 @@ const TotpStep = ({
   const msg = errorMessage();
 
   return (
-    <Box display="flex" flexDirection="column" gap={2}>
+    <Box display="flex" flexDirection="column" gap={1}>
       <Typography variant="body2" color="text.secondary" textAlign="center">
         {formatMessage({ id: 'mfaEnrollmentStep3Body' })}
       </Typography>
-
       <FormControl variant="filled">
         <InputLabel htmlFor="totp-code-input">
           {formatMessage({ id: 'mfaCodeLabel' })}
@@ -93,7 +92,6 @@ const TotpStep = ({
           disabled={isLoading}
         />
       </FormControl>
-
       {msg && (
         <Fade in>
           <Alert
@@ -112,7 +110,6 @@ const TotpStep = ({
           </Alert>
         </Fade>
       )}
-
       <Button
         size="small"
         variant="text"
@@ -202,7 +199,6 @@ const LoginForm = ({
           <FormHelperText id="login-email-error">{emailError}</FormHelperText>
         )}
       </FormControl>
-
       <FormControl variant="filled" error={!!passwordError}>
         <InputLabel htmlFor="login-password">
           {formatMessage({ id: 'Password' })}
@@ -239,10 +235,9 @@ const LoginForm = ({
           </FormHelperText>
         )}
       </FormControl>
-
       {serverError && (
         <Fade in>
-          <Alert severity="error" sx={{ mt: 1 }}>
+          <Alert severity="error" sx={{ mt: 0.5 }}>
             {serverError}
           </Alert>
         </Fade>

--- a/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/ExploredEntrancesMap.jsx
@@ -53,14 +53,14 @@ const ExploredEntrancesMap = ({ userId }) => {
       <Skeleton
         variant="rectangular"
         height={400}
-        sx={{ mb: 3, borderRadius: 1 }}
+        sx={{ mb: 2, borderRadius: 1 }}
       />
     );
   }
   if (hasExploredData === false) return null;
 
   return (
-    <Box sx={{ mb: 3 }}>
+    <Box sx={{ mb: 2 }}>
       <CustomMapContainer
         wholePage={false}
         center={initialCenter}

--- a/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
+++ b/packages/web-app/src/components/common/Maps/MapClusters/index.jsx
@@ -417,12 +417,10 @@ const HydratedMap = ({
         </ListSubheader>
         <Box
           sx={{
-            pl: 3,
-            pr: 1,
-            py: 0.5,
+            pl: 2,
+            pr: 0.5,
             display: 'flex',
-            alignItems: 'center',
-            gap: 0.5
+            alignItems: 'center'
           }}>
           <Typography variant="body2" sx={{ flex: 1 }}>
             {contextDisplayValue}

--- a/packages/web-app/src/components/common/Maps/_stories.jsx
+++ b/packages/web-app/src/components/common/Maps/_stories.jsx
@@ -12,7 +12,7 @@ import {
 } from './common/Markers/Components';
 
 const Card = styled(MuiCard)`
-  margin: ${({ theme }) => theme.spacing(2)};
+  margin: ${({ theme }) => theme.spacing(1)};
 `;
 
 const positions = {

--- a/packages/web-app/src/components/common/Properties/Property.jsx
+++ b/packages/web-app/src/components/common/Properties/Property.jsx
@@ -74,10 +74,10 @@ const Property = ({
     ) : (
       // Using div instead of Box for performance purpose on the marker's popup on the map.
       // https://github.com/mui/material-ui/issues/21657#issuecomment-707140999
-      (<div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
         <Title variant="caption">{label}</Title>
         <ValueComponent secondary={secondary} url={url} value={value} />
-      </div>)
+      </div>
     )}
   </PropertyWrapper>
 );

--- a/packages/web-app/src/components/common/Properties/Property.jsx
+++ b/packages/web-app/src/components/common/Properties/Property.jsx
@@ -9,7 +9,7 @@ import AppLink from '../AppLink';
 
 export const StyledTypography = styled(Typography)`
   margin-left: ${({ theme, variant }) =>
-    variant === 'caption' && theme.spacing(2)};
+    variant === 'caption' && theme.spacing(1)};
 `;
 
 export const PropertyWrapper = styled('div')`
@@ -18,9 +18,9 @@ export const PropertyWrapper = styled('div')`
   display: flex;
   flex-basis: ${({ $flexBasis }) => $flexBasis};
   flex-shrink: 0;
-  padding: ${({ theme }) => theme.spacing(0)};
+  padding: ${({ theme }) => theme.spacing(0.25)};
   & > svg {
-    margin-right: ${({ theme }) => theme.spacing(1)};
+    margin-right: ${({ theme }) => theme.spacing(0.5)};
   }
 `;
 
@@ -29,7 +29,7 @@ const Title = styled(Typography)`
 `;
 
 const IconWrapper = styled('div')`
-  margin-right: ${({ theme }) => theme.spacing(1)};
+  margin-right: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const ValueComponent = ({ secondary, value, url }) => {
@@ -74,10 +74,10 @@ const Property = ({
     ) : (
       // Using div instead of Box for performance purpose on the marker's popup on the map.
       // https://github.com/mui/material-ui/issues/21657#issuecomment-707140999
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      (<div style={{ display: 'flex', flexDirection: 'column' }}>
         <Title variant="caption">{label}</Title>
         <ValueComponent secondary={secondary} url={url} value={value} />
-      </div>
+      </div>)
     )}
   </PropertyWrapper>
 );

--- a/packages/web-app/src/components/common/Properties/Rating.jsx
+++ b/packages/web-app/src/components/common/Properties/Rating.jsx
@@ -11,7 +11,7 @@ const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
   text-align: center;
-  padding: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const Rating = ({ value, label, size }) => (

--- a/packages/web-app/src/components/common/RelatedCaves/RelatedCaves.jsx
+++ b/packages/web-app/src/components/common/RelatedCaves/RelatedCaves.jsx
@@ -175,7 +175,7 @@ const RelatedCaves = ({
         />
       )}
       {!isOrganization && userId && (
-        <Box sx={{ mt: isCaveSearchVisible ? 0 : -3 }}>
+        <Box sx={{ mt: isCaveSearchVisible ? 0.25 : -2 }}>
           <ExploredEntrancesMap userId={userId} />
         </Box>
       )}
@@ -191,7 +191,7 @@ const RelatedCaves = ({
           })}
         />
       ) : (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           {isOrganization && (
             <EntitiesList
               type="cave"
@@ -212,7 +212,6 @@ const RelatedCaves = ({
           />
         </Box>
       )}
-
       <StandardDialog
         open={!!pendingRemove}
         onClose={handleCancelRemove}

--- a/packages/web-app/src/components/common/SideMenu/MenuLinks.jsx
+++ b/packages/web-app/src/components/common/SideMenu/MenuLinks.jsx
@@ -30,7 +30,7 @@ const SectionHeader = styled(ListSubheader)(({ theme }) => ({
   textTransform: 'uppercase',
   color: theme.palette.text.secondary,
   lineHeight: '2rem',
-  paddingTop: theme.spacing(1)
+  paddingTop: theme.spacing(0.5)
 }));
 
 const EntityIcon = ({ src, alt }) => (
@@ -95,7 +95,7 @@ const MenuLinks = ({ toggle }) => {
       <Divider />
       <List
         component="nav"
-        sx={{ pb: 0 }}
+        sx={{ pb: 0.25 }}
         subheader={
           <SectionHeader disableSticky>
             <Translate>Browse</Translate>

--- a/packages/web-app/src/components/common/SideMenu/_stories.jsx
+++ b/packages/web-app/src/components/common/SideMenu/_stories.jsx
@@ -9,7 +9,7 @@ import SideMenu from './index';
 
 const MainWrapper = styled('main')`
   flex-grow: 1;
-  padding: ${({ theme }) => theme.spacing(3)};
+  padding: ${({ theme }) => theme.spacing(2)};
   transition: ${({ theme, isSideMenuOpen }) =>
     !isMobileOnly &&
     theme.transitions.create('margin', {

--- a/packages/web-app/src/components/common/SideMenu/index.jsx
+++ b/packages/web-app/src/components/common/SideMenu/index.jsx
@@ -34,7 +34,7 @@ const Header = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  padding: theme.spacing(0, 2),
+  padding: theme.spacing(0.25, 1),
   ...theme.mixins.toolbar,
   backgroundColor: alpha(theme.palette.primary.main, 0.06),
   flexShrink: 0,
@@ -44,7 +44,7 @@ const Header = styled('div')(({ theme }) => ({
 const HeaderLink = styled(Link)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(3),
+  gap: theme.spacing(2),
   color: theme.palette.primary.dark,
   textDecoration: 'none',
   transition: theme.transitions.create('opacity'),
@@ -75,8 +75,8 @@ const Footer = styled('div')`
 `;
 
 const ContributeButton = styled(Button)(({ theme }) => ({
-  margin: theme.spacing(2, 1),
-  width: `calc(100% - ${theme.spacing(2)})`
+  margin: theme.spacing(1, 0.5),
+  width: `calc(100% - ${theme.spacing(1)})`
 }));
 
 const SideMenu = ({ isOpen }) => {
@@ -129,7 +129,7 @@ const SideMenu = ({ isOpen }) => {
       <Content>
         {isTopbarCompact && (
           <>
-            <Box sx={{ py: 1 }}>
+            <Box sx={{ py: 0.5 }}>
               <QuickSearch onClose={handleClose} />
             </Box>
             <Divider />

--- a/packages/web-app/src/components/common/Subscriptions/SubscriptionsList.jsx
+++ b/packages/web-app/src/components/common/Subscriptions/SubscriptionsList.jsx
@@ -57,14 +57,14 @@ const SubscriptionsList = ({
   ];
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       {sections.map(({ labelId, emptyId, items, type }) => (
         <Box key={labelId}>
           <Typography variant="h4" gutterBottom>
             {formatMessage({ id: labelId })}
           </Typography>
           {items.length > 0 ? (
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
               {items.map(item => (
                 <SubscriptionListItem
                   canUnsubscribe={canUnsubscribe}

--- a/packages/web-app/src/components/common/Tour/TourTooltip.jsx
+++ b/packages/web-app/src/components/common/Tour/TourTooltip.jsx
@@ -24,20 +24,22 @@ const TourTooltip = ({ currentStep, steps, setCurrentStep, setIsOpen }) => {
 
   return (
     <Card sx={{ maxWidth: 320 }} elevation={8}>
-      <CardContent sx={{ pb: 1 }}>
+      <CardContent sx={{ pb: 0.5 }}>
         <Box
           sx={{
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'flex-start',
-            mb: 1
+            mb: 0.5
           }}>
           <Typography variant="subtitle2">{step.title}</Typography>
           <IconButton
             size="small"
             onClick={() => setIsOpen(false)}
             aria-label={formatMessage({ id: 'Tour - Skip' })}
-            sx={{ ml: 1, mt: -0.5 }}>
+            sx={{
+              ml: 0.5
+            }}>
             <CloseIcon fontSize="small" />
           </IconButton>
         </Box>
@@ -46,7 +48,7 @@ const TourTooltip = ({ currentStep, steps, setCurrentStep, setIsOpen }) => {
         </Typography>
         {isLastStep && (
           <FormControlLabel
-            sx={{ mt: 1 }}
+            sx={{ mt: 0.5 }}
             control={
               <Checkbox
                 size="small"
@@ -62,7 +64,7 @@ const TourTooltip = ({ currentStep, steps, setCurrentStep, setIsOpen }) => {
           />
         )}
       </CardContent>
-      <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>
+      <CardActions sx={{ justifyContent: 'flex-end', pt: 0.25 }}>
         {currentStep > 0 && (
           <Button size="small" onClick={() => setCurrentStep(s => s - 1)}>
             {formatMessage({ id: 'Tour - Back' })}

--- a/packages/web-app/src/components/common/card/Deleted.jsx
+++ b/packages/web-app/src/components/common/card/Deleted.jsx
@@ -65,8 +65,8 @@ export const DELETED_ENTITIES = {
 
 const StyledAuthor = styled('div')`
   display: inline-grid;
-  padding-top: ${({ theme }) => theme.spacing(3)};
-  padding-left: ${({ theme }) => theme.spacing(1)};
+  padding-top: ${({ theme }) => theme.spacing(2)};
+  padding-left: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const StyledEntityIcon = styled(EntityIcon)`
@@ -135,7 +135,7 @@ export const DeletedCard = ({
           </>
         }
       />
-      <Box variant="outlined" sx={{ marginTop: 3 }}>
+      <Box variant="outlined" sx={{ marginTop: 2 }}>
         {!!redirectToUrl && (
           <Button variant="contained" color="secondary" href={redirectToUrl}>
             {formatMessage(
@@ -148,7 +148,7 @@ export const DeletedCard = ({
           </Button>
         )}
         {isLoading && (
-          <Box sx={{ margin: 2 }}>
+          <Box sx={{ margin: 1 }}>
             <CircularProgress />
           </Box>
         )}
@@ -157,7 +157,7 @@ export const DeletedCard = ({
           <Tooltip title={formatMessage({ id: 'Restore' })}>
             <Button
               variant="outlined"
-              sx={{ marginLeft: 3 }}
+              sx={{ marginLeft: 2 }}
               onClick={() => onRestorePress()}
               color="primary"
               aria-label={formatMessage({ id: 'restore' })}>
@@ -170,7 +170,7 @@ export const DeletedCard = ({
           <Tooltip title={formatMessage({ id: 'Permanently delete' })}>
             <Button
               variant="outlined"
-              sx={{ marginLeft: 3 }}
+              sx={{ marginLeft: 2 }}
               onClick={() => onPermanentDeletePress()}
               color="primary"
               aria-label={formatMessage({ id: 'delete' })}>
@@ -285,7 +285,7 @@ export const DeleteConfirmationDialog = ({
       actions={
         <>
           {isLoading && (
-            <Box sx={{ margin: 2 }}>
+            <Box sx={{ margin: 1 }}>
               <CircularProgress />
             </Box>
           )}
@@ -346,7 +346,7 @@ export const DeleteConfirmationDialog = ({
         )}
 
         {selectedEntity && (
-          <Box sx={{ padding: 2, background: 'white' }}>
+          <Box sx={{ padding: 1, background: 'white' }}>
             {selectedEntity.iconSrc && (
               <StyledEntityIcon src={selectedEntity.iconSrc} />
             )}
@@ -354,7 +354,7 @@ export const DeleteConfirmationDialog = ({
               aria-label={formatMessage({ id: 'remove' })}
               sx={{
                 float: 'right',
-                padding: selectedEntity?.subtitle ? 2 : 0
+                padding: selectedEntity?.subtitle ? 1 : 0.25
               }}
               onClick={() => {
                 setSelectedEntity(null);

--- a/packages/web-app/src/components/common/card/NewsCard.jsx
+++ b/packages/web-app/src/components/common/card/NewsCard.jsx
@@ -58,7 +58,7 @@ const NewsCard = ({
       <StyledCard>
         <Skeleton variant="rectangular" height={150} />
         <CardContent>
-          <Skeleton variant="text" width="25%" sx={{ mb: 1 }} />
+          <Skeleton variant="text" width="25%" sx={{ mb: 0.5 }} />
           <Skeleton variant="text" width="70%" height={32} />
           <Skeleton variant="text" width="100%" />
           <Skeleton variant="text" width="90%" />
@@ -71,7 +71,7 @@ const NewsCard = ({
   if (!text) {
     return (
       <StyledCard>
-        <CardContent sx={{ textAlign: 'center', py: 4 }}>
+        <CardContent sx={{ textAlign: 'center', py: 3 }}>
           <SyncProblemOutlined color="disabled" sx={{ fontSize: 40 }} />
         </CardContent>
       </StyledCard>
@@ -81,16 +81,16 @@ const NewsCard = ({
   return (
     <StyledCard>
       <CardMedia image="images/homepage/news.jpg" sx={{ height: 150 }} />
-      <CardContent sx={{ pt: 2 }}>
+      <CardContent sx={{ pt: 1 }}>
         {day && month && (
           <DateLabel variant="caption">
             {day} {month}
           </DateLabel>
         )}
-        <Typography variant="h6" fontWeight={600} sx={{ mt: '4px', mb: 1 }}>
+        <Typography variant="h6" fontWeight={600} sx={{ mt: '4px', mb: 0.5 }}>
           {title}
         </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
           {text}
         </Typography>
         {linkMore && (

--- a/packages/web-app/src/components/common/card/RandomEntryCard.jsx
+++ b/packages/web-app/src/components/common/card/RandomEntryCard.jsx
@@ -98,14 +98,13 @@ const RandomEntryCard = ({ entry, isFetching, fetch, onRefresh }) => {
         sx={{ position: 'absolute', inset: 0, height: '100%' }}
       />
       <Overlay />
-
       <Box
         sx={{
           position: 'absolute',
           top: 12,
           left: 12,
           zIndex: 1,
-          '& > span': { margin: 0 }
+          '& > span': { margin: 0.25 }
         }}>
         <CustomIcon type="entrance" size={32} />
       </Box>
@@ -123,7 +122,6 @@ const RandomEntryCard = ({ entry, isFetching, fetch, onRefresh }) => {
           <Autorenew sx={{ fontSize: 28 }} />
         </IconButton>
       )}
-
       <Content>
         <Typography variant="h6" fontWeight={600} sx={{ color: 'white' }}>
           {entry.name}
@@ -141,7 +139,7 @@ const RandomEntryCard = ({ entry, isFetching, fetch, onRefresh }) => {
             display: 'flex',
             alignItems: 'flex-end',
             justifyContent: 'space-between',
-            gap: 1,
+            gap: 0.5,
             mt: '4px'
           }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
@@ -184,7 +182,7 @@ const RandomEntryCard = ({ entry, isFetching, fetch, onRefresh }) => {
               ) : null
             )}
             {cave && (cave.depth || cave.length) && (
-              <Box sx={{ display: 'flex', gap: 2, mt: '4px' }}>
+              <Box sx={{ display: 'flex', gap: 1, mt: '4px' }}>
                 {cave.depth && (
                   <Box
                     sx={{ display: 'flex', alignItems: 'center', gap: '4px' }}>

--- a/packages/web-app/src/components/common/card/RecentChangesCard.jsx
+++ b/packages/web-app/src/components/common/card/RecentChangesCard.jsx
@@ -173,7 +173,7 @@ const ChangeItem = ({ changeInfo }) => {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'flex-start',
-            gap: 1,
+            gap: 0.5,
             flexWrap: 'wrap'
           }}>
           <Typography variant="body2" component="span" sx={{ flex: 1 }}>

--- a/packages/web-app/src/components/common/entitiesList/EntitiesList.jsx
+++ b/packages/web-app/src/components/common/entitiesList/EntitiesList.jsx
@@ -60,7 +60,7 @@ const EntitiesList = ({
       sx={{
         display: 'grid',
         gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
-        gap: { xs: 2, md: 3 }
+        gap: { xs: 1, md: 2 }
       }}>
       {sorted.map(e => (
         <ListItemComponent key={e.id} {...listItemProps(e)} />

--- a/packages/web-app/src/components/common/entitiesList/EntitiesListItem.jsx
+++ b/packages/web-app/src/components/common/entitiesList/EntitiesListItem.jsx
@@ -77,7 +77,7 @@ const BaseCard = ({ to, icon, children, itemActionButton }) => (
         {children}
       </Box>
       {itemActionButton && (
-        <Box className="remove-btn" sx={{ display: 'flex', alignItems: 'center', pr: 1 }}>
+        <Box className="remove-btn" sx={{ display: 'flex', alignItems: 'center', pr: 0.5 }}>
           {itemActionButton}
         </Box>
       )}
@@ -108,7 +108,7 @@ export const CaveCard = ({ cave, itemActionButton }) => {
           {cave.name}
         </Typography>
         {(cave.depth || cave.length) && (
-          <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
             {cave.depth && (
               <StatBadge src={depthIcon} alt="depth" value={`${cave.depth.toLocaleString(locale)} m`} />
             )}
@@ -178,7 +178,7 @@ export const OrganizationCard = ({ organization, itemActionButton }) => {
         to={to}
         icon={<CustomIcon type="organization" size={32} />}
         itemActionButton={itemActionButton}>
-        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
           <Typography
             variant="body1"
             fontWeight={600}

--- a/packages/web-app/src/conf/grottoTheme.js
+++ b/packages/web-app/src/conf/grottoTheme.js
@@ -22,15 +22,10 @@ const paddingUnit = 8;
 
 export const overridings = {
   name: 'Main theme',
-  spacing: [
-    paddingUnit / 4,
-    paddingUnit / 2,
-    paddingUnit,
-    paddingUnit * 2,
-    paddingUnit * 3,
-    paddingUnit * 4,
-    paddingUnit * 8
-  ],
+  // Standard MUI spacing: theme.spacing(factor) = factor * 8px.
+  // Use fractional factors (0.25, 0.5, 1.5, ...) freely — unlike the previous
+  // custom array-based scale, they resolve correctly instead of being dropped.
+  spacing: paddingUnit,
   sideMenuWidth,
   appBarHeight,
   breadcrumpHeight,

--- a/packages/web-app/src/pages/Account/index.jsx
+++ b/packages/web-app/src/pages/Account/index.jsx
@@ -80,7 +80,7 @@ import { notificationPreferencesUrl } from '../../conf/apiRoutes';
 // ─── Shared styled components ─────────────────────────────────────────────────
 
 const SectionPaper = styled(Paper)(({ theme }) => ({
-  marginBottom: theme.spacing(2),
+  marginBottom: theme.spacing(1),
   overflow: 'hidden'
 }));
 
@@ -88,7 +88,7 @@ const SectionHeader = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: theme.spacing(2, 3)
+  padding: theme.spacing(1, 2)
 }));
 
 const SectionHeaderTitle = styled(Box)(() => ({
@@ -98,14 +98,14 @@ const SectionHeaderTitle = styled(Box)(() => ({
 }));
 
 const SectionBody = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(2, 3, 3)
+  padding: theme.spacing(1, 2, 2)
 }));
 
 const InfoRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(2),
-  padding: theme.spacing(1, 0),
+  gap: theme.spacing(1),
+  padding: theme.spacing(0.5, 0.25),
   borderBottom: `1px solid ${theme.palette.divider}`,
   '&:last-child': { borderBottom: 'none' }
 }));
@@ -121,8 +121,8 @@ const EditFooter = styled(Box)(({ theme }) => ({
   display: 'flex',
   justifyContent: 'flex-end',
   alignItems: 'center',
-  gap: theme.spacing(1),
-  marginTop: theme.spacing(3)
+  gap: theme.spacing(0.5),
+  marginTop: theme.spacing(2)
 }));
 
 // ─── Generic section shell ────────────────────────────────────────────────────
@@ -172,7 +172,7 @@ SettingSection.propTypes = {
 
 // ─── Save/cancel footer used in edit forms ────────────────────────────────────
 
-const BoolValue = ({ value }) => <BoolIcon value={value} sx={{ ml: 1 }} />;
+const BoolValue = ({ value }) => <BoolIcon value={value} sx={{ ml: 0.5 }} />;
 
 BoolValue.propTypes = {
   value: PropTypes.bool.isRequired
@@ -273,7 +273,7 @@ const PersonalInfoSection = ({ account, onSaved }) => {
     <>
       <InfoRow>
         <InfoLabel variant="body2">{formatMessage({ id: 'Id' })}</InfoLabel>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           <Typography variant="body1">{account?.id ?? '—'}</Typography>
           {account?.id && (
             <Button
@@ -485,7 +485,7 @@ const EmailSecuritySection = ({ account, onSaved, isAdmin = false }) => {
         sx={{
           display: 'flex',
           alignItems: 'center',
-          gap: 1,
+          gap: 0.5,
           flexWrap: 'wrap'
         }}>
         <Typography variant="body1">{account?.mail || '—'}</Typography>
@@ -564,7 +564,7 @@ const EmailSecuritySection = ({ account, onSaved, isAdmin = false }) => {
             {formatMessage({ id: 'Password' })}
           </InfoLabel>
           {!isChangingPassword ? (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Typography variant="body1" sx={{ letterSpacing: 3 }}>
                 ••••••••
               </Typography>
@@ -697,7 +697,7 @@ const MfaSection = () => {
       <InfoLabel variant="body2">
         {formatMessage({ id: 'mfaStatus' })}
       </InfoLabel>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
         {isMfaEnabled ? (
           <>
             <Chip
@@ -731,7 +731,6 @@ const MfaSection = () => {
   return (
     <>
       {viewContent}
-
       <StandardDialog
         open={isDialogOpen}
         onClose={handleClose}
@@ -757,7 +756,7 @@ const MfaSection = () => {
             </Button>
           </>
         }>
-        <Box display="flex" flexDirection="column" gap={2}>
+        <Box display="flex" flexDirection="column" gap={1}>
           <Alert
             severity="warning"
             content={formatMessage({ id: 'mfaResetWarning' })}
@@ -1008,11 +1007,11 @@ const PreferencesSection = ({ account, onSaved }) => {
           )}
         />
       </FormRow>
-      <Box sx={{ mt: 2 }}>
+      <Box sx={{ mt: 1 }}>
         <Typography
           variant="subtitle2"
           color="text.secondary"
-          sx={{ mb: 1 }}>
+          sx={{ mb: 0.5 }}>
           {formatMessage({ id: 'Notification Preferences' })}
         </Typography>
         <Controller
@@ -1213,23 +1212,23 @@ const AccountPage = () => {
   ];
 
   const settingsContent = (
-    <Box sx={{ p: { xs: 1, sm: 2 } }}>
+    <Box sx={{ p: { xs: 0.5, sm: 1 } }}>
       {isAccountLoading && (
         <>
           <Skeleton
             variant="rectangular"
             height={130}
-            sx={{ mb: 2, borderRadius: 1 }}
+            sx={{ mb: 1, borderRadius: 1 }}
           />
           <Skeleton
             variant="rectangular"
             height={160}
-            sx={{ mb: 2, borderRadius: 1 }}
+            sx={{ mb: 1, borderRadius: 1 }}
           />
           <Skeleton
             variant="rectangular"
             height={130}
-            sx={{ mb: 2, borderRadius: 1 }}
+            sx={{ mb: 1, borderRadius: 1 }}
           />
         </>
       )}
@@ -1270,11 +1269,11 @@ const AccountPage = () => {
         {/* Tab Activités */}
         <div>
           {isPersonFetching ? (
-            <Box sx={{ px: 2 }}>
+            <Box sx={{ px: 1 }}>
               <Skeleton
                 variant="rectangular"
                 height={100}
-                sx={{ mb: 2, borderRadius: 1 }}
+                sx={{ mb: 1, borderRadius: 1 }}
               />
               <Skeleton
                 variant="rectangular"
@@ -1401,7 +1400,7 @@ const AccountPage = () => {
         {/* Tab Documents */}
         <div>
           {isPersonFetching && (
-            <Card sx={{ m: 2, p: 3 }}>
+            <Card sx={{ m: 1, p: 2 }}>
               <Skeleton height={40} width="100%" />
               <Skeleton height={60} />
               <Skeleton height={60} />
@@ -1415,7 +1414,6 @@ const AccountPage = () => {
           )}
         </div>
       </PageTabs>
-
       <StandardDialog
         open={!!pendingLeaveOrg}
         onClose={() => setPendingLeaveOrg(null)}

--- a/packages/web-app/src/pages/Admin/ManageUserGroups.jsx
+++ b/packages/web-app/src/pages/Admin/ManageUserGroups.jsx
@@ -30,7 +30,7 @@ const UserBlock = styled('div')`
 
 const FlexBlock = styled('div')`
   flex: 1;
-  margin: ${({ theme }) => theme.spacing(3)};
+  margin: ${({ theme }) => theme.spacing(2)};
 `;
 
 const SearchBarBackground = styled('div')`
@@ -165,12 +165,12 @@ const ManageUserGroups = () => {
       {selectedUser && (
         <>
           <IconButton
-            sx={{ marginTop: 2 }}
+            sx={{ marginTop: 1 }}
             onClick={() => setSelectedUser(null)}>
             <ClearIcon />
           </IconButton>
           <Button
-            sx={{ marginTop: 2, float: 'right' }}
+            sx={{ marginTop: 1, float: 'right' }}
             variant="outlined"
             component={AppLink}
             to={`/ui/persons/${selectedUser?.id}`}

--- a/packages/web-app/src/pages/Admin/ManageUsers.jsx
+++ b/packages/web-app/src/pages/Admin/ManageUsers.jsx
@@ -18,7 +18,7 @@ import EntityTable from '../../components/common/EntityTable';
 import ManageUserGroups from './ManageUserGroups';
 
 const MarginBottomBlock = styled('div')`
-  margin-bottom: ${({ theme }) => theme.spacing(4)};
+  margin-bottom: ${({ theme }) => theme.spacing(3)};
 `;
 
 const UserList = ({ isLoading, title, userList }) => (

--- a/packages/web-app/src/pages/Admin/UserGroups.jsx
+++ b/packages/web-app/src/pages/Admin/UserGroups.jsx
@@ -15,7 +15,7 @@ import {
 import GROUPS from '../../helpers/GroupHelper';
 
 const SpacedButton = styled(Button)`
-  margin: ${({ theme }) => theme.spacing(1)};
+  margin: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const UserGroups = ({
@@ -98,9 +98,7 @@ const UserGroups = ({
           style={{ display: 'block' }}
         />
       ))}
-
-      <Divider sx={{ my: 2 }} />
-
+      <Divider sx={{ my: 1 }} />
       <Typography variant="h3" gutterBottom>
         {formatMessage({ id: 'Banned' })}
       </Typography>
@@ -125,7 +123,6 @@ const UserGroups = ({
           />
         </span>
       </Tooltip>
-
       <SpacedButton
         onClick={handleSave}
         color={isLoading ? 'inherit' : 'primary'}
@@ -136,7 +133,6 @@ const UserGroups = ({
           formatMessage({ id: 'Save' })
         )}
       </SpacedButton>
-
       <SpacedButton
         variant="outlined"
         onClick={handleReset}

--- a/packages/web-app/src/pages/ChangePasswordForm/index.jsx
+++ b/packages/web-app/src/pages/ChangePasswordForm/index.jsx
@@ -27,7 +27,7 @@ const FormWrapper = styled('form')`
 `;
 
 const SpacedCenteredButton = styled(Button)`
-  margin: ${({ theme }) => theme.spacing(1)} auto;
+  margin: ${({ theme }) => theme.spacing(0.5)} auto;
 `;
 
 const ChangePasswordForm = ({

--- a/packages/web-app/src/pages/Contributions/Actions.jsx
+++ b/packages/web-app/src/pages/Contributions/Actions.jsx
@@ -18,9 +18,9 @@ const ActionTypes = {
 const Wrapper = styled('div')`
   display: flex;
   flex-direction: row;
-  margin-top: ${({ theme }) => theme.spacing(3)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
   & > button {
-    margin-right: ${({ theme }) => theme.spacing(2)};
+    margin-right: ${({ theme }) => theme.spacing(1)};
   }
 `;
 

--- a/packages/web-app/src/pages/Dashboard.jsx
+++ b/packages/web-app/src/pages/Dashboard.jsx
@@ -25,7 +25,7 @@ const StyledListItem = styled(ListItemButton)`
   border: 1px solid ${props => props.theme.palette.primary1Color};
   flex: 0 0 220px;
   flex-direction: column;
-  margin: ${props => props.theme.spacing(2)};
+  margin: ${props => props.theme.spacing(1)};
 `;
 
 const StyledListItemDBExport = styled(StyledListItem)`
@@ -33,7 +33,7 @@ const StyledListItemDBExport = styled(StyledListItem)`
 `;
 
 const DashboardBlock = styled('div')`
-  margin-bottom: ${props => props.theme.spacing(4)};
+  margin-bottom: ${props => props.theme.spacing(3)};
 `;
 
 const Dashboard = () => {

--- a/packages/web-app/src/pages/DocumentDetails/Section.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/Section.jsx
@@ -68,18 +68,14 @@ const HorizontalList = styled(List)(({ theme }) => ({
   justifyContent: 'flex-start',
   paddingTop: 0,
   paddingBottom: 0,
-  marginTop: theme.spacing(-1),
-  gap: theme.spacing(0.5),
+  marginTop: theme.spacing(-0.5),
 
   '& .MuiListItem-root': {
-    width: 'initial',
-    paddingTop: theme.spacing(0.5),
-    paddingBottom: theme.spacing(0.5)
+    width: 'initial'
   },
 
   '& .MuiListItemIcon-root': {
-    minWidth: 0,
-    marginRight: theme.spacing(1.5)
+    minWidth: 0
   },
 
   '& .MuiListItemText-root': {
@@ -112,8 +108,7 @@ SummaryText.propTypes = { children: PropTypes.node };
 const PropertiesGrid = styled(Box)(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-  rowGap: theme.spacing(1.25),
-  columnGap: theme.spacing(2)
+  columnGap: theme.spacing(1)
 }));
 
 const PropertyCell = styled('div', {
@@ -129,7 +124,7 @@ export const DetailsList = ({ children }) => {
   return (
     <Paper
       variant="outlined"
-      sx={{ p: 2, borderRadius: 2, bgcolor: 'grey.50' }}>
+      sx={{ p: 1, borderRadius: 2, bgcolor: 'grey.50' }}>
       <PropertiesGrid>{items}</PropertiesGrid>
     </Paper>
   );
@@ -198,7 +193,7 @@ const VideoPreview = styled('video')(({ theme }) => ({
   maxHeight: 320,
   display: 'block',
   background: theme.palette.common.black,
-  borderRadius: theme.spacing(1),
+  borderRadius: theme.spacing(0.5),
   [theme.breakpoints.up('sm')]: { maxHeight: 480 },
   [theme.breakpoints.up('md')]: { maxHeight: 600 }
 }));
@@ -227,17 +222,16 @@ const isAudioFile = fileName =>
 const FileRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(1.5),
-  padding: theme.spacing(1),
+  padding: theme.spacing(0.5),
   border: `1px solid ${theme.palette.divider}`,
-  borderRadius: theme.spacing(1)
+  borderRadius: theme.spacing(0.5)
 }));
 
 export const EmptySection = ({ icon, message }) => (
   <Paper
     variant="outlined"
     sx={{
-      p: 2,
+      p: 1,
       borderRadius: 2,
       bgcolor: 'grey.50',
       minHeight: { xs: 100, sm: 200 },
@@ -245,7 +239,7 @@ export const EmptySection = ({ icon, message }) => (
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      gap: 1,
+      gap: 0.5,
       color: 'text.secondary'
     }}>
     {icon ?? <InsertDriveFile fontSize="large" color="disabled" />}
@@ -264,12 +258,12 @@ export const EventDateSection = ({ date }) => {
     <Paper
       variant="outlined"
       sx={{
-        p: 2,
+        p: 1,
         borderRadius: 2,
         bgcolor: 'grey.50',
         display: 'flex',
         alignItems: 'center',
-        gap: 2
+        gap: 1
       }}>
       <EventAvailable sx={{ fontSize: 40, color: 'text.secondary' }} />
       <Box>
@@ -286,7 +280,7 @@ EventDateSection.propTypes = { date: PropTypes.string };
 const ImageGallery = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: theme.spacing(2)
+  gap: theme.spacing(1)
 }));
 
 export const FilesSection = ({ files }) => {
@@ -332,7 +326,7 @@ export const FilesSection = ({ files }) => {
   }
 
   return (
-    <Stack spacing={3}>
+    <Stack spacing={2}>
       {images.length > 0 && (
         <ImageGallery>
           {images.map((file, idx) => {
@@ -349,15 +343,14 @@ export const FilesSection = ({ files }) => {
           })}
         </ImageGallery>
       )}
-
       {pdfs.map(file => (
         <Box key={file.completePath}>
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1,
-              mb: 1
+              gap: 0.5,
+              mb: 0.5
             }}>
             {getFileIcon(file.fileName)}
             <AppLink href={file.completePath}>
@@ -373,15 +366,14 @@ export const FilesSection = ({ files }) => {
           </PdfPreview>
         </Box>
       ))}
-
       {videos.map(file => (
         <Box key={file.completePath}>
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1,
-              mb: 1
+              gap: 0.5,
+              mb: 0.5
             }}>
             {getFileIcon(file.fileName)}
             <AppLink href={file.completePath}>
@@ -395,15 +387,14 @@ export const FilesSection = ({ files }) => {
           />
         </Box>
       ))}
-
       {audios.map(file => (
         <Box key={file.completePath}>
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1,
-              mb: 1
+              gap: 0.5,
+              mb: 0.5
             }}>
             {getFileIcon(file.fileName)}
             <AppLink href={file.completePath}>
@@ -413,9 +404,8 @@ export const FilesSection = ({ files }) => {
           <AudioPreview controls preload="metadata" src={file.completePath} />
         </Box>
       ))}
-
       {others.length > 0 && (
-        <Stack spacing={1}>
+        <Stack spacing={0.5}>
           {others.map(file => (
             <FileRow key={file.completePath}>
               {getFileIcon(file.fileName)}
@@ -428,7 +418,6 @@ export const FilesSection = ({ files }) => {
           ))}
         </Stack>
       )}
-
       {lightboxIndex !== null && (
         <ImageLightbox
           open={lightboxIndex !== null}

--- a/packages/web-app/src/pages/DocumentDetails/index.jsx
+++ b/packages/web-app/src/pages/DocumentDetails/index.jsx
@@ -59,12 +59,12 @@ import linkifyOptions from '../../helpers/linkifyOptions';
 const HalfSplitContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 
   ${({ theme }) => theme.breakpoints.up('md')} {
     flex-direction: row;
     align-items: flex-start;
-    gap: ${({ theme }) => theme.spacing(3)};
+    gap: ${({ theme }) => theme.spacing(2)};
   }
 `;
 
@@ -73,7 +73,7 @@ const MainColumn = styled('div')`
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const SideColumn = styled('div')`
@@ -81,7 +81,7 @@ const SideColumn = styled('div')`
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const Document = ({
@@ -334,7 +334,6 @@ const Document = ({
         subheader={breadcrumb}
         actions={actions}
       />
-
       {documentData?.isDeleted && (
         <ScrollableContent
           content={
@@ -351,7 +350,6 @@ const Document = ({
           }
         />
       )}
-
       <DeleteConfirmationDialog
         entityType={DELETED_ENTITIES.document}
         isOpen={isDeleteConfirmationOpen}
@@ -362,7 +360,6 @@ const Document = ({
           onDeletePress(entity?.id, isDeleteConfirmationPermanent);
         }}
       />
-
       {isLoading && (
         <ScrollableContent
           content={
@@ -377,7 +374,6 @@ const Document = ({
           }
         />
       )}
-
       {error && (
         <ScrollableContent
           content={
@@ -390,7 +386,6 @@ const Document = ({
           }
         />
       )}
-
       {documentData && (
         <>
           <ScrollableContent
@@ -418,7 +413,7 @@ const Document = ({
                           <Chip
                             label={childIssues.length}
                             size="small"
-                            sx={{ ml: 1, fontWeight: 600, verticalAlign: 'middle' }}
+                            sx={{ ml: 0.5, fontWeight: 600, verticalAlign: 'middle' }}
                           />
                         </Typography>
                         {childIssues.length > 0 ? (
@@ -597,7 +592,7 @@ const Document = ({
                     </DetailsList>
                   </SideColumn>
                 </HalfSplitContainer>
-                <Box sx={{ mt: 1, mb: -2 }}>
+                <Box sx={{ mt: 0.5, mb: -1 }}>
                   <AuthorAndDate
                     author={documentData.creator}
                     textColor="textSecondary"

--- a/packages/web-app/src/pages/DocumentValidation/Actions.jsx
+++ b/packages/web-app/src/pages/DocumentValidation/Actions.jsx
@@ -34,9 +34,9 @@ const ActionTypes = {
 const Wrapper = styled('div')`
   display: flex;
   flex-direction: row;
-  margin-top: ${({ theme }) => theme.spacing(3)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
   & > button {
-    margin-right: ${({ theme }) => theme.spacing(2)};
+    margin-right: ${({ theme }) => theme.spacing(1)};
   }
 `;
 

--- a/packages/web-app/src/pages/DocumentValidation/index.jsx
+++ b/packages/web-app/src/pages/DocumentValidation/index.jsx
@@ -20,7 +20,7 @@ import Translate from '../../components/common/Translate';
 const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
-  padding: ${({ theme }) => theme.spacing(2)};
+  padding: ${({ theme }) => theme.spacing(1)};
 `;
 
 const DocumentValidationPage = () => {

--- a/packages/web-app/src/pages/DuplicateImportHandle/index.jsx
+++ b/packages/web-app/src/pages/DuplicateImportHandle/index.jsx
@@ -16,8 +16,8 @@ const DOCUMENT_TAB = 'document';
 const TABS = [ENTRANCE_TAB, DOCUMENT_TAB];
 
 const StyledActionButton = styled(ActionButton)`
-  margin-top: ${({ theme }) => theme.spacing(1)};
-  margin-bottom: ${({ theme }) => theme.spacing(1)};
+  margin-top: ${({ theme }) => theme.spacing(0.5)};
+  margin-bottom: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const DuplicateImportHandle = () => {

--- a/packages/web-app/src/pages/EntityCreation/EntityPicker.jsx
+++ b/packages/web-app/src/pages/EntityCreation/EntityPicker.jsx
@@ -16,8 +16,8 @@ const EntityPicker = () => {
           sx={{
             display: 'grid',
             gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
-            gap: 3,
-            mt: 1
+            gap: 2,
+            mt: 0.5
           }}>
           {ENTITIES.map(({ path, iconType, titleKey, descriptionKey }) => (
             <Card
@@ -40,7 +40,7 @@ const EntityPicker = () => {
               // iOS keeps :focus style after tap; blur on touchEnd removes the stale focus ring
               onTouchEnd={e => e.currentTarget.blur()}>
               <CardContent>
-                <Box display="flex" alignItems="center" gap={2} mb={1.5}>
+                <Box display="flex" alignItems="center" gap={1}>
                   <EntityIcon iconType={iconType} />
                   <Typography variant="h6" fontWeight={600}>
                     {formatMessage({ id: titleKey })}

--- a/packages/web-app/src/pages/EntityCreation/index.jsx
+++ b/packages/web-app/src/pages/EntityCreation/index.jsx
@@ -19,12 +19,12 @@ const EntitiesCreation = () => {
         title={formatMessage({ id: 'Create a new entity in Grottocenter' })}
         content={
           <Box sx={{ textAlign: 'center' }}>
-            <Alert severity="error" sx={{ mb: 2 }}>
+            <Alert severity="error" sx={{ mb: 1 }}>
               {formatMessage({
                 id: 'You must be authenticated to submit a new entity to Grottocenter.'
               })}
             </Alert>
-            <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5 }}>
               <Button
                 onClick={() => dispatch(displayLoginDialog())}
                 variant="contained">

--- a/packages/web-app/src/pages/ForgotPassword.jsx
+++ b/packages/web-app/src/pages/ForgotPassword.jsx
@@ -17,7 +17,7 @@ const FormWrapper = styled('form')`
 `;
 
 const SpacedCenteredButton = styled(Button)`
-  margin: ${({ theme }) => theme.spacing(1)} auto;
+  margin: ${({ theme }) => theme.spacing(0.5)} auto;
 `;
 
 const ForgotPasswordPage = ({

--- a/packages/web-app/src/pages/Messages/ComposeDialog.jsx
+++ b/packages/web-app/src/pages/Messages/ComposeDialog.jsx
@@ -181,11 +181,11 @@ const ComposeDialog = ({ open, onClose, prefilledRecipientId }) => {
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          gap: 2,
-          pt: 1,
+          gap: 1,
+          pt: 0.5,
           height: isMobile ? '100%' : 'auto'
         }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography variant="subtitle2" sx={{ minWidth: 'fit-content' }}>
             {formatMessage({ id: 'To', defaultMessage: 'To' })}
           </Typography>
@@ -259,7 +259,7 @@ const ComposeDialog = ({ open, onClose, prefilledRecipientId }) => {
         />
 
         {sendError && (
-          <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+          <Typography color="error" variant="body2" sx={{ mt: 0.5 }}>
             {sendError}
           </Typography>
         )}

--- a/packages/web-app/src/pages/Messages/ConversationDetail.jsx
+++ b/packages/web-app/src/pages/Messages/ConversationDetail.jsx
@@ -41,7 +41,7 @@ const MessagesList = styled(List)(({ theme }) => ({
   overflowY: 'auto',
   overflowX: 'hidden',
   minWidth: 0,
-  padding: theme.spacing(2),
+  padding: theme.spacing(1),
   display: 'flex',
   flexDirection: 'column-reverse' // Shows latest at the bottom
 }));
@@ -50,7 +50,7 @@ const MessagesList = styled(List)(({ theme }) => ({
 const MessageBubble = styled(Paper, {
   shouldForwardProp: prop => !prop.startsWith('$')
 })(({ theme, $isMine }) => ({
-  padding: theme.spacing(1, 2),
+  padding: theme.spacing(0.5, 1),
   maxWidth: '75%',
   minWidth: 0,
   width: 'fit-content',
@@ -61,7 +61,7 @@ const MessageBubble = styled(Paper, {
   color: $isMine
     ? theme.palette.primary.contrastText
     : theme.palette.text.primary,
-  marginBottom: theme.spacing(1),
+  marginBottom: theme.spacing(0.5),
   borderRadius: 16,
   borderBottomRightRadius: $isMine ? 4 : 16,
   borderBottomLeftRadius: $isMine ? 16 : 4,
@@ -82,10 +82,10 @@ const MessageDate = styled(Typography, {
 }));
 
 const InputArea = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(2),
+  padding: theme.spacing(1),
   backgroundColor: theme.palette.background.paper,
   display: 'flex',
-  gap: theme.spacing(1),
+  gap: theme.spacing(0.5),
   alignItems: 'flex-start',
   borderTop: `1px solid ${theme.palette.divider}`
 }));
@@ -98,7 +98,7 @@ const BlankStateContainer = styled(Box)(({ theme }) => ({
   height: '100%',
   backgroundColor: theme.palette.action.hover,
   color: theme.palette.text.secondary,
-  padding: theme.spacing(4),
+  padding: theme.spacing(3),
   textAlign: 'center'
 }));
 
@@ -242,7 +242,7 @@ const ConversationDetail = () => {
 
   if (status === REDUCER_STATUS.FAILED) {
     return (
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ p: 2 }}>
         <Alert
           severity="error"
           title={
@@ -321,7 +321,7 @@ Message Body: ${body}`;
     <DetailContainer>
       <Box
         sx={{
-          p: 2,
+          p: 1,
           borderBottom: 1,
           borderColor: 'divider',
           bgcolor: 'background.paper',
@@ -331,7 +331,7 @@ Message Body: ${body}`;
         <IconButton
           sx={{
             display: { xs: 'inline-flex', md: 'none' },
-            mr: 2,
+            mr: 1,
             border: '1px solid',
             borderColor: 'divider',
             borderRadius: '8px',
@@ -346,7 +346,7 @@ Message Body: ${body}`;
             width: '1px',
             height: '24px',
             bgcolor: 'divider',
-            mr: 2
+            mr: 1
           }}
         />
         <Typography variant="h6">
@@ -362,7 +362,6 @@ Message Body: ${body}`;
           )}
         </Typography>
       </Box>
-
       <MessagesList ref={messagesListRef}>
         <div ref={messagesEndRef} />
         {[...messages].reverse().map(msg => {
@@ -374,7 +373,7 @@ Message Body: ${body}`;
                   display: 'flex',
                   justifyContent: 'space-between',
                   alignItems: 'flex-start',
-                  gap: 1
+                  gap: 0.5
                 }}>
                 <Box sx={{ flexGrow: 1, minWidth: 0 }}>
                   <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>
@@ -393,9 +392,9 @@ Message Body: ${body}`;
                       sx={{
                         color: 'text.secondary',
                         '&:hover': { color: 'error.main' },
-                        padding: 0,
+                        padding: 0.25,
                         mt: '4px',
-                        ml: 1,
+                        ml: 0.5,
                         flexShrink: 0
                       }}>
                       <FlagIcon fontSize="small" />
@@ -421,7 +420,7 @@ Message Body: ${body}`;
         {hasMore && (
           <Box
             ref={sentinelRef}
-            sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+            sx={{ display: 'flex', justifyContent: 'center', py: 0.5 }}>
             {status === REDUCER_STATUS.LOADING ? (
               <CircularProgress size={24} />
             ) : (
@@ -435,7 +434,6 @@ Message Body: ${body}`;
           </Box>
         )}
       </MessagesList>
-
       <InputArea>
         <TextField
           fullWidth
@@ -466,7 +464,7 @@ Message Body: ${body}`;
                 display: 'flex',
                 justifyContent: 'flex-end',
                 width: '100%',
-                m: 0
+                m: 0.25
               }}>
               <span
                 style={{ color: replyText.length > 5000 ? 'red' : 'inherit' }}>
@@ -493,7 +491,6 @@ Message Body: ${body}`;
           {isSending ? <CircularProgress size={24} /> : <SendIcon />}
         </IconButton>
       </InputArea>
-
       <StandardDialog
         open={isReportDialogOpen}
         onClose={handleCloseReportDialog}

--- a/packages/web-app/src/pages/Messages/index.jsx
+++ b/packages/web-app/src/pages/Messages/index.jsx
@@ -65,9 +65,8 @@ const EmptyStateContainer = styled(Box)(({ theme }) => ({
 // client), standard page card on desktop.
 //
 // The height fills the viewport minus everything around the card. Each term is
-// derived from the theme rather than hardcoded: theme.spacing is an array here
-// (see grottoTheme), so spacing(2) is 8px and spacing(1) is 4px — not the MUI
-// defaults. `containerPb` must stay in sync with PageContainer's own `pb: 1`.
+// derived from the theme rather than hardcoded. `containerPb` must stay in sync
+// with PageContainer's own `pb: 1`.
 const StyledCard = styled(Card)(({ theme }) => {
   const containerPb = theme.spacing(0.5);
   const chromeXs = containerPb;

--- a/packages/web-app/src/pages/Messages/index.jsx
+++ b/packages/web-app/src/pages/Messages/index.jsx
@@ -56,7 +56,7 @@ const StyledListItem = styled(ListItem, {
 }));
 
 const EmptyStateContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(4),
+  padding: theme.spacing(3),
   textAlign: 'center',
   color: theme.palette.text.secondary
 }));
@@ -69,9 +69,9 @@ const EmptyStateContainer = styled(Box)(({ theme }) => ({
 // (see grottoTheme), so spacing(2) is 8px and spacing(1) is 4px — not the MUI
 // defaults. `containerPb` must stay in sync with PageContainer's own `pb: 1`.
 const StyledCard = styled(Card)(({ theme }) => {
-  const containerPb = theme.spacing(1);
+  const containerPb = theme.spacing(0.5);
   const chromeXs = containerPb;
-  const chromeMd = `${theme.spacing(2)} * 2 + ${containerPb}`; // margins + pb
+  const chromeMd = `${theme.spacing(1)} * 2 + ${containerPb}`; // margins + pb
   return `
   display: flex;
   flex-direction: column;
@@ -82,7 +82,7 @@ const StyledCard = styled(Card)(({ theme }) => {
   height: calc(100dvh - ${theme.appBarHeight}px - (${chromeXs}));
 
   ${theme.breakpoints.up('md')} {
-    margin: ${theme.spacing(2)};
+    margin: ${theme.spacing(1)};
     border-radius: ${theme.shape.borderRadius};
     box-shadow: ${theme.shadows[1]};
     height: calc(100vh - ${theme.appBarHeight}px - (${chromeMd}));
@@ -151,7 +151,7 @@ const MessagesPage = () => {
   const renderContent = () => {
     if (status === REDUCER_STATUS.LOADING && conversations.length === 0) {
       return (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
           <CircularProgress />
         </Box>
       );
@@ -275,7 +275,7 @@ const MessagesPage = () => {
                   flexDirection: 'column',
                   bgcolor: 'background.paper'
                 }}>
-                  <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: 1, borderColor: 'divider' }}>
+                  <Box sx={{ p: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: 1, borderColor: 'divider' }}>
                     <Typography variant="h6" component="h1">
                       {formatMessage({ id: 'Conversations', defaultMessage: 'Conversations' })}
                     </Typography>
@@ -305,7 +305,7 @@ const MessagesPage = () => {
                     {renderContent()}
 
                     {totalCount > PAGE_SIZE && (
-                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
                         <Pagination
                           count={Math.ceil(totalCount / PAGE_SIZE)}
                           page={page}

--- a/packages/web-app/src/pages/SignUpForm/index.jsx
+++ b/packages/web-app/src/pages/SignUpForm/index.jsx
@@ -25,7 +25,7 @@ const FormWrapper = styled('form')`
 `;
 
 const SpacedCenteredButton = styled(Button)`
-  margin: ${({ theme }) => theme.spacing(1)} auto;
+  margin: ${({ theme }) => theme.spacing(0.5)} auto;
 `;
 
 const SignUpForm = ({

--- a/packages/web-app/src/pages/VerifyEmail/index.jsx
+++ b/packages/web-app/src/pages/VerifyEmail/index.jsx
@@ -7,7 +7,7 @@ import { styled } from '@mui/material/styles';
 import Layout from '../../components/common/Layouts/Fixed/FixedContent';
 
 const SpacedCenteredButton = styled(Button)`
-  margin: ${({ theme }) => theme.spacing(3)} auto;
+  margin: ${({ theme }) => theme.spacing(2)} auto;
 `;
 
 const VerifyEmailPage = ({

--- a/packages/web-app/src/pages/homepage/Association.jsx
+++ b/packages/web-app/src/pages/homepage/Association.jsx
@@ -91,8 +91,8 @@ const Association = () => {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 2,
-            mb: 3,
+            gap: 1,
+            mb: 2,
             flexWrap: 'wrap'
           }}>
           <Box
@@ -121,7 +121,7 @@ const Association = () => {
           sx={{
             color: 'rgba(255,255,255,0.85)',
             textAlign: 'center',
-            mb: 4,
+            mb: 3,
             maxWidth: 640,
             mx: 'auto'
           }}>
@@ -146,11 +146,11 @@ const Association = () => {
           />
         </Typography>
 
-        <Grid container spacing={2} sx={{ mb: 4 }}>
+        <Grid container spacing={1} sx={{ mb: 3 }}>
           {GOALS.map(({ key, Icon, wordId, descId }) => (
             <Grid key={key} size={{ xs: 12, sm: 6, md: 4 }}>
               <GoalCard>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   <Icon sx={{ color: 'secondary.main', fontSize: 22 }} />
                   <Typography
                     variant="subtitle2"
@@ -174,7 +174,7 @@ const Association = () => {
           sx={{
             color: 'rgba(255,255,255,0.55)',
             textAlign: 'center',
-            mb: 4,
+            mb: 3,
             maxWidth: 680,
             mx: 'auto',
             '& a': { color: 'rgba(255,255,255,0.9)', textDecoration: 'underline' }
@@ -205,7 +205,7 @@ const Association = () => {
             target="_blank"
             rel="noopener noreferrer"
             startIcon={<FavoriteBorder />}
-            sx={{ fontWeight: 600, px: 4, textTransform: 'none' }}>
+            sx={{ fontWeight: 600, px: 3, textTransform: 'none' }}>
             {formatMessage({ id: 'Donate now' })}
           </Button>
         </Box>

--- a/packages/web-app/src/pages/homepage/Footer.jsx
+++ b/packages/web-app/src/pages/homepage/Footer.jsx
@@ -126,11 +126,15 @@ const Footer = () => {
   return (
     <FooterRoot>
       <MainSection>
-        <Grid container spacing={4}>
+        <Grid container spacing={3}>
           {/* Column 1 — Brand + Licenses */}
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <Box
-              sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5 }}>
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1
+              }}>
               <Box
                 sx={{
                   backgroundColor: 'rgba(255,255,255,0.92)',
@@ -149,7 +153,10 @@ const Footer = () => {
             </Box>
             <Typography
               variant="body2"
-              sx={{ color: 'rgba(255,255,255,0.5)', lineHeight: 1.7, mb: 1.5 }}>
+              sx={{
+                color: 'rgba(255,255,255,0.5)',
+                lineHeight: 1.7
+              }}>
               {formatMessage({ id: 'Published by' })}{' '}
               <InternationalizedLink links={wikicavesLink}>
                 <Box
@@ -311,7 +318,6 @@ const Footer = () => {
           </Grid>
         </Grid>
       </MainSection>
-
       <LicenseBar>
         <LicenseLine>
           <InternationalizedLink links={licenceLinks}>
@@ -325,7 +331,7 @@ const Footer = () => {
             })}
           </Typography>
         </LicenseLine>
-        <LicenseLine sx={{ mb: 0 }}>
+        <LicenseLine sx={{ mb: 0.25 }}>
           <InternationalizedLink links={licensesODBLink}>
             <LicenseBadge src="/images/odbl.png" alt="ODbL licence" />
           </InternationalizedLink>

--- a/packages/web-app/src/pages/homepage/HeroStats.jsx
+++ b/packages/web-app/src/pages/homepage/HeroStats.jsx
@@ -93,7 +93,7 @@ const HeroStats = () => {
                     alignItems: 'center',
                     width: '100%'
                   }}>
-                  <Box sx={{ '& > span': { margin: 0 } }}>
+                  <Box sx={{ '& > span': { margin: 0.25 } }}>
                     <CustomIcon type={iconType} size={isMobile ? 32 : 48} />
                   </Box>
                   <Typography
@@ -101,7 +101,7 @@ const HeroStats = () => {
                     fontWeight="bold"
                     color={theme.palette.primary.main}
                     sx={{
-                      mt: 1,
+                      mt: 0.5,
                       [theme.breakpoints.down('sm')]: {
                         fontSize: '1.5rem',
                         mt: '0px'

--- a/packages/web-app/src/pages/homepage/LatestBlogNewsSection.jsx
+++ b/packages/web-app/src/pages/homepage/LatestBlogNewsSection.jsx
@@ -52,7 +52,7 @@ const LatestBlogNewsSection = () => {
           blog={isFrench ? 'fr' : 'en'}
           url={isFrench ? frenchRssUrl : englishRssUrl}
         />
-        <Box sx={{ textAlign: 'center', mt: 3 }}>
+        <Box sx={{ textAlign: 'center', mt: 2 }}>
           <AppLink href={isFrench ? bloggerLinks.fr : bloggerLinks['*']}>
             <Typography
               variant="body2"

--- a/packages/web-app/src/pages/homepage/Welcome.jsx
+++ b/packages/web-app/src/pages/homepage/Welcome.jsx
@@ -55,13 +55,13 @@ const Welcome = () => {
   return (
     <WelcomeSection aria-label={formatMessage({ id: 'Free access' })}>
       <Inner>
-        <Grid container spacing={{ xs: 2, sm: 4 }}>
+        <Grid container spacing={{ xs: 1, sm: 3 }}>
           {BLOCKS.map(({ titleId, textIds }) => (
             <Grid key={titleId} size={{ xs: 12, sm: 4 }}>
               <BlockTitle
                 variant="h6"
                 component="h2"
-                sx={{ mb: { xs: '4px', sm: 1 } }}>
+                sx={{ mb: { xs: '4px', sm: 0.5 } }}>
                 {formatMessage({ id: titleId })}
               </BlockTitle>
               <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
# refactor(theme): migrate to standard MUI spacing scale

## 🤔 What

- Switch `theme.spacing` from a custom array (`[2, 4, 8, 16, 24, 32, 64]`) to the standard MUI factor-of-8 number (`spacing: 8`) in `grottoTheme.js`
- Remap all 747 existing integer spacing usages (`theme.spacing()` calls, `sx` shorthand props, `Stack`/`Grid` spacing props) to the equivalent new factor, so every one renders the exact same pixel value as before
- Remove 76 fractional/overflow spacing values (e.g. `gap: 1.5`, `py: 8`) that were previously silently dropped by the array scale, so current rendering stays unchanged rather than suddenly activating
- Update `AGENTS.md` spacing guidance to reflect the standard scale

## 🤷‍♂️ Why

MUI's array-type spacing only accepts integer indices — passing any fractional factor (`theme.spacing(0.5)`, `sx={{ p: 1.5 }}`) throws a console warning and silently resolves to nothing (the declaration is dropped). This was happening throughout the app any time a developer wrote a fractional spacing value, without ever being noticed visually.

MUI's own documentation recommends the factor-of-8 scale by default and explicitly warns that the array form doesn't support fractional signatures. MUI's own components (`Divider`, `DataGrid` internals) have shipped fractional `theme.spacing()` calls that broke under array-based themes, confirming this is not a supported pattern even for library maintainers.

## 🔍 How

- `grottoTheme.js`: `spacing: [...]` → `spacing: paddingUnit` (8)
- An AST codemod (recast + ast-types) walked every `.jsx`/`.js` file to:
  - Remap integer `theme.spacing(n)` calls and spacing-prop shorthands (`m`, `p`, `gap`, `Stack`/`Grid` `spacing`, etc.) from the old array index to the equivalent new standard factor (`0→0.25`, `1→0.5`, `2→1`, `3→2`, `4→3`, `5→4`, `6→8`), preserving identical rendered pixels
  - Detect values that were previously inert (non-integer factors, or integers beyond the old array's length) and remove them entirely, since they never applied any spacing before
  - Leave `styled()()` CSS-in-JS bodies alone for bare numeric CSS properties (those are raw emotion CSS, not MUI spacing) — only explicit `theme.spacing()` calls inside them were touched
- Verified via `git show` against the pre-change commit that no multi-argument `theme.spacing(a, b)` call in the codebase mixes a valid and an inert argument, so no case needed manual disambiguation

## 🧪 Testing

- `yarn test`: 581 tests pass; the only 10 failures (`MapMassif.test.jsx`, `MapMassif.property.test.jsx`) are a pre-existing Leaflet mock issue (`map.getPane is not a function`), confirmed unrelated by reproducing them against the pre-change commit
- `yarn lint` could not run in the dev environment due to a pre-existing missing `@babel/eslint-parser` install, unrelated to this change
- No functional/visual change is expected: every touched value either renders the same pixels as before, or was already a no-op and is now simply absent from the code

## 📸 Previews

No visual change expected — this PR intentionally preserves current rendering. A visual smoke test of a few pages that had inert spacing values (documents list, advanced search filters, entity tables) is still recommended before merge.
