### PR TITLE
fix(document): reset validation selection between batches

### DIFF
--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
@@ -246,7 +246,7 @@ const DesktopEntityTable = ({
   setEntityColumns,
   isLoading,
   onSelected,
-  selectedIds,
+  selectedIds: controlledSelectedIds,
   pageRows,
   nbTotalRows,
   onRowClick,
@@ -275,7 +275,10 @@ const DesktopEntityTable = ({
   const [order, setOrder] = useState('');
   const [orderBy, setOrderBy] = useState('');
   const [internalSelectedIds, setInternalSelectedIds] = useState([]);
-  const selected = selectedIds ?? internalSelectedIds;
+  const selected = controlledSelectedIds ?? internalSelectedIds;
+  const isSelectionControlled = controlledSelectedIds !== undefined;
+  const onSelectedRef = useRef(onSelected);
+  onSelectedRef.current = onSelected;
   // Sticky results toolbar + sticky table header both pin to the same card
   // scroller; the header sits just below the toolbar, at its measured height
   // (see hook). 0 when the toolbar isn't rendered (shouldHideFooter).
@@ -347,7 +350,7 @@ const DesktopEntityTable = ({
     } else {
       newSelected.splice(selectedIndex, 1);
     }
-    if (selectedIds === undefined) setInternalSelectedIds(newSelected);
+    if (!isSelectionControlled) setInternalSelectedIds(newSelected);
     onSelected(newSelected);
   };
 
@@ -398,7 +401,7 @@ const DesktopEntityTable = ({
     if (event.target.checked) {
       newSelected = pageRows.map(n => n.id);
     }
-    if (selectedIds === undefined) setInternalSelectedIds(newSelected);
+    if (!isSelectionControlled) setInternalSelectedIds(newSelected);
     onSelected(newSelected);
   };
 
@@ -408,7 +411,10 @@ const DesktopEntityTable = ({
     setOrder('');
     setOrderBy('');
     setInternalSelectedIds([]);
-  }, [isNewQuery]);
+    if (isSelectionControlled && onSelectedRef.current) {
+      onSelectedRef.current([]);
+    }
+  }, [isNewQuery, isSelectionControlled]);
 
   const colSpan = visibleColumns.length + (onSelected ? 1 : 0);
 

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.jsx
@@ -246,6 +246,7 @@ const DesktopEntityTable = ({
   setEntityColumns,
   isLoading,
   onSelected,
+  selectedIds,
   pageRows,
   nbTotalRows,
   onRowClick,
@@ -273,7 +274,8 @@ const DesktopEntityTable = ({
   );
   const [order, setOrder] = useState('');
   const [orderBy, setOrderBy] = useState('');
-  const [selected, setSelected] = useState([]);
+  const [internalSelectedIds, setInternalSelectedIds] = useState([]);
+  const selected = selectedIds ?? internalSelectedIds;
   // Sticky results toolbar + sticky table header both pin to the same card
   // scroller; the header sits just below the toolbar, at its measured height
   // (see hook). 0 when the toolbar isn't rendered (shouldHideFooter).
@@ -345,7 +347,7 @@ const DesktopEntityTable = ({
     } else {
       newSelected.splice(selectedIndex, 1);
     }
-    setSelected(newSelected);
+    if (selectedIds === undefined) setInternalSelectedIds(newSelected);
     onSelected(newSelected);
   };
 
@@ -396,7 +398,7 @@ const DesktopEntityTable = ({
     if (event.target.checked) {
       newSelected = pageRows.map(n => n.id);
     }
-    setSelected(newSelected);
+    if (selectedIds === undefined) setInternalSelectedIds(newSelected);
     onSelected(newSelected);
   };
 
@@ -405,7 +407,7 @@ const DesktopEntityTable = ({
     setPage(0);
     setOrder('');
     setOrderBy('');
-    setSelected([]);
+    setInternalSelectedIds([]);
   }, [isNewQuery]);
 
   const colSpan = visibleColumns.length + (onSelected ? 1 : 0);
@@ -744,6 +746,9 @@ DesktopEntityTable.propTypes = {
   setEntityColumns: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
   onSelected: PropTypes.func,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   pageRows: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   nbTotalRows: PropTypes.number,
   onRowClick: PropTypes.func,

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
@@ -209,3 +209,43 @@ describe('DesktopEntityTable - Export controls', () => {
     expect(screen.queryByText('Export to CSV')).not.toBeInTheDocument();
   });
 });
+
+describe('DesktopEntityTable - Controlled selection', () => {
+  it('starts a new selection after the parent clears selected ids', () => {
+    const onSelected = vi.fn();
+    const { rerender } = renderTable({
+      onSelected,
+      selectedIds: []
+    });
+
+    let checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[checkboxes.length - 1]);
+    expect(onSelected).toHaveBeenLastCalledWith([1]);
+
+    rerender(
+      <IntlProvider locale="en" messages={messages}>
+        <DesktopEntityTable
+          {...defaultProps}
+          onSelected={onSelected}
+          selectedIds={[1]}
+        />
+      </IntlProvider>
+    );
+
+    rerender(
+      <IntlProvider locale="en" messages={messages}>
+        <DesktopEntityTable
+          {...defaultProps}
+          pageRows={[{ id: 2, name: 'Cave B' }]}
+          onSelected={onSelected}
+          selectedIds={[]}
+        />
+      </IntlProvider>
+    );
+
+    checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[checkboxes.length - 1]);
+
+    expect(onSelected).toHaveBeenLastCalledWith([2]);
+  });
+});

--- a/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/DesktopEntityTable.test.jsx
@@ -14,6 +14,7 @@ vi.mock('./VisibleColumnsMenu', () => {
 vi.mock('../../../hooks/useOpenLink', () => ({ default: () => vi.fn() }));
 
 const messages = {
+  Name: 'Name',
   Export: 'Export',
   'Export to CSV': 'Export to CSV',
   'Export unavailable above 10000 results':
@@ -232,6 +233,9 @@ describe('DesktopEntityTable - Controlled selection', () => {
       </IntlProvider>
     );
 
+    checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[checkboxes.length - 1]).toBeChecked();
+
     rerender(
       <IntlProvider locale="en" messages={messages}>
         <DesktopEntityTable
@@ -247,5 +251,13 @@ describe('DesktopEntityTable - Controlled selection', () => {
     fireEvent.click(checkboxes[checkboxes.length - 1]);
 
     expect(onSelected).toHaveBeenLastCalledWith([2]);
+  });
+
+  it('requests a controlled selection reset for a new query', () => {
+    const onSelected = vi.fn();
+
+    renderTable({ isNewQuery: true, onSelected, selectedIds: [1] });
+
+    expect(onSelected).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
+++ b/packages/web-app/src/components/common/EntityTable/EntityTable.jsx
@@ -50,6 +50,7 @@ const EntityTable = ({
   entityColumnsModifier,
   isLoading = true,
   onSelected,
+  selectedIds,
   pageRows,
   nbTotalRows,
   onRowClick,
@@ -192,6 +193,7 @@ const EntityTable = ({
           icon={entityConfig.icon}
           renderCellFn={renderCell}
           onSelected={onSelected}
+          selectedIds={selectedIds}
           onRowClick={onRowClick}
         />
       </Box>
@@ -205,6 +207,7 @@ const EntityTable = ({
       setEntityColumns={setEntityColumns}
       isLoading={isLoading}
       onSelected={onSelected}
+      selectedIds={selectedIds}
       pageRows={pageRows}
       nbTotalRows={nbTotalRows}
       onRowClick={onRowClick}
@@ -226,6 +229,9 @@ EntityTable.propTypes = {
   entityColumnsModifier: PropTypes.func,
   isLoading: PropTypes.bool,
   onSelected: PropTypes.func,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   pageRows: PropTypes.arrayOf(PropTypes.shape({})),
   nbTotalRows: PropTypes.number,
   onRowClick: PropTypes.func,

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
@@ -179,6 +179,7 @@ const MobileEntityList = ({
   const [page, setPage] = useState(0);
   const [internalSelectedIds, setInternalSelectedIds] = useState([]);
   const selectedIds = controlledSelectedIds ?? internalSelectedIds;
+  const isSelectionControlled = controlledSelectedIds !== undefined;
   const isAppending = useRef(false);
   const hasInteracted = useRef(false);
   // Keep callback changes from retriggering the internal selection effect.
@@ -190,9 +191,12 @@ const MobileEntityList = ({
     setAllRows([]);
     setPage(0);
     setInternalSelectedIds([]);
+    if (isSelectionControlled && onSelectedRef.current) {
+      onSelectedRef.current([]);
+    }
     hasInteracted.current = false;
     isAppending.current = false;
-  }, [isNewQuery]);
+  }, [isNewQuery, isSelectionControlled]);
 
   useEffect(() => {
     if (isAppending.current) {
@@ -224,7 +228,7 @@ const MobileEntityList = ({
         ? selectedIds.filter(selectedId => selectedId !== id)
         : [...selectedIds, id];
 
-      if (controlledSelectedIds !== undefined) {
+      if (isSelectionControlled) {
         if (onSelectedRef.current) onSelectedRef.current(nextSelectedIds);
         return;
       }
@@ -232,7 +236,7 @@ const MobileEntityList = ({
       hasInteracted.current = true;
       setInternalSelectedIds(nextSelectedIds);
     },
-    [controlledSelectedIds, selectedIds]
+    [isSelectionControlled, selectedIds]
   );
 
   const handleLoadMore = () => {

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
@@ -213,8 +213,8 @@ const MobileEntityList = ({
   }, [rows]);
 
   // Notify parent only when selection actually changes, not on mount.
-  // onSelectedRef is a ref — intentionally excluded from deps to keep the effect
-  // stable and avoid triggering on every parent re-render that recreates the callback.
+  // Uncontrolled path only: controlled mode notifies through handleToggle and
+  // never writes internalSelectedIds, so this effect stays idle.
   useEffect(() => {
     if (!hasInteracted.current) return;
     if (onSelectedRef.current) onSelectedRef.current(internalSelectedIds);

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.jsx
@@ -172,14 +172,16 @@ const MobileEntityList = ({
   icon,
   renderCellFn,
   onSelected = null,
+  selectedIds: controlledSelectedIds,
   onRowClick = null
 }) => {
   const [allRows, setAllRows] = useState(rows ?? []);
   const [page, setPage] = useState(0);
-  const [selectedIds, setSelectedIds] = useState([]);
+  const [internalSelectedIds, setInternalSelectedIds] = useState([]);
+  const selectedIds = controlledSelectedIds ?? internalSelectedIds;
   const isAppending = useRef(false);
   const hasInteracted = useRef(false);
-  // Keep a stable ref to the callback so handleToggle never changes reference
+  // Keep callback changes from retriggering the internal selection effect.
   const onSelectedRef = useRef(onSelected);
   onSelectedRef.current = onSelected;
 
@@ -187,7 +189,7 @@ const MobileEntityList = ({
     if (!isNewQuery) return;
     setAllRows([]);
     setPage(0);
-    setSelectedIds([]);
+    setInternalSelectedIds([]);
     hasInteracted.current = false;
     isAppending.current = false;
   }, [isNewQuery]);
@@ -211,16 +213,27 @@ const MobileEntityList = ({
   // stable and avoid triggering on every parent re-render that recreates the callback.
   useEffect(() => {
     if (!hasInteracted.current) return;
-    if (onSelectedRef.current) onSelectedRef.current(selectedIds);
-  }, [selectedIds]);
+    if (onSelectedRef.current) onSelectedRef.current(internalSelectedIds);
+  }, [internalSelectedIds]);
 
-  // Stable reference — does not depend on onSelected directly
-  const handleToggle = useCallback(id => {
-    hasInteracted.current = true;
-    setSelectedIds(prev =>
-      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
-    );
-  }, []);
+  // In controlled mode the parent owns the selection, so report the next
+  // value directly. Existing callers keep the internal-state behavior.
+  const handleToggle = useCallback(
+    id => {
+      const nextSelectedIds = selectedIds.includes(id)
+        ? selectedIds.filter(selectedId => selectedId !== id)
+        : [...selectedIds, id];
+
+      if (controlledSelectedIds !== undefined) {
+        if (onSelectedRef.current) onSelectedRef.current(nextSelectedIds);
+        return;
+      }
+
+      hasInteracted.current = true;
+      setInternalSelectedIds(nextSelectedIds);
+    },
+    [controlledSelectedIds, selectedIds]
+  );
 
   const handleLoadMore = () => {
     isAppending.current = true;
@@ -302,6 +315,9 @@ MobileEntityList.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   renderCellFn: PropTypes.func.isRequired,
   onSelected: PropTypes.func,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   onRowClick: PropTypes.func
 };
 

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.test.jsx
@@ -3,6 +3,8 @@ import { IntlProvider } from 'react-intl';
 
 import MobileEntityList from './MobileEntityList';
 
+const messages = { Name: 'Name' };
+
 const columns = [
   { field: 'name', label: 'Name', visible: true, isTitle: true }
 ];
@@ -20,7 +22,7 @@ const defaultProps = {
 
 const renderList = props =>
   render(
-    <IntlProvider locale="en">
+    <IntlProvider locale="en" messages={messages}>
       <MobileEntityList {...defaultProps} {...props} />
     </IntlProvider>
   );
@@ -34,7 +36,7 @@ describe('MobileEntityList - Controlled selection', () => {
     expect(onSelected).toHaveBeenLastCalledWith([1]);
 
     rerender(
-      <IntlProvider locale="en">
+      <IntlProvider locale="en" messages={messages}>
         <MobileEntityList
           {...defaultProps}
           onSelected={onSelected}
@@ -43,8 +45,10 @@ describe('MobileEntityList - Controlled selection', () => {
       </IntlProvider>
     );
 
+    expect(screen.getByRole('checkbox')).toBeChecked();
+
     rerender(
-      <IntlProvider locale="en">
+      <IntlProvider locale="en" messages={messages}>
         <MobileEntityList
           {...defaultProps}
           rows={[{ id: 2, name: 'Cave B' }]}
@@ -57,5 +61,13 @@ describe('MobileEntityList - Controlled selection', () => {
     fireEvent.click(screen.getByRole('checkbox'));
 
     expect(onSelected).toHaveBeenLastCalledWith([2]);
+  });
+
+  it('requests a controlled selection reset for a new query', () => {
+    const onSelected = vi.fn();
+
+    renderList({ isNewQuery: true, onSelected, selectedIds: [1] });
+
+    expect(onSelected).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/web-app/src/components/common/EntityTable/MobileEntityList.test.jsx
+++ b/packages/web-app/src/components/common/EntityTable/MobileEntityList.test.jsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import MobileEntityList from './MobileEntityList';
+
+const columns = [
+  { field: 'name', label: 'Name', visible: true, isTitle: true }
+];
+
+const defaultProps = {
+  rows: [{ id: 1, name: 'Cave A' }],
+  columns,
+  totalRows: 1,
+  isLoading: false,
+  isNewQuery: false,
+  rowsPerPage: 20,
+  link: doc => `/caves/${doc.id}`,
+  renderCellFn: (doc, field) => doc[field]
+};
+
+const renderList = props =>
+  render(
+    <IntlProvider locale="en">
+      <MobileEntityList {...defaultProps} {...props} />
+    </IntlProvider>
+  );
+
+describe('MobileEntityList - Controlled selection', () => {
+  it('starts a new selection after the parent clears selected ids', () => {
+    const onSelected = vi.fn();
+    const { rerender } = renderList({ onSelected, selectedIds: [] });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onSelected).toHaveBeenLastCalledWith([1]);
+
+    rerender(
+      <IntlProvider locale="en">
+        <MobileEntityList
+          {...defaultProps}
+          onSelected={onSelected}
+          selectedIds={[1]}
+        />
+      </IntlProvider>
+    );
+
+    rerender(
+      <IntlProvider locale="en">
+        <MobileEntityList
+          {...defaultProps}
+          rows={[{ id: 2, name: 'Cave B' }]}
+          onSelected={onSelected}
+          selectedIds={[]}
+        />
+      </IntlProvider>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onSelected).toHaveBeenLastCalledWith([2]);
+  });
+});

--- a/packages/web-app/src/pages/DocumentValidation/index.jsx
+++ b/packages/web-app/src/pages/DocumentValidation/index.jsx
@@ -97,6 +97,7 @@ const DocumentValidationPage = () => {
                   isLoading={isLoading}
                   pageRows={data.documents}
                   nbTotalRows={totalCount}
+                  selectedIds={selectedIds}
                   onPageChange={(pageNum, pageSize) => {
                     setPage(pageNum);
                     setRowsPerPage(pageSize);


### PR DESCRIPTION
# fix(document): reset validation selection between batches

## 🤔 What

- Make the document validation table selection controllable by its parent.
- Reset desktop and mobile table selections between independent validation batches.
- Add regression tests for controlled selection on both table layouts.
- Closes #1508.

## 🤷‍♂️ Why

The validation page cleared its selected document IDs after a successful batch,
but the table retained an internal copy of the previous selection. Selecting a
document for the next batch therefore restored the old IDs and displayed a
cumulative document count.

## 🔍 How

`EntityTable` now accepts an optional `selectedIds` prop and forwards it to its
desktop and mobile implementations. When this prop is provided, the table uses
the parent-owned selection; existing callers without it keep the previous
internal-state behavior.

The document validation page passes its own `selectedIds`, so clearing that
state after a successful request also clears the table selection.

## 🔗 Related API PR

Not applicable.

## 🧪 Testing

- `yarn lint`
- `yarn test` — 106 test files and 970 tests passed
- Targeted controlled-selection tests for desktop and mobile layouts

## 📸 Previews

Not applicable; this fixes state synchronization without changing the visual
design.
