### PR TITLE
fix(twa): edge-to-edge readiness, R8 optimization and AGP 9 migration

### DIFF
--- a/twa/README.md
+++ b/twa/README.md
@@ -314,6 +314,31 @@ bubblewrap update            # apply twa-manifest.json changes to the project
 > Bubblewrap version emits. Google Play requires the target API to be at most one
 > year behind the latest Android release (**API 36 minimum from 2026-08-31**), so
 > check that line after every regeneration.
+>
+> ⚠️ The same goes for everything below — Bubblewrap 1.25 still generates an AGP 8
+> project with an unoptimized R8 setup, so a regeneration silently undoes all of it
+> and the Play Console warnings come back:
+>
+> In `app/build.gradle`:
+>
+> - `androidbrowserhelper:2.7.2` — Bubblewrap still pins 2.6.2, and 2.7.x is what
+>   makes the splash screen edge-to-edge
+> - `minSdk 23` — 2.7.x will not merge below it
+> - `shrinkResources`, `proguardFiles …-optimize.txt`, `proguard-rules.pro`
+> - AGP 9 DSL — `compileSdk`/`minSdk`/`targetSdk`, `lint {}`,
+>   `buildFeatures { resValues = true }`
+>
+> Elsewhere:
+>
+> - `build.gradle` — `com.android.tools.build:gradle:9.3.1`, `mavenCentral()`
+>   instead of the shut-down `jcenter()`
+> - `gradle.properties` — `android.enableR8.fullMode=true`
+> - `app/src/main/res/raw/keep.xml` — a new file Bubblewrap never generates
+> - `app/src/main/AndroidManifest.xml` — no `package=` attribute (AGP 9 rejects it)
+>
+> `buildFeatures { resValues = true }` is the dangerous one: without it AGP 9 builds
+> an app whose every generated string and color resolves to nothing, and the build
+> still succeeds.
 
 Then **commit the regenerated project** so CI builds the updated app:
 

