### PR TITLE
feat(Release): publish a GitHub release on every merge and show the version in the footer

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -18,12 +18,36 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true
+          # Tags and full history: next-version.js derives the version from the
+          # commits since the last release, and a shallow clone has neither.
+          fetch-depth: 0
+      # The version the Release workflow is about to tag, derived from the same
+      # cliff.toml on the same commit so the deployed bundle and the tag always
+      # agree. Nothing is written to the repository — it only travels as an env
+      # var into the build, the way VITE_TURNSTILE_SITE_KEY already does.
+      - name: Resolve the app version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="$(npx --yes git-cliff@2 --bumped-version)"
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::git-cliff returned an unusable version ('$VERSION')"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # A preview is not a release: never let it claim a version number
+            # that has not been tagged.
+            VERSION="${VERSION}-preview"
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building GrottoCenter $VERSION"
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         env:
           NODE_VERSION: 20
           VITE_TURNSTILE_SITE_KEY: ${{ secrets.VITE_TURNSTILE_SITE_KEY }}
+          VITE_APP_VERSION: ${{ steps.version.outputs.value }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ORANGE_ROCK_0D4F87503 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - develop
 
+env:
+  # Pinned to a major so a git-cliff release cannot silently change how versions
+  # are computed between two deployments. Keep in sync with release.yml.
+  GIT_CLIFF: git-cliff@2
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -29,7 +34,7 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          VERSION="$(npx --yes git-cliff@2 --bumped-version)"
+          VERSION="$(npx --yes "$GIT_CLIFF" --bumped-version)"
           if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::git-cliff returned an unusable version ('$VERSION')"
             exit 1

--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true
-          # Tags and full history: next-version.js derives the version from the
-          # commits since the last release, and a shallow clone has neither.
+          # Tags and full history: git-cliff derives the version from the commits
+          # since the last release, and a shallow clone has neither.
           fetch-depth: 0
       # The version the Release workflow is about to tag, derived from the same
       # cliff.toml on the same commit so the deployed bundle and the tag always

--- a/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-rock-0d4f87503.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - develop
 
+# Two deployments to the same target must not race: on two quick merges the
+# slower upload could land after the newer one. Keyed on the target rather than
+# flat, so previews — which each own a distinct environment — queue per PR
+# instead of behind production, and a PR teardown waits for that PR's upload.
+# Never cancel in progress: an interrupted upload leaves the target half-built.
+concurrency:
+  group: azure-deploy-${{ github.event.pull_request.number || 'production' }}
+  cancel-in-progress: false
+
 env:
   # Pinned to a major so a git-cliff release cannot silently change how versions
   # are computed between two deployments. Keep in sync with release.yml.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ on:
   push:
     branches: [develop]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab. No inputs:
+  # a manual run always re-derives the version from the tip of develop, so
+  # this is only useful to retry after a transient failure, not to target a
+  # specific commit or override the computed version.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,6 @@ on:
   push:
     branches: [develop]
 
-  # Allows you to run this workflow manually from the Actions tab. No inputs:
-  # a manual run always re-derives the version from the tip of develop, so
-  # this is only useful to retry after a transient failure, not to target a
-  # specific commit or override the computed version.
-  workflow_dispatch:
-
 permissions:
   contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+# Publishes a release on every merge into develop — no release PR, no version
+# bump commit. The tag is the source of truth for the version; the deployed
+# bundle carries the same number because the Azure workflow derives it from the
+# same cliff.toml, on the same commit.
+#
+# This job never blocks a deployment: it runs alongside the Azure one, so a
+# failure here leaves production untouched and is fixed by re-running the job.
+name: Release
+
+on:
+  push:
+    branches: [develop]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Two quick merges must not race for the same tag
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  # Pinned to a major so a git-cliff release cannot silently change how versions
+  # are computed between two deployments.
+  GIT_CLIFF: git-cliff@2
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Tags and full history: the version is derived from the commits since
+          # the last release, neither of which exist in a shallow clone.
+          fetch-depth: 0
+
+      - name: Compute the version
+        id: next
+        run: |
+          set -euo pipefail
+          VERSION="$(npx --yes "$GIT_CLIFF" --bumped-version)"
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::git-cliff returned an unusable version ('$VERSION')"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Nothing releasable (or a re-run of an already published commit): the
+          # tag existing is the only reliable signal, since --bumped-version
+          # always prints something.
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "$VERSION is already tagged — nothing to release."
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Releasing $VERSION"
+          fi
+
+      - name: Assemble the release body
+        if: ${{ steps.next.outputs.release == 'true' }}
+        env:
+          VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          set -euo pipefail
+          {
+            printf '## 🕳️ GrottoCenter %s is rolling out\n\n' "$VERSION"
+            printf 'Live shortly on <https://grottocenter.org> — already have the app open? '
+            printf 'Use the update button to load this version.\n\n'
+            npx --yes "$GIT_CLIFF" --bump --unreleased
+            printf '\n---\n\n'
+            printf '📰 The story behind this release, in French, on the [blog](https://blog-fr.grottocenter.org)\n'
+            printf '🐛 Something wrong? [Open an issue](https://github.com/%s/issues/new)\n' "$GITHUB_REPOSITORY"
+            printf '❤️ Thanks to everyone contributing to the worldwide caving database\n'
+          } > release-body.md
+
+      - name: Tag and publish the GitHub Release
+        if: ${{ steps.next.outputs.release == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          # Plain semver, no `v`. The app- namespace belongs to the Android build
+          # (see twa/README.md), so this tag never triggers a TWA build.
+          tag_name: ${{ steps.next.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: GrottoCenter ${{ steps.next.outputs.version }}
+          body_path: release-body.md
+          make_latest: true

--- a/.github/workflows/twa-build.yml
+++ b/.github/workflows/twa-build.yml
@@ -9,14 +9,18 @@ on:
         default: '1.0.0'
   push:
     tags:
-      # Only semver release tags (1.0.0, 10.2.3…) trigger a build + Release.
+      # Only Android release tags (app-1.0.0, app-10.2.3…) trigger a build.
+      # The `app-` namespace keeps this workflow off the web release tags: bare
+      # semver (1.0.0) belongs to release-please, which tags the web app on every
+      # merged release PR. Android ships on its own cadence, so it gets its own
+      # prefix — but the version inside the tag stays plain semver.
       # GitHub Actions tag filters are globs, not regex: [0-9] is a digit class,
       # + means "one or more of the preceding", and \. escapes the literal dot
       # (without escaping, `.` would match any character — including `-`, which
-      # would let tags like `1-0-0` trigger a build only to fail semver validation).
+      # would let tags like `app-1-0-0` trigger a build only to fail validation).
       # The Resolve step still validates strict semver as defense-in-depth (and
       # for workflow_dispatch).
-      - '[0-9]+\.[0-9]+\.[0-9]+'
+      - 'app-[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   build:
@@ -47,10 +51,11 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             NAME="${{ github.event.inputs.version_name }}"
           else
-            # Tag push: derive the name from the tag (v1.2.3 -> 1.2.3).
-            NAME="${GITHUB_REF_NAME#v}"
+            # Tag push: strip the namespace prefix (app-1.2.3 -> 1.2.3).
+            NAME="${GITHUB_REF_NAME#app-}"
           fi
-          # versionName must be strict semver X.Y.Z (human-facing version).
+          # versionName must be strict semver X.Y.Z (human-facing version): the
+          # `app-` prefix is a tag namespace only and must never reach Gradle.
           if ! printf '%s' "$NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::version must be semver X.Y.Z (got '$NAME')"
             exit 1
@@ -61,7 +66,8 @@ jobs:
           CODE="${{ github.run_number }}"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: $NAME (code $CODE)"
+          echo "tag=app-$NAME" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $NAME (code $CODE, tag app-$NAME)"
 
       - name: Decode keystore from secret
         env:
@@ -107,9 +113,10 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          # On a tag push GITHUB_REF_NAME is reused; on workflow_dispatch the tag
-          # is created from the resolved version name. Tags are plain semver (no v).
-          tag_name: ${{ steps.version.outputs.name }}
+          # Always the app- namespaced tag: on a tag push it matches the tag that
+          # triggered the run, on workflow_dispatch it is created here. Never the
+          # bare semver tag — that one is release-please's web release.
+          tag_name: ${{ steps.version.outputs.tag }}
           name: Grottocenter App ${{ steps.version.outputs.name }} (build ${{ steps.version.outputs.code }})
           generate_release_notes: true
           # files are relative to the repo root, not working-directory.

--- a/.github/workflows/twa-build.yml
+++ b/.github/workflows/twa-build.yml
@@ -11,9 +11,9 @@ on:
     tags:
       # Only Android release tags (app-1.0.0, app-10.2.3…) trigger a build.
       # The `app-` namespace keeps this workflow off the web release tags: bare
-      # semver (1.0.0) belongs to release-please, which tags the web app on every
-      # merged release PR. Android ships on its own cadence, so it gets its own
-      # prefix — but the version inside the tag stays plain semver.
+      # semver (1.0.0) belongs to git-cliff (.github/workflows/release.yml), which
+      # tags the web app on every merge into develop. Android ships on its own cadence,
+      # so it gets its own prefix — but the version inside the tag stays plain semver.
       # GitHub Actions tag filters are globs, not regex: [0-9] is a digit class,
       # + means "one or more of the preceding", and \. escapes the literal dot
       # (without escaping, `.` would match any character — including `-`, which
@@ -115,7 +115,7 @@ jobs:
         with:
           # Always the app- namespaced tag: on a tag push it matches the tag that
           # triggered the run, on workflow_dispatch it is created here. Never the
-          # bare semver tag — that one is release-please's web release.
+          # bare semver tag — that one is git-cliff's web release.
           tag_name: ${{ steps.version.outputs.tag }}
           name: Grottocenter App ${{ steps.version.outputs.name }} (build ${{ steps.version.outputs.code }})
           generate_release_notes: true

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,48 @@
+# Version and release notes configuration.
+#
+# Both workflows read this file on the same commit: the Azure one bakes
+# `git cliff --bumped-version` into the bundle it deploys, the Release one tags
+# that version and publishes `git cliff --bump --unreleased` as the release body.
+
+[changelog]
+header = ""
+# The `<!-- n -->` prefixes only force the section order (git-cliff sorts groups
+# alphabetically); `striptags` removes them before rendering.
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+
+{% for commit in commits %}
+- {% if commit.breaking %}**BREAKING** {% endif %}\
+{% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+{{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+# Every merge on develop must produce a release, so a commit that does not
+# follow the convention still counts instead of vanishing.
+filter_unconventional = false
+protect_breaking_commits = true
+sort_commits = "oldest"
+# Bare semver only — this is what keeps the Android tags (app-3.1.0) out of the
+# web version history. See twa/README.md.
+tag_pattern = '^[0-9]+\.[0-9]+\.[0-9]+$'
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->✨ New features" },
+  { message = "^improvement", group = "<!-- 1 -->🚀 Improvements" },
+  { message = "^fix", group = "<!-- 2 -->🐛 Bug fixes" },
+  { message = "^perf", group = "<!-- 3 -->⚡ Performance" },
+  { message = "^revert", group = "<!-- 4 -->⏪ Reverts" },
+  { message = "^docs", group = "<!-- 5 -->📝 Documentation" },
+  { message = "^tech", group = "<!-- 6 -->🔧 Technical" },
+  { message = "^refactor", group = "<!-- 6 -->🔧 Technical" },
+  { message = "^chore", group = "<!-- 7 -->📦 Maintenance" },
+  { message = "^style", group = "<!-- 7 -->📦 Maintenance" },
+  { message = "^test", group = "<!-- 7 -->📦 Maintenance" },
+  { message = ".*", group = "<!-- 8 -->Other changes" }
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grotto-front",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "Grottocenter front monorepo",
   "private": true,
   "workspaces": [

--- a/packages/web-app/.env
+++ b/packages/web-app/.env
@@ -15,3 +15,7 @@ VITE_BI_URL=https://bi.grottocenter.org
 # 1x00000000000000000000AA is Cloudflare's "always-pass" test key for local dev.
 # Leave empty to disable the widget locally.
 VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+
+# App version shown in the footer. CI overrides it with the version being tagged
+# (see .github/workflows/release.yml); locally it stays an obvious placeholder.
+VITE_APP_VERSION=0.0.0-dev

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grotto-front/web-app",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "private": true,
   "homepage": "https://grottocenter.org",
   "scripts": {

--- a/packages/web-app/src/pages/homepage/Footer.jsx
+++ b/packages/web-app/src/pages/homepage/Footer.jsx
@@ -68,6 +68,10 @@ const LicenseBadgeFrame = styled(Box)({
 
 const FOOTER_BADGE_SIZE = 36;
 
+// Injected at build time by CI from the version being tagged; falls back to the
+// .env placeholder in local development.
+const appVersion = import.meta.env.VITE_APP_VERSION;
+
 const LicenseBar = styled(Box)({
   borderTop: '1px solid rgba(255,255,255,0.1)',
   padding: '14px 24px',
@@ -350,6 +354,19 @@ const Footer = () => {
             })}
           </Typography>
         </LicenseLine>
+        {appVersion && (
+          <Typography
+            variant="caption"
+            sx={{
+              // Dimmer than the license text above: informative, never
+              // competing with the legal notices for attention.
+              color: 'rgba(255,255,255,0.3)',
+              display: 'block',
+              textAlign: 'center'
+            }}>
+            Grottocenter web v{appVersion}
+          </Typography>
+        )}
       </LicenseBar>
     </FooterRoot>
   );

--- a/packages/web-app/src/vite-env.d.ts
+++ b/packages/web-app/src/vite-env.d.ts
@@ -10,6 +10,9 @@ interface ImportMetaEnv {
   readonly VITE_BI_URL?: string;
   readonly VITE_DISABLE_MAP_TOUR?: string;
   readonly VITE_TURNSTILE_SITE_KEY?: string;
+  // Injected by CI at build time from the version about to be tagged; .env
+  // provides a placeholder for local development.
+  readonly VITE_APP_VERSION?: string;
 }
 
 interface ImportMeta {

--- a/twa/README.md
+++ b/twa/README.md
@@ -150,7 +150,7 @@ Make sure the PWA is already deployed and valid at `https://grottocenter.org`
 >
 > | Tag         | Created by                                         | Ships                        |
 > | ----------- | -------------------------------------------------- | ---------------------------- |
-> | `X.Y.Z`     | release-please (`.github/workflows/release.yml`)   | the web app + `CHANGELOG.md` |
+> | `X.Y.Z`     | git-cliff (`.github/workflows/release.yml`)        | the web app (release notes in GitHub Releases) |
 > | `app-X.Y.Z` | you, when the Android shell itself needs a rebuild | the signed `.aab` / `.apk`   |
 >
 > Without the prefix, every web release would trigger a full Android build and both
@@ -182,7 +182,7 @@ The workflow signs with your upload key, then:
    debugging only, not durable storage), and
 2. publishes a **GitHub Release** `app-X.Y.Z` with the `.aab`/`.apk` attached — this is
    the **permanent, versioned archive** of each build. It is a separate release from
-   the web one release-please publishes under the bare `X.Y.Z` tag.
+   the web one `.github/workflows/release.yml` publishes under the bare `X.Y.Z` tag.
 
 (Local alternative: build it yourself — see [Building locally](#building-locally).)
 

--- a/twa/README.md
+++ b/twa/README.md
@@ -142,13 +142,27 @@ Make sure the PWA is already deployed and valid at `https://grottocenter.org`
 
 - **Manually** — GitHub → Actions → _TWA Android Build_ → Run workflow, providing a
   `version_name` in strict semver `X.Y.Z` (e.g. `1.0.0`).
-- **By pushing a tag** `X.Y.Z` (plain semver, no `v` prefix) — the version name is the tag.
+- **By pushing a tag** `app-X.Y.Z` (e.g. `app-1.0.0`) — the version name is the tag
+  without its `app-` prefix.
+
+> **Why the `app-` prefix?** The repository has two independent release tracks, so the
+> tags are namespaced to keep them apart:
+>
+> | Tag         | Created by                                         | Ships                        |
+> | ----------- | -------------------------------------------------- | ---------------------------- |
+> | `X.Y.Z`     | release-please (`.github/workflows/release.yml`)   | the web app + `CHANGELOG.md` |
+> | `app-X.Y.Z` | you, when the Android shell itself needs a rebuild | the signed `.aab` / `.apk`   |
+>
+> Without the prefix, every web release would trigger a full Android build and both
+> workflows would fight over the same tag. **The version stays plain semver
+> everywhere** — the prefix is a tag namespace only, and it is stripped before the
+> version reaches Gradle or the Play Store.
 
 Version handling **decouples the two Android version fields**, which is the standard
 Play Store practice:
 
-- **`versionName`** (the human-facing version) = the semver above. A non-semver value
-  fails the build early.
+- **`versionName`** (the human-facing version) = the semver above, never the raw tag:
+  `app-1.2.3` produces `versionName "1.2.3"`. A non-semver value fails the build early.
 - **`versionCode`** (the integer Play compares) = **`github.run_number`**, a
   CI-managed counter that GitHub increments on every run. This guarantees it is
   **strictly increasing** for each build regardless of the version name — a hard Play
@@ -166,8 +180,9 @@ The workflow signs with your upload key, then:
 
 1. uploads `*.aab` / `*.apk` as a **workflow artifact** (30-day retention — for quick
    debugging only, not durable storage), and
-2. publishes a **GitHub Release** `vX.Y.Z` with the `.aab`/`.apk` attached — this is
-   the **permanent, versioned archive** of each build.
+2. publishes a **GitHub Release** `app-X.Y.Z` with the `.aab`/`.apk` attached — this is
+   the **permanent, versioned archive** of each build. It is a separate release from
+   the web one release-please publishes under the bare `X.Y.Z` tag.
 
 (Local alternative: build it yourself — see [Building locally](#building-locally).)
 
@@ -322,7 +337,7 @@ The AAB is a shell; the content is served from the web.
 | Change                                                                          | Action                                                                                           |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Content, features, UI fixes, data, translations…                                | **Deploy the website** (push to `develop`). Users get it immediately, **no Play Store release**. |
-| App icon, name, `packageId`, chrome colors, `minSdkVersion`, native permissions | **Regenerate + commit** the project (see above), then run the workflow (tag or dispatch) and republish. |
+| App icon, name, `packageId`, chrome colors, `minSdkVersion`, native permissions | **Regenerate + commit** the project (see above), then run the workflow (push an `app-X.Y.Z` tag, or dispatch it manually) and republish. |
 | Keystore rotation                                                               | Rebuild the AAB **and** update `assetlinks.json` fingerprints, then redeploy the web.            |
 
 > In practice, after the first release the AAB is rebuilt **rarely**. That is the


### PR DESCRIPTION
# feat(Release): publish a GitHub release on every merge and show the version in the footer

## 🤔 What

Every merge on `develop` now publishes a versioned GitHub Release automatically, and the running version is visible in the app footer.

- **New** `cliff.toml` — declares how versions are computed and how release notes are grouped
- **New** `.github/workflows/release.yml` — tags the version and publishes the GitHub Release
- `.github/workflows/azure-static-web-apps-*.yml` — resolves the same version and injects it into the build as `VITE_APP_VERSION`
- `.github/workflows/twa-build.yml` — Android tags move to the `app-x.y.z` namespace
- `Footer.jsx` — discreet, centered `Grottocenter web vX.Y.Z` under the license bar
- `twa/README.md` — documents the two tag namespaces
- `package.json`, `packages/web-app/package.json` — aligned on 3.0.0

## 🤷‍♂️ Why

Release communication was entirely manual: changes were written up by hand on Slack, Facebook and Blogger, with nothing tying them back to the repository. Meanwhile the project already enforces conventional commits through CommitLint — the raw material for a changelog was there, and unused.

There was also no way for anyone to tell which version was actually running in production.

Two constraints shaped the design:

- **No release PR.** Releases happen on merge, not after a second review step.
- **No second deployment.** A version bump committed back to `develop` would redeploy the site for a change that alters nothing, and would prompt every PWA user to update for it.

## 🔍 How

The version is computed, injected into the build, and only tagged afterwards — never committed:

```
merge on develop
  ├─ Azure    : git cliff --bumped-version → VITE_APP_VERSION → build → deploy
  └─ Release  : git cliff --bumped-version → tag → GitHub Release
```

Both workflows run on the **same commit** and read the **same** `cliff.toml`, so the deployed version and the tag cannot disagree. They are independent: the release job never gates a deployment, so a failure there leaves production untouched and is fixed by re-running the job.

`VITE_APP_VERSION` travels as a step `env:` var through Oryx into `import.meta.env`, exactly like the existing `VITE_TURNSTILE_SITE_KEY`. Nothing is written back to the repository — hence no extra commit, no `[skip ci]`, and a single deployment per merge.

**Bump rules** — every merge produces a release, including `chore(deps)`: `!`/`BREAKING CHANGE` → major, `feat` → minor, anything else → patch. `filter_unconventional = false` keeps non-conventional commits counting rather than vanishing.

**Tag namespaces** — `tag_pattern` accepts bare semver only. This is what keeps the Android tags out of the web version history, and the matching change in `twa-build.yml` means a web release no longer triggers a full Android build. The `app-` prefix is stripped before the version reaches Gradle, since `versionName` must stay strict semver.

**Re-run safety** — the release job skips publication when the computed tag already exists, so re-running it is harmless.

## 🔗 Related API PR

None.

## 🧪 Testing

Both derivations were verified against this repository:

```bash
npx git-cliff@2 --bumped-version     # 3.0.0 → "nothing to bump" until a commit lands
npx git-cliff@2 --bump --unreleased  # grouped notes, correct sections
```

Bump rules were checked on a throwaway repository across the five cases: chore-only → patch, `feat` → minor, `feat` + `fix` → minor, `!` → major, and `BREAKING CHANGE` footer → major.

To review the footer: run the app and scroll to the bottom of the homepage — it should read `Grottocenter web v0.0.0-dev` locally, and the tagged version once deployed.

Note that this PR's own preview deployment will display a `-preview` suffix, which is intended: a preview must never claim a version number that has not been tagged.

## 📸 Previews

Footer license bar, bottom of the homepage:

```
[CC-BY-SA]  Unless stated otherwise, the CC-BY-SA license applies…
[ODBL]      The ODBL license applies to all data that is not copyrighted.
                       Grottocenter web v3.0.0
```

## ⚠️ Note for the reviewer

The first release will be **3.1.0**, computed from the `3.0.0` tag already pushed on `develop`.

`package.json` is no longer updated automatically — the git tag is now the source of truth for the version, and the file only serves as a readable reference. There is no `CHANGELOG.md`: the notes live in the GitHub Releases.

One known limitation: if two merges land within a couple of minutes, the second build may compute its version before the first tag exists and display a number one patch behind. It corrects itself on the following merge. Removing it entirely would mean serialising release and deployment, which would make deployments depend on the release tooling — a trade rejected on purpose.
