### PR TITLE
fix(document): use authorsOrganization consistently instead of authorsGrotto

### DIFF
--- a/packages/web-app/src/components/appli/EntitiesForm/Document/Provider.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/Provider.jsx
@@ -21,7 +21,7 @@ export const defaultDocAttributes = {
   datePublication: '',
   creatorComment: '',
   authors: [],
-  authorsGrotto: [],
+  authorsOrganization: [],
   editor: null,
   library: null,
   type: -1,
@@ -71,7 +71,7 @@ const checkFormValidation = document => {
   )
     isValid = false;
 
-  if (document.authors.length + document.authorsGrotto.length === 0)
+  if (document.authors.length + document.authorsOrganization.length === 0)
     isValid = false;
   if (!isDocumentPagesFormatValid(document.pages)) isValid = false;
   if (document.identifier && !document.identifierType) isValid = false;
@@ -115,10 +115,7 @@ const normalizeInitialValues = values => {
     ...rest,
     selectOptionAuthorizationDocument: option ?? null,
     files: (files ?? []).map(f => ({ ...f, state: IS_INTACT })),
-    // The API reads organization-authors as `authorsOrganization` but expects
-    // them back as `authorsGrotto` on write; the form only ever uses the
-    // write-side name internally.
-    authorsGrotto: authorsOrganization ?? []
+    authorsOrganization: authorsOrganization ?? []
   };
 };
 

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
@@ -210,7 +210,7 @@ const AuthorsSection = () => {
                 {...params}
                 variant="filled"
                 label={formatMessage({ id: 'Authors' })}
-                required
+                required={value.length === 0}
                 error={hasError}
                 InputProps={{
                   ...params.InputProps,

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/formElements/AuthorsSection/index.jsx
@@ -75,7 +75,7 @@ const AuthorsSection = () => {
       !isNewDocument ||
       !currentUser.id ||
       doc.authors.length > 0 ||
-      doc.authorsGrotto.length > 0 ||
+      doc.authorsOrganization.length > 0 ||
       doc.selectOptionAuthorizationDocument === DOCUMENT_AUTHORIZE_TO_PUBLISH
     )
       return;
@@ -90,9 +90,9 @@ const AuthorsSection = () => {
   const value = useMemo(
     () => [
       ...doc.authors.map(a => ({ ...a, _type: 'persons' })),
-      ...doc.authorsGrotto.map(o => ({ ...o, _type: 'organizations' }))
+      ...doc.authorsOrganization.map(o => ({ ...o, _type: 'organizations' }))
     ],
-    [doc.authors, doc.authorsGrotto]
+    [doc.authors, doc.authorsOrganization]
   );
 
   const { inputValue, setInputValue, results, isLoading, hasError } =
@@ -112,7 +112,7 @@ const AuthorsSection = () => {
       newValue.filter(v => v._type === 'persons').map(stripType)
     );
     updateAttribute(
-      'authorsGrotto',
+      'authorsOrganization',
       newValue.filter(v => v._type === 'organizations').map(stripType)
     );
   };

--- a/packages/web-app/src/components/appli/EntitiesForm/Document/types.js
+++ b/packages/web-app/src/components/appli/EntitiesForm/Document/types.js
@@ -48,7 +48,7 @@ export const defaultDocumentValuesTypes = PropTypes.shape({
   datePublication: PropTypes.string,
   creatorComment: PropTypes.string,
   authors: PropTypes.arrayOf(simpleCaverType),
-  authorsGrotto: PropTypes.arrayOf(simpleOrganisationType),
+  authorsOrganization: PropTypes.arrayOf(simpleOrganisationType),
   editor: simpleOrganisationType,
   library: simpleOrganisationType,
   type: PropTypes.string,

--- a/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
+++ b/packages/web-app/src/components/common/DuplicatesHandler/DocumentsHandler.jsx
@@ -121,7 +121,7 @@ const DocumentsHandler = ({
     // Organizations-as-authors have no atomic "create + attach" endpoint yet
     // (backend follow-up), so only pre-existing organizations (with an id)
     // can come out of the merge — new items are never produced here.
-    const { previousItems: previousAuthorsGrotto } =
+    const { previousItems: previousAuthorsOrganization } =
       retrieveFromObjectCollection(authorsOrganization);
 
     const {
@@ -154,7 +154,7 @@ const DocumentsHandler = ({
         parent: getIdOrUndefined(parent),
         license: license.id,
         authors: onlyIfFilled(previousAuthors),
-        authorsGrotto: onlyIfFilled(previousAuthorsGrotto),
+        authorsOrganization: onlyIfFilled(previousAuthorsOrganization),
         // Subjects coming from the database carry their code as `id` (the
         // TSubject primary key is the `code` column); only subjects coming from
         // an imported duplicate carry a `code` field.

--- a/packages/web-app/src/utils/documentTypeHelpers.js
+++ b/packages/web-app/src/utils/documentTypeHelpers.js
@@ -207,7 +207,7 @@ export const documentTypeHelpers = {
   isUnknown
 };
 
-const BASE_PAYLOAD_FIELDS = ['id', 'type', 'title', 'authors', 'authorsGrotto'];
+const BASE_PAYLOAD_FIELDS = ['id', 'type', 'title', 'authors', 'authorsOrganization'];
 const LANGUAGE_PAYLOAD_FIELDS = ['mainLanguage', 'mainLanguageName'];
 const FILE_PAYLOAD_FIELDS = [
   'files',


### PR DESCRIPTION
# fix(document): use authorsOrganization consistently instead of authorsGrotto

## 🤔 What

- Renames every remaining `authorsGrotto` reference to `authorsOrganization` in the Document form:
  - `Provider.jsx` (default attributes, validation, initial values normalization)
  - `AuthorsSection/index.jsx`
  - `types.js` PropTypes shape
  - `DuplicatesHandler/DocumentsHandler.jsx`
  - `documentTypeHelpers.js` payload fields
- Removes the now-obsolete workaround comment explaining the read/write field name mismatch.

closes #1496

## 🤷‍♂️ Why

The API used to read organization-authors as `authorsOrganization` but expected them back as `authorsGrotto` on write, forcing the form to translate between the two names internally. That asymmetry no longer exists, so keeping two names around was just a source of confusion and bugs.

## 🔍 How

Straight rename of the field across the Document form state, validation, PropTypes, duplicate-merge handling, and payload building — no behavioral change beyond dropping the now-unnecessary translation.

## 🔗 Related API PR

https://github.com/GrottoCenter/grottocenter-api/issues/1729

## 🧪 Testing

- Create/edit a document and add an organization as author, save, and confirm it persists correctly.
- Merge two duplicate documents that both have organization authors and confirm the merged result keeps them.

## 📸 Previews

_N/A — internal field rename, no visual changes._