--- a/twa/README.md
+++ b/twa/README.md
@@ -300,14 +300,19 @@ bubblewrap update            # apply twa-manifest.json changes to the project
 >     }
 >     buildTypes {
 >         release {
->             minifyEnabled true
->             signingConfig signingConfigs.release   // ← add this line
+>             minifyEnabled true                     // ← Bubblewrap emits only this
+>             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+>             shrinkResources = true
+>             signingConfig = signingConfigs.release
 >         }
 >     }
 > }
 > ```
 >
-> Without it the release build is unsigned and Play rejects it.
+> Without the `signingConfig` the release build is unsigned and Play rejects it;
+> without the other two the Play Console reports the app as unoptimized. Bubblewrap
+> regenerates the `release` block with `minifyEnabled` alone, so all three lines have
+> to come back by hand.
 >
 > ⚠️ Same problem for **`targetSdkVersion`**: it is not exposed in
 > `twa-manifest.json`, so `bubblewrap update` resets it to whatever the installed

--- a/twa/README.md
+++ b/twa/README.md
@@ -300,7 +300,7 @@ bubblewrap update            # apply twa-manifest.json changes to the project
 >     }
 >     buildTypes {
 >         release {
->             minifyEnabled true                     // ← Bubblewrap emits only this
+>             minifyEnabled = true                   // ← Bubblewrap emits `minifyEnabled true`
 >             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 >             shrinkResources = true
 >             signingConfig = signingConfigs.release
@@ -332,6 +332,11 @@ bubblewrap update            # apply twa-manifest.json changes to the project
 > - `shrinkResources`, `proguardFiles …-optimize.txt`, `proguard-rules.pro`
 > - AGP 9 DSL — `compileSdk`/`minSdk`/`targetSdk`, `lint {}`,
 >   `buildFeatures { resValues = true }`
+> - `tasks.register('generateShortcutsFile') { doLast { … } }` and
+>   `tasks.named('preBuild') { dependsOn('generateShortcutsFile') }` — Bubblewrap
+>   emits a bare `task generateShorcutsFile { … }` (note the typo) whose body runs
+>   during Gradle's configuration phase, so it rewrites `shortcuts.xml` on every
+>   invocation. The registered form makes it lazy and only writes when it runs.
 >
 > Elsewhere:
 >

--- a/twa/app/build.gradle
+++ b/twa/app/build.gradle
@@ -55,7 +55,10 @@ android {
     namespace "org.grottocenter.twa"
     defaultConfig {
         applicationId "org.grottocenter.twa"
-        minSdkVersion 21
+        // 23 (Android 6.0), not Bubblewrap's default of 21: androidbrowserhelper 2.7.x
+        // declares minSdk 23 and the manifest merger refuses anything lower. Forcing it
+        // with tools:overrideLibrary would only move the failure to runtime.
+        minSdkVersion 23
         targetSdkVersion 36
         versionCode 4
         versionName "4"
@@ -165,6 +168,13 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            // Without an explicit proguardFiles block AGP injects no default config at
+            // all, so R8 runs on the AAPT-generated rules only and its optimizer stays
+            // idle — which is what the Play Console reports as "optimization is not
+            // enabled". Use the `-optimize` variant: plain proguard-android.txt carries
+            // `-dontoptimize` and is deprecated.
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            shrinkResources true
             signingConfig signingConfigs.release
         }
     }
@@ -223,6 +233,10 @@ dependencies {
 
         implementation 'com.google.androidbrowserhelper:locationdelegation:1.1.2'
 
-        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.6.2'
+        // Pinned ahead of Bubblewrap, which still generates 2.6.2. 2.7.x is what makes
+        // the splash screen edge-to-edge: it draws the system bar colors through
+        // androidx ProtectionLayout/ColorProtection instead of the Window.set*BarColor
+        // setters Android 15 deprecated. Re-check this line after any `bubblewrap update`.
+        implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.7.2'
 
 }

--- a/twa/app/build.gradle
+++ b/twa/app/build.gradle
@@ -175,7 +175,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled = true
             // Without an explicit proguardFiles block AGP injects no default config at
             // all, so R8 runs on the AAPT-generated rules only and its optimizer stays
             // idle — which is what the Play Console reports as "optimization is not
@@ -199,7 +199,7 @@ android {
 // configuration phase, so it rewrote a tracked source file on every invocation —
 // even `./gradlew tasks`. Registering it and moving the work into doLast makes it
 // an ordinary task: lazily created, and only writing when it actually runs.
-tasks.register('generateShorcutsFile') {
+tasks.register('generateShortcutsFile') {
     doLast {
         assert twaManifest.shortcuts.size() < 5, "You can have at most 4 shortcuts."
         twaManifest.shortcuts.eachWithIndex { s, i ->
@@ -254,7 +254,7 @@ tasks.register('generateShorcutsFile') {
     }
 }
 
-tasks.named('preBuild') { dependsOn('generateShorcutsFile') }
+tasks.named('preBuild') { dependsOn('generateShortcutsFile') }
 
 repositories {
 

--- a/twa/app/build.gradle
+++ b/twa/app/build.gradle
@@ -51,7 +51,7 @@ def twaManifest = [
 ]
 
 android {
-    compileSdk 36
+    compileSdk = 36
     namespace = "org.grottocenter.twa"
 
     // AGP 9 flipped android.defaults.buildfeatures.resvalues to false. Nearly every
@@ -62,14 +62,14 @@ android {
     }
 
     defaultConfig {
-        applicationId "org.grottocenter.twa"
+        applicationId = "org.grottocenter.twa"
         // 23 (Android 6.0), not Bubblewrap's default of 21: androidbrowserhelper 2.7.x
         // declares minSdk 23 and the manifest merger refuses anything lower. Forcing it
         // with tools:overrideLibrary would only move the failure to runtime.
-        minSdk 23
-        targetSdk 36
-        versionCode 4
-        versionName "4"
+        minSdk = 23
+        targetSdk = 36
+        versionCode = 4
+        versionName = "4"
 
         // The name for the application
         resValue "string", "appName", twaManifest.name
@@ -167,10 +167,10 @@ android {
             // the Java signing API (no shell command is built), so special
             // characters in the password are safe — unlike Bubblewrap's apksigner
             // invocation, which mangles them via shell quoting.
-            storeFile file(System.getenv("KEYSTORE_FILE") ?: "android.keystore")
-            storePassword System.getenv("KEYSTORE_PASSWORD")
-            keyAlias System.getenv("KEY_ALIAS")
-            keyPassword System.getenv("KEY_PASSWORD")
+            storeFile = file(System.getenv("KEYSTORE_FILE") ?: "android.keystore")
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
         }
     }
     buildTypes {
@@ -187,8 +187,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     lint {
         checkReleaseBuilds = false
@@ -205,8 +205,8 @@ tasks.register('generateShortcutsFile') {
         twaManifest.shortcuts.eachWithIndex { s, i ->
             assert s.name != null, 'Missing `name` in shortcut #' + i
             assert s.short_name != null, 'Missing `short_name` in shortcut #' + i
-            assert s.url != null, 'Missing `icon` in shortcut #' + i
-            assert s.icon != null, 'Missing `url` in shortcut #' + i
+            assert s.url != null, 'Missing `url` in shortcut #' + i
+            assert s.icon != null, 'Missing `icon` in shortcut #' + i
         }
 
         def shortcutsFile = new File("$projectDir/src/main/res/xml", "shortcuts.xml")

--- a/twa/app/build.gradle
+++ b/twa/app/build.gradle
@@ -51,15 +51,23 @@ def twaManifest = [
 ]
 
 android {
-    compileSdkVersion 36
-    namespace "org.grottocenter.twa"
+    compileSdk 36
+    namespace = "org.grottocenter.twa"
+
+    // AGP 9 flipped android.defaults.buildfeatures.resvalues to false. Nearly every
+    // string and color this app uses is a resValue below, so leaving this off does
+    // not fail the build — it produces an app whose resources resolve to nothing.
+    buildFeatures {
+        resValues = true
+    }
+
     defaultConfig {
         applicationId "org.grottocenter.twa"
         // 23 (Android 6.0), not Bubblewrap's default of 21: androidbrowserhelper 2.7.x
         // declares minSdk 23 and the manifest merger refuses anything lower. Forcing it
         // with tools:overrideLibrary would only move the failure to runtime.
-        minSdkVersion 23
-        targetSdkVersion 36
+        minSdk 23
+        targetSdk 36
         versionCode 4
         versionName "4"
 
@@ -174,55 +182,79 @@ android {
             // enabled". Use the `-optimize` variant: plain proguard-android.txt carries
             // `-dontoptimize` and is deprecated.
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            shrinkResources true
-            signingConfig signingConfigs.release
+            shrinkResources = true
+            signingConfig = signingConfigs.release
         }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    lintOptions {
-        checkReleaseBuilds false
+    lint {
+        checkReleaseBuilds = false
     }
 }
 
-task generateShorcutsFile {
-    assert twaManifest.shortcuts.size() < 5, "You can have at most 4 shortcuts."
-    twaManifest.shortcuts.eachWithIndex { s, i ->
-        assert s.name != null, 'Missing `name` in shortcut #' + i
-        assert s.short_name != null, 'Missing `short_name` in shortcut #' + i
-        assert s.url != null, 'Missing `icon` in shortcut #' + i
-        assert s.icon != null, 'Missing `url` in shortcut #' + i
-    }
+// Bubblewrap generated this as a bare `task { … }` whose body ran during Gradle's
+// configuration phase, so it rewrote a tracked source file on every invocation —
+// even `./gradlew tasks`. Registering it and moving the work into doLast makes it
+// an ordinary task: lazily created, and only writing when it actually runs.
+tasks.register('generateShorcutsFile') {
+    doLast {
+        assert twaManifest.shortcuts.size() < 5, "You can have at most 4 shortcuts."
+        twaManifest.shortcuts.eachWithIndex { s, i ->
+            assert s.name != null, 'Missing `name` in shortcut #' + i
+            assert s.short_name != null, 'Missing `short_name` in shortcut #' + i
+            assert s.url != null, 'Missing `icon` in shortcut #' + i
+            assert s.icon != null, 'Missing `url` in shortcut #' + i
+        }
 
-    def shortcutsFile = new File("$projectDir/src/main/res/xml", "shortcuts.xml")
+        def shortcutsFile = new File("$projectDir/src/main/res/xml", "shortcuts.xml")
 
-    def xmlWriter = new StringWriter()
-    def xmlMarkup = new MarkupBuilder(new IndentPrinter(xmlWriter, "    ", true))
+        def xmlWriter = new StringWriter()
+        def xmlMarkup = new MarkupBuilder(new IndentPrinter(xmlWriter, "    ", true))
 
-    xmlMarkup
-        .'shortcuts'('xmlns:android': 'http://schemas.android.com/apk/res/android') {
-            twaManifest.shortcuts.eachWithIndex { s, i ->
-                'shortcut'(
-                        'android:shortcutId': 'shortcut' + i,
-                        'android:enabled': 'true',
-                        'android:icon': '@drawable/' + s.icon,
-                        'android:shortcutShortLabel': '@string/shortcut_short_name_' + i,
-                        'android:shortcutLongLabel': '@string/shortcut_name_' + i) {
-                    'intent'(
-                            'android:action': 'android.intent.action.MAIN',
-                            'android:targetPackage': twaManifest.applicationId,
-                            'android:targetClass': twaManifest.applicationId + '.LauncherActivity',
-                            'android:data': s.url)
-                    'categories'('android:name': 'android.intent.category.LAUNCHER')
+        xmlMarkup
+            .'shortcuts'('xmlns:android': 'http://schemas.android.com/apk/res/android') {
+                twaManifest.shortcuts.eachWithIndex { s, i ->
+                    'shortcut'(
+                            'android:shortcutId': 'shortcut' + i,
+                            'android:enabled': 'true',
+                            'android:icon': '@drawable/' + s.icon,
+                            'android:shortcutShortLabel': '@string/shortcut_short_name_' + i,
+                            'android:shortcutLongLabel': '@string/shortcut_name_' + i) {
+                        'intent'(
+                                'android:action': 'android.intent.action.MAIN',
+                                'android:targetPackage': twaManifest.applicationId,
+                                'android:targetClass': twaManifest.applicationId + '.LauncherActivity',
+                                'android:data': s.url)
+                        'categories'('android:name': 'android.intent.category.LAUNCHER')
+                    }
                 }
             }
-        }
-    shortcutsFile.text = xmlWriter.toString() + '\n'
+        // Emitted so the generated file matches the committed one byte for byte —
+        // otherwise every build leaves shortcuts.xml modified in the working tree.
+        def licenseHeader = '''<!--
+    Copyright 2019 Google Inc. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+'''
+        shortcutsFile.text = licenseHeader + xmlWriter.toString() + '\n'
+    }
 }
 
-preBuild.dependsOn(generateShorcutsFile)
+tasks.named('preBuild') { dependsOn('generateShorcutsFile') }
 
 repositories {
 

--- a/twa/app/proguard-rules.pro
+++ b/twa/app/proguard-rules.pro
@@ -10,6 +10,12 @@
 # here. The one such case is the TrustedWebActivityService binding: the platform
 # resolves it through the manifest, but R8 full mode strips the no-arg constructor
 # of classes it thinks are never instantiated from code.
+#
+# locationdelegation.PermissionRequestActivity is not listed below: Chrome / the
+# TWA host resolves it through PackageManager intent resolution, so the class
+# itself is kept by R8's activity rules derived from the manifest. If the
+# geolocation permission prompt ever stops working under R8, add:
+#   -keep class com.google.androidbrowserhelper.locationdelegation.PermissionRequestActivity { <init>(); }
 -keep class com.google.androidbrowserhelper.trusted.DelegationService { <init>(); }
 -keep class org.grottocenter.twa.DelegationService { <init>(); }
 

--- a/twa/app/proguard-rules.pro
+++ b/twa/app/proguard-rules.pro
@@ -1,0 +1,19 @@
+# R8 keep rules for the TWA wrapper.
+#
+# This app has no business logic of its own — it launches the PWA in Chrome — so
+# there is almost nothing to keep. Everything reachable is either declared in
+# AndroidManifest.xml (activities, the DelegationService, the FileProvider), which
+# R8 keeps automatically, or lives in androidbrowserhelper.
+#
+# androidbrowserhelper ships no consumer ProGuard rules of its own (there is no
+# proguard.txt in its AAR), so anything it reaches by reflection has to be kept
+# here. The one such case is the TrustedWebActivityService binding: the platform
+# resolves it through the manifest, but R8 full mode strips the no-arg constructor
+# of classes it thinks are never instantiated from code.
+-keep class com.google.androidbrowserhelper.trusted.DelegationService { <init>(); }
+-keep class org.grottocenter.twa.DelegationService { <init>(); }
+
+# Keep the line numbers of crash reports readable in the Play Console. R8 emits the
+# mapping file to app/build/outputs/mapping/release/ — upload it if a stack trace
+# ever needs deobfuscating.
+-keepattributes SourceFile,LineNumberTable

--- a/twa/app/proguard-rules.pro
+++ b/twa/app/proguard-rules.pro
@@ -22,4 +22,9 @@
 # Keep the line numbers of crash reports readable in the Play Console. R8 emits the
 # mapping file to app/build/outputs/mapping/release/ — upload it if a stack trace
 # ever needs deobfuscating.
+#
+# renamesourcefileattribute replaces the real filename in the DEX with the literal
+# string "SourceFile"; retrace resolves it back through the mapping file, so the
+# stack traces stay readable while the class-internal names stay out of the APK.
 -keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/twa/app/src/main/AndroidManifest.xml
+++ b/twa/app/src/main/AndroidManifest.xml
@@ -14,13 +14,10 @@
      limitations under the License.
 -->
 
-<!-- The "package" attribute is rewritten by the Gradle build with the value of applicationId.
-     It is still required here, as it is used to derive paths, for instance when referring
-     to an Activity by ".MyActivity" instead of the full name. If more Activities are added to the
-     application, the package attribute will need to reflect the correct path in order to use
-     the abbreviated format. -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.grottocenter.twa">
+<!-- The namespace lives in app/build.gradle, not here: AGP stopped honouring the
+     `package` attribute and now rejects it outright. Abbreviated class names such as
+     ".LauncherActivity" still resolve against that namespace. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     
         <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/twa/app/src/main/res/raw/keep.xml
+++ b/twa/app/src/main/res/raw/keep.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    androidbrowserhelper resolves this string through Resources.getIdentifier(), by
+    name, so no compiled reference points at it and the shrinker cannot see it is
+    used. AGP 9's optimized resource shrinking drops it as a result, and the
+    "your Chrome is out of date" toast then silently never shows — ChromeUpdatePrompt
+    treats a missing resource as "skip the toast" rather than failing loudly.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/update_chrome_toast" />

--- a/twa/build.gradle
+++ b/twa/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.9.1'
@@ -30,10 +30,12 @@ buildscript {
     }
 }
 
+// jcenter() was in the Bubblewrap template but the repository has been shut down
+// since 2022 — every artifact here resolves from google() or mavenCentral().
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/twa/build.gradle
+++ b/twa/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:9.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -39,6 +39,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/twa/gradle.properties
+++ b/twa/gradle.properties
@@ -12,3 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+# Already the default on AGP 8+, but stated explicitly: full mode is what the Play
+# Console counts as "optimization enabled", and leaving it implicit means a future
+# AGP change or a stray override could turn it off unnoticed.
+android.enableR8.fullMode=true

--- a/twa/gradle/wrapper/gradle-wrapper.properties
+++ b/twa/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/twa/twa-manifest.json
+++ b/twa/twa-manifest.json
@@ -39,7 +39,7 @@
   "isChromeOSOnly": false,
   "isMetaQuest": false,
   "fullScopeUrl": "https://grottocenter.org/",
-  "minSdkVersion": 21,
+  "minSdkVersion": 23,
   "orientation": "default",
   "fingerprints": [
     {


### PR DESCRIPTION
## 🤔 What

Clears the three warnings the Play Console raised on the published bundle, and brings the Android build up to date.

- `androidbrowserhelper` 2.6.2 → **2.7.2**, which makes the splash screen edge-to-edge
- **minSdk 21 → 23** (Android 6.0) — forced by the above, see below
- R8: adds `shrinkResources`, `proguardFiles`, `proguard-rules.pro`, explicit full mode
- **AGP 8.9.1 → 9.3.1**, **Gradle 8.11.1 → 9.7.0**, and the AGP 9 DSL migration
- Drops `jcenter()`, shut down since 2022
- `res/raw/keep.xml` — new, see the resource-shrinking note below
- `generateShorcutsFile` no longer rewrites a tracked source file on every build

**APK −53% (1.41 MB → 654 KB), AAB −52% (1.54 MB → 747 KB)** versus `develop`.

## 🤷‍♂️ Why

Play Console reported, on the published bundle:

1. Deprecated edge-to-edge window APIs under Android 15 — `Window.setStatusBarColor`, `setNavigationBarColor`, `getStatusBarColor`
2. Resource shrinking not enabled
3. R8 optimization not enabled, and AGP below 9.0

**On (1) — none of it was our code.** All three call sites Google listed live inside `androidbrowserhelper` 2.6.2 (June 2023). Our Android code is three trivial classes and touches no window API, so there was nothing for `enableEdgeToEdge()` to be added to. Version 2.7.2 (June 2026) paints the splash screen through androidx `ProtectionLayout`/`ColorProtection` and opts in via `WindowCompat.enableEdgeToEdge()` — which *is* the `enableEdgeToEdge()` Google's message asks for, just inside the library.

**On (3) — `minifyEnabled true` was set, but there was no `proguardFiles` block at all.** Without one AGP injects no default configuration, so R8 ran on the AAPT-generated rules only and its optimizer never engaged. That is what the Console reports as "optimization is not enabled".

## 🔍 How

### The dependency bump forces minSdk 23

`androidbrowserhelper` 2.7.x declares `minSdk 23` and the manifest merger refuses to go below it. The only alternative Google offers is `tools:overrideLibrary`, which its own message describes as "may lead to runtime failures" — it trades a build error for a crash on Android 5.x. So the floor moves to Android 6.0.

⚠️ **Worth a look at the Play Console install base before merging.** Android 5.0/5.1 should be a rounding error in 2026, and a TWA needs a recent Chrome anyway, but the number is yours to check.

### What is actually left in the release DEX

Disassembled the shipped APK to confirm the fix rather than trusting the changelog. Two call sites remain, both benign:

| Call site | Status |
| --- | --- |
| `LauncherActivity.a()` | androidx `WindowCompat.enableEdgeToEdge()`, inlined by R8 — the documented pre-API-35 compat path, guarded on `SDK_INT` |
| `WebViewFallbackActivity.onCreate` | guarded to `SDK_INT <= 34`, and unreachable anyway with `fallbackType: customtabs` |

The two `Utils.set*BarColor` helpers Play named are **gone** from the DEX: nothing in 2.7.2 calls them any more, so R8 strips them. `WebViewFallbackActivity` will probably still show up in the Console's report — the analysis is static and sees the guarded call — but it never executes.

### AGP 9

`buildFeatures { resValues = true }` is the load-bearing line. AGP 9 flips `android.defaults.buildfeatures.resvalues` to `false`, and this project routes practically everything it displays through `resValue` — app name, launch URL, system bar colors, provider authority. **Without the opt-in the build still succeeds** and produces an app whose resources resolve to nothing.

Also migrated: `compileSdkVersion`/`minSdkVersion`/`targetSdkVersion` → `compileSdk`/`minSdk`/`targetSdk`, `lintOptions` → `lint`, `task clean` → `tasks.register`, and the `package=` attribute removed from `AndroidManifest.xml` (AGP 9 rejects it rather than ignoring it). `versionCode`/`versionName` were deliberately left in space-assignment syntax so the CI `sed` in `twa-build.yml` keeps matching. Zero Gradle deprecation warnings remain.

### One real regression, caught and fixed

AGP 9 enables optimized resource shrinking, which traces resources and classes together — worth another 37% off the APK on its own. It also silently removed `string/update_chrome_toast`: `androidbrowserhelper` resolves that one through `Resources.getIdentifier()`, by name, so no compiled reference points at it. The out-of-date-Chrome toast simply stopped appearing (`ChromeUpdatePrompt` treats a missing resource as "skip the toast", so no crash). `res/raw/keep.xml` restores it.

`string/fullScopeUrl` is also shrunk away, in this PR and already before it — it is read only by Meta Quest builds and `isMetaQuest` is `false`.

### Build hygiene

`generateShorcutsFile` was generated by Bubblewrap as a bare `task { … }`, so its body ran during Gradle's configuration phase and rewrote the tracked `shortcuts.xml` on every invocation — `./gradlew tasks` included, stripping its license header each time. It is now registered with the work in `doLast` and emits the header, so generated and committed match and builds leave the working tree clean.

### Keeping this from being undone

Bubblewrap 1.25.0 — the latest — still pins `androidbrowserhelper:2.6.2` and still generates an AGP 8 project with the unoptimized R8 setup. A `bubblewrap update` would silently revert all of this and bring the warnings back. `twa/README.md` now lists everything that has to survive a regeneration.

## 🧪 Testing

Verified locally with a full signed release build (AGP 9.3.1 / Gradle 9.7.0 / JDK 17), throwaway keystore:

- `./gradlew clean :app:bundleRelease :app:assembleRelease` — green, no deprecation warnings
- Packaged manifest: `minSdkVersion 23`, `targetSdkVersion 36`, launchable activity and label intact
- Resource table: every `resValue` resolves — `bool/enableNotification` = true, `integer/splashScreenFadeOutDuration` = 300, `color/backgroundColor` = `#ff5d4037`; splash, launcher and notification icons present
- DEX: all three app classes kept; the only `Window` bar-colour call sites are the two listed above

**Still needed before publishing** — I could not do these here:

- [ ] Install the release APK on a **physical Android 15 or 16 device** and check the splash screen draws correctly behind the system bars, then the TWA opens with no Chrome URL bar
- [ ] Confirm notification delegation and the geolocation permission prompt still work — R8 full mode is newly effective here and `androidbrowserhelper` ships no consumer ProGuard rules of its own
- [ ] Check the Android 5.x install base in the Play Console against the `minSdk` bump

## 📸 Previews

Size comparison, both built from a clean tree with the same throwaway keystore:

| Artifact | `develop` | This branch | Δ |
| --- | --- | --- | --- |
| APK | 1 409 143 B | 656 814 B | −53.4% |
| AAB | 1 539 671 B | 746 686 B | −51.5% |
