### PR TITLE
tech(ci): inject Turnstile site key at build time via GitHub secret

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -23,6 +23,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         env:
           NODE_VERSION: 20
+          VITE_TURNSTILE_SITE_KEY: ${{ secrets.VITE_TURNSTILE_SITE_KEY }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ORANGE_ROCK_0D4F87503 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)


### PR DESCRIPTION
# Fix Turnstile site key not applied in production

## 🤔 What

- Add `VITE_TURNSTILE_SITE_KEY` to the `env` block of the GitHub Actions build step
- Closes #1477

## 🤷‍♂️ Why

`VITE_` prefixed variables are inlined by Vite at **build time**, not injected at runtime. The key was previously set as an Azure Static Web Apps application setting, which only affects server-side runtime — it never reached the Vite build, so the test key (`1x00000000000000000000AA`) was baked into the production bundle instead.

## 🔍 How

The `VITE_TURNSTILE_SITE_KEY` env var is now sourced from a GitHub Actions secret (`secrets.VITE_TURNSTILE_SITE_KEY`) and passed into the build environment. Vite picks it up during the build and inlines the real production key into the bundle.

The secret must be set in GitHub: **Settings → Secrets and variables → Actions → `VITE_TURNSTILE_SITE_KEY`**.

## 🔗 Related API PR

N/A

## 🧪 Testing

1. Add the `VITE_TURNSTILE_SITE_KEY` secret in GitHub Actions settings
2. Merge and let the pipeline deploy
3. Visit the sign-up page in production — the Turnstile widget should render without the "For tests only" watermark

## 📸 Previews

N/A
