### PR TITLE
fix(Map): do not bind marker tooltips on touch so popups open on iOS

### DIFF
--- a/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.jsx
+++ b/packages/web-app/src/components/common/Maps/common/Markers/useMarkers.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useCallback, useEffect } from 'react';
 import { useMap } from 'react-leaflet';
 import * as L from 'leaflet';
-import { GlobalStyles } from '@mui/material';
+import { GlobalStyles, useMediaQuery } from '@mui/material';
 import useRenderPopup from './useRenderPopup';
 
 export const MarkerGlobalCss = (
@@ -31,6 +31,7 @@ const useMarkers = ({
   // Map<id, L.Marker> for O(1) lookups during diff
   const markersRef = useRef(new Map());
   const renderPopup = useRenderPopup();
+  const isTouch = useMediaQuery('(pointer: coarse)');
 
   const createLeafletMarker = useCallback(
     marker => {
@@ -52,14 +53,25 @@ const useMarkers = ({
         markerEl.bindPopup(() => renderPopup(popupContent(marker)));
       }
 
-      if (tooltipContent) {
+      // Tooltips are a hover affordance, and binding one makes Leaflet listen
+      // for mouseover/mouseout on the marker. That turns the marker into a
+      // hoverable element, and iOS Safari then withholds the click of the first
+      // tap on such an element: only the hover events are delivered, so the
+      // tooltip opens while `_openPopup` never runs. The popup — the only thing
+      // carrying a link to the entrance page — stays unreachable, and the
+      // second tap lands on a tooltip that Leaflet renders with
+      // `pointer-events: none`, passing through to the map which closes it.
+      // Binding them only where a pointer can hover removes the conflict at the
+      // source; on touch the first tap now opens the popup directly.
+      if (tooltipContent && !isTouch) {
         markerEl.bindTooltip(`${tooltipContent(marker)}`, {});
-        // On touch devices a tap fires both tooltip and popup; hide tooltip on click
-        // (fires before popupopen, works reliably for both L.marker and L.circleMarker)
-        markerEl.on('click', () => {
-          markerEl.closeTooltip();
-          if (onMarkerClick) onMarkerClick(marker);
-        });
+      }
+
+      // Registered on its own rather than alongside the tooltip: ExploredOverlay
+      // drives its navigation through this callback, so tying it to the tooltip
+      // would silently disable it on the very devices we are fixing here.
+      if (onMarkerClick) {
+        markerEl.on('click', () => onMarkerClick(marker));
       }
 
       // Listeners are cleaned up by Leaflet when markerEl.remove() is called.
@@ -79,6 +91,7 @@ const useMarkers = ({
       popupContent,
       renderPopup,
       tooltipContent,
+      isTouch,
       onMarkerClick,
       onMarkerOver,
       onMarkerOut,


### PR DESCRIPTION
> Kept as a draft until confirmed on an iOS device.

## 🤔 What

Marker tooltips are no longer bound on touch devices, so a tap opens the popup directly.

- `useMarkers` binds the tooltip only when the pointer can hover (`(pointer: coarse)` is false)
- the `closeTooltip()` workaround in the click handler is removed
- `onMarkerClick` is registered independently of the tooltip

## 🤷‍♂️ Why

On iOS, tapping an entrance on the main map never opened its page. The decisive clue was a screenshot: the bubble that appears on a short tap is the **tooltip** (one line, entrance icon + name — the output of `makeIconTooltip`), not the popup. The popup, which is the only thing carrying a link, never opens at all.

Binding a tooltip makes Leaflet listen for `mouseover`/`mouseout` on the marker, which turns it into a hoverable element. iOS Safari then applies its long-standing rule for hoverable elements: the first tap delivers only the hover events and withholds the click. So:

1. tap 1 → `mouseover` → the tooltip opens, and the `click` that would have run `_openPopup` is never fired;
2. tap 2 → it lands on the tooltip, which Leaflet renders with `pointer-events: none`, so it passes through to the map → map click → the tooltip closes and nothing else happens.

That is exactly the reported "the bubble closes instead of navigating". Android and every desktop browser fire the click normally, which is why they were unaffected.

A tooltip is a hover affordance and carries no information the popup does not already show, so it has no purpose on a touch device. Not binding it removes the conflict at its source. Leaflet documents the same class of conflict in [#6122](https://github.com/Leaflet/Leaflet/issues/6122).

## 🔍 How

```js
const isTouch = useMediaQuery('(pointer: coarse)');

if (tooltipContent && !isTouch) {
  markerEl.bindTooltip(`${tooltipContent(marker)}`, {});
}
if (onMarkerClick) {
  markerEl.on('click', () => onMarkerClick(marker));
}
```

`(pointer: coarse)` matches the detection already used in `MapClusters/index.jsx`. A laptop with a touchscreen reports a fine pointer and keeps its tooltips.

The second half matters on its own: `onMarkerClick` used to be registered *inside* the `if (tooltipContent)` block, and `ExploredOverlay` drives its navigation through that callback. Gating tooltips without decoupling it would have silently disabled explored entrances on touch devices.

## 🧪 Testing

**On an iOS device**, on the main map: tap an entrance. The full popup (title, city, depth, length, quality) must open on the **first** tap, with no small tooltip appearing, and tapping its title must open the entrance page.

On desktop, nothing should change: hovering a marker shows the tooltip, clicking opens the popup.

Worth checking on the massif page map too — it binds tooltips the same way, so it is very likely affected in the same manner, and should now behave identically.

If the popup opens but its title still does not navigate on iOS, the remaining issue is link activation inside the popup, which is a separate problem with its own fix (delegating popup link clicks to the router).

## 📸 Previews

N/A — the visible change is the absence of tooltips on touch devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
