### PR TITLE
fix(Document): handle empty m2m collections on update and duplicate merge

### DIFF
--- a/packages/web-app/src/actions/Document/utils.js
+++ b/packages/web-app/src/actions/Document/utils.js
@@ -1,8 +1,14 @@
 // From https://stackoverflow.com/a/42483509/16600080
 // FormData can't send null values, so we omit them.
+// An empty array can't be represented either: omitting the key is read by the API
+// as "leave this collection untouched". The literal string '[]' is the agreed
+// sentinel meaning "clear this collection" (see config/constants/document.js and
+// DocumentService.getConvertedDataFromClient in grottocenter-api).
 // eslint-disable-next-line import/prefer-default-export
 export const buildFormData = (formData, data, parentKey) => {
-  if (
+  if (parentKey && Array.isArray(data) && data.length === 0) {
+    formData.append(parentKey, '[]');
+  } else if (
     data &&
     typeof data === 'object' &&
     !(data instanceof Date) &&

--- a/packages/web-app/src/actions/Document/utils.test.js
+++ b/packages/web-app/src/actions/Document/utils.test.js
@@ -1,0 +1,77 @@
+import { buildFormData } from './utils';
+
+const entries = formData => Array.from(formData.entries());
+
+describe('buildFormData', () => {
+  it('flattens nested objects with bracket notation', () => {
+    const formData = new FormData();
+    buildFormData(formData, { title: 'Cave map', editor: { id: 12 } });
+
+    expect(entries(formData)).toEqual([
+      ['title', 'Cave map'],
+      ['editor[id]', '12']
+    ]);
+  });
+
+  it('indexes array items', () => {
+    const formData = new FormData();
+    buildFormData(formData, { authors: [{ id: 3 }, { id: 7 }] });
+
+    expect(entries(formData)).toEqual([
+      ['authors[0][id]', '3'],
+      ['authors[1][id]', '7']
+    ]);
+  });
+
+  // FormData cannot express an empty array: without the sentinel the key would
+  // be missing altogether and the API would keep the existing associations.
+  it('sends the "[]" sentinel for an empty array', () => {
+    const formData = new FormData();
+    buildFormData(formData, { authors: [], subjects: [], iso3166: [] });
+
+    expect(entries(formData)).toEqual([
+      ['authors', '[]'],
+      ['subjects', '[]'],
+      ['iso3166', '[]']
+    ]);
+  });
+
+  it('does not send a sentinel when the root value is an empty array', () => {
+    const formData = new FormData();
+    buildFormData(formData, []);
+
+    expect(entries(formData)).toEqual([]);
+  });
+
+  it('omits null and undefined values but keeps empty strings', () => {
+    const formData = new FormData();
+    buildFormData(formData, {
+      pages: null,
+      issue: undefined,
+      identifier: ''
+    });
+
+    expect(entries(formData)).toEqual([['identifier', '']]);
+  });
+
+  it('appends File values as-is', () => {
+    const formData = new FormData();
+    const file = new File(['topo'], 'topo.png', { type: 'image/png' });
+    buildFormData(formData, { file });
+
+    const [[key, value]] = entries(formData);
+    expect(key).toBe('file');
+    expect(value).toBeInstanceOf(File);
+    expect(value.name).toBe('topo.png');
+  });
+
+  it('appends nested data under the given parent key', () => {
+    const formData = new FormData();
+    buildFormData(formData, { id: 4, fileName: 'a.png' }, 'deletedFiles[0]');
+
+    expect(entries(formData)).toEqual([
+      ['deletedFiles[0][id]', '4'],
+      ['deletedFiles[0][fileName]', 'a.png']
+    ]);
+  });
+});

--- a/packages/web-app/src/actions/Document/utils.test.js
+++ b/packages/web-app/src/actions/Document/utils.test.js
@@ -65,6 +65,16 @@ describe('buildFormData', () => {
     expect(value.name).toBe('topo.png');
   });
 
+  it('appends Date values as their string representation instead of iterating them', () => {
+    const formData = new FormData();
+    const datePublication = new Date('2024-01-01T00:00:00.000Z');
+    buildFormData(formData, { datePublication });
+
+    const [[key, value]] = entries(formData);
+    expect(key).toBe('datePublication');
+    expect(value).toBe(datePublication.toString());
+  });
+
   it('appends nested data under the given parent key', () => {
     const formData = new FormData();
     buildFormData(formData, { id: 4, fileName: 'a.png' }, 'deletedFiles[0]');

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
@@ -57,15 +57,25 @@ const stripType = ({ _type, ...rest }) => rest;
 
 const AuthorsSection = () => {
   const { formatMessage } = useIntl();
-  const { document: doc, updateAttribute } = useContext(DocumentFormContext);
+  const {
+    document: doc,
+    isNewDocument,
+    updateAttribute
+  } = useContext(DocumentFormContext);
   const currentUser = useUserProperties();
   const hasPrefilledRef = useRef(false);
 
+  // Convenience prefill for a brand new document only: never attribute
+  // authorship to whoever edits an existing one. A document is validly authored
+  // by at least one person OR one organization, so an existing organization
+  // author is enough to leave the field alone.
   useEffect(() => {
     if (
       hasPrefilledRef.current ||
+      !isNewDocument ||
       !currentUser.id ||
       doc.authors.length > 0 ||
+      doc.authorsGrotto.length > 0 ||
       doc.selectOptionAuthorizationDocument === DOCUMENT_AUTHORIZE_TO_PUBLISH
     )
       return;
@@ -73,9 +83,9 @@ const AuthorsSection = () => {
     updateAttribute('authors', [
       { id: currentUser.id, nickname: currentUser.nickname }
     ]);
-    // doc.authors and updateAttribute are stable; currentUser.id guards async hydration
+    // doc author collections and updateAttribute are stable; currentUser.id guards async hydration
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser.id, doc.selectOptionAuthorizationDocument]);
+  }, [currentUser.id, isNewDocument, doc.selectOptionAuthorizationDocument]);
 
   const value = useMemo(
     () => [

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
@@ -210,6 +210,7 @@ const AuthorsSection = () => {
                 {...params}
                 variant="filled"
                 label={formatMessage({ id: 'Authors' })}
+                required
                 error={hasError}
                 InputProps={{
                   ...params.InputProps,

--- a/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
@@ -107,6 +107,13 @@ const DocumentsHandler = ({
   const isSubmittable = () =>
     !(isEmpty(author) || isEmpty(type) || isEmpty(license));
 
+  // Every collection state starts empty and is only filled when the moderator
+  // clicks a value, so an empty array means "not touched", not "clear all".
+  // The API reads an explicit [] as a deliberate clear (it replaces the whole
+  // collection), so untouched collections must be omitted from the payload.
+  const onlyIfFilled = collection =>
+    collection.length > 0 ? collection : undefined;
+
   const onSubmit = () => {
     const { newItems: newAuthors, previousItems: previousAuthors } =
       retrieveFromObjectCollection(authors);
@@ -146,9 +153,12 @@ const DocumentsHandler = ({
         type: type.id,
         parent: getIdOrUndefined(parent),
         license: license.id,
-        authors: previousAuthors,
-        authorsGrotto: previousAuthorsGrotto,
-        subjects: subjects.map(sub => sub.code),
+        authors: onlyIfFilled(previousAuthors),
+        authorsGrotto: onlyIfFilled(previousAuthorsGrotto),
+        // Subjects coming from the database carry their code as `id` (the
+        // TSubject primary key is the `code` column); only subjects coming from
+        // an imported duplicate carry a `code` field.
+        subjects: onlyIfFilled(subjects.map(sub => sub.id ?? sub.code)),
         descriptions: previousDescriptions,
         languages: languages.map(lang => lang.id)
       },

--- a/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
@@ -14,6 +14,13 @@ import {
   retrieveFromObjectCollection
 } from './utils/retrieveFromObjectCollection';
 
+// Every collection state starts empty and is only filled when the moderator
+// clicks a value, so an empty array means "not touched", not "clear all".
+// The API reads an explicit [] as a deliberate clear (it replaces the whole
+// collection), so untouched collections must be omitted from the payload.
+const onlyIfFilled = collection =>
+  collection.length > 0 ? collection : undefined;
+
 const DocumentsHandler = ({
   duplicate1,
   duplicate2,
@@ -107,13 +114,6 @@ const DocumentsHandler = ({
   const isSubmittable = () =>
     !(isEmpty(author) || isEmpty(type) || isEmpty(license));
 
-  // Every collection state starts empty and is only filled when the moderator
-  // clicks a value, so an empty array means "not touched", not "clear all".
-  // The API reads an explicit [] as a deliberate clear (it replaces the whole
-  // collection), so untouched collections must be omitted from the payload.
-  const onlyIfFilled = collection =>
-    collection.length > 0 ? collection : undefined;
-
   const onSubmit = () => {
     const { newItems: newAuthors, previousItems: previousAuthors } =
       retrieveFromObjectCollection(authors);
@@ -160,6 +160,9 @@ const DocumentsHandler = ({
         // an imported duplicate carry a `code` field.
         subjects: onlyIfFilled(subjects.map(sub => sub.id ?? sub.code)),
         descriptions: previousDescriptions,
+        // `languages` is stripped by filterDocumentPayload and never reaches
+        // the API, so an empty array here has no wipe risk and onlyIfFilled
+        // is not needed.
         languages: languages.map(lang => lang.id)
       },
       {


### PR DESCRIPTION
# fix(Document): handle empty m2m collections on update and duplicate merge

## 🤔 What

closes #1491

Front-end companion to the API fix on document many-to-many collections (authors, organization authors, subjects, geographic coverage…).

- `buildFormData` now emits the literal string `'[]'` for empty arrays instead of omitting the key entirely
- The duplicate merge screen no longer sends empty collections it never filled, so merging a duplicate stops clearing the document's authors / organization authors / subjects
- The duplicate merge screen reads subject ids from `id` with a fallback on `code`, instead of `code` only
- Unit tests added for `buildFormData`

## 🤷‍♂️ Why

The API used to silently ignore collection fields passed to Waterline's `.set()`, so editing a document's authors had no effect at all. Now that they are written through `replaceCollection`, the write protocol is **field absent = leave untouched / empty array = clear all**, and two front-end paths do not follow it.

**`PUT /documents/{id}` (multipart).** `FormData` cannot express an empty array: `buildFormData` iterated `Object.keys([])` and appended nothing, so a cleared collection arrived as an absent field, which the API reads as "leave untouched". Concretely, removing the last person author (while keeping an organization author) or clearing every subject was a no-op — replacing one of several authors worked, removing the last one did not.

**`PUT /documents/{id}/new-entities` (JSON, moderator duplicate merge).** This screen starts with every collection state empty and only fills it when the moderator clicks a value on either side. Those `[]` were previously ignored by the API; they now clear the association in database. Merging a duplicate without touching the Subjects column would wipe the document's subjects. On top of that, subjects were mapped on `sub.code`, a field that only exists on subjects coming from an imported duplicate — database subjects carry their code as `id` (the `TSubject` primary key is the `code` column), so the payload was an array of `undefined`.

## 🔍 How

**`actions/Document/utils.js`** — `buildFormData` intercepts empty arrays before the object branch and appends the `'[]'` sentinel, which `DocumentService.getConvertedDataFromClient` converts back to `[]` API-side. The `parentKey` guard keeps the top-level call safe. Scope is contained: the helper is only used by `CreateDocument` and `UpdateDocument`, and the only arrays reaching it are `authors`, `authorsGrotto`, `subjects` and `iso3166` (`files` is destructured out beforehand, `modifiedFiles`/`deletedFiles` are appended per item with an explicit parent key). On the create path the sentinel resolves to `[]` before `TDocument.create()`, which is a no-op.

**`DuplicatesHandler/DocumentsHandler.jsx`** — a small `onlyIfFilled` helper returns `undefined` for an empty collection; `JSON.stringify` drops the key, so the field is genuinely absent from the request and the API leaves the association untouched. Omitting `authors` stays safe when new cavers are created in the same request: the API creates them with `documents: [documentId]`, which writes the join row directly, and skips `replaceCollection` when the field is `undefined`. `subjects` is mapped on `sub.id ?? sub.code`, mirroring the API's own fallback.

`languages`, `descriptions` and `entrances` sent by that screen are already stripped by `filterDocumentPayload` and never reach the API, so they are untouched here.

## 🔗 Related API PR

<https://github.com/GrottoCenter/grottocenter-api/pull/1750>

This PR is only observable once the API PR is merged and deployed — the staging site will not show the fix before that.

## 🧪 Testing

`yarn lint` passes, `yarn test` passes (756 tests / 81 files), including the new `src/actions/Document/utils.test.js`.

Manual end-to-end, with the API PR branch deployed. Note that `PUT /documents/{id}` only stores `modifiedDocJson`: the actual write happens when a moderator validates the document, so every case below needs the validation step to be observed.

- **Clear** — edit a document having one person author and one organization author, remove the person author, save, then validate it as a moderator. The person author must be gone.
- **Replace** — swap one author for another: only the new one remains.
- **Untouched** — edit only the title: subjects and geographic coverage are unchanged.
- **Merge** — open a document duplicate whose database side has subjects, merge without clicking the Subjects column: the subjects must be preserved.

In devtools, a cleared collection appears in the multipart body as `authors: []` (the string).

## 📸 Previews

N/A — no visual change.
